### PR TITLE
Implement Manager and introduce EvalContext

### DIFF
--- a/meerkat-lib/src/runtime/interpreter/evaluator.rs
+++ b/meerkat-lib/src/runtime/interpreter/evaluator.rs
@@ -25,21 +25,28 @@ impl std::fmt::Display for EvalError {
 
 impl std::error::Error for EvalError {}
 
+/// Evaluation context: holds the stable execution state that doesn't
+/// change per call frame. Passed as &mut so manager can be updated.
+/// env is kept separate since it changes at each function call boundary.
+pub struct EvalContext<'a> {
+    pub manager: &'a mut Manager,
+    pub service_name: &'a str,
+}
+
 #[async_recursion::async_recursion]
 pub async fn eval(
     expr: &Expr,
-    env: &Vec<(String, Value)>,
-    manager: &mut Manager,
-    service_name: &str,
+    env: &[(String, Value)],
+    ctx: &mut EvalContext<'_>,
 ) -> Result<Value, EvalError> {
     match expr {
         Expr::Literal { val } => Ok(val.clone()),
 
         Expr::Call { func, args } => {
-            let func_val = eval(func, env, manager, service_name).await?;
+            let func_val = eval(func, env, ctx).await?;
             let mut arg_vals = Vec::new();
             for arg in args {
-                arg_vals.push(eval(arg, env, manager, service_name).await?);
+                arg_vals.push(eval(arg, env, ctx).await?);
             }
             match func_val {
                 Value::Closure { params, body, env: closure_env } => {
@@ -47,7 +54,7 @@ pub async fn eval(
                     for (param, arg_val) in params.iter().zip(arg_vals) {
                         new_env.push((param.clone(), arg_val));
                     }
-                    eval(&body, &new_env, manager, service_name).await
+                    eval(&body, &new_env, ctx).await
                 }
                 _ => Err(EvalError::TypeError("Attempting to call a non-function value".to_string())),
             }
@@ -59,13 +66,12 @@ pub async fn eval(
                     return Ok(var_val.clone());
                 }
             }
-            // not in local env — ask the manager (like `this.ident` in OO)
-            manager.lookup(ident, service_name).await
+            ctx.manager.lookup(ident, ctx.service_name).await
         }
 
         Expr::Binop { op, expr1, expr2 } => {
-            let val1 = eval(expr1, env, manager, service_name).await?;
-            let val2 = eval(expr2, env, manager, service_name).await?;
+            let val1 = eval(expr1, env, ctx).await?;
+            let val2 = eval(expr2, env, ctx).await?;
             match (op, val1, val2) {
                 (BinOp::Add, Value::Number { val: v1 }, Value::Number { val: v2 }) => Ok(Value::Number { val: v1 + v2 }),
                 (BinOp::Sub, Value::Number { val: v1 }, Value::Number { val: v2 }) => Ok(Value::Number { val: v1 - v2 }),
@@ -81,7 +87,7 @@ pub async fn eval(
         }
 
         Expr::Unop { op, expr } => {
-            let val = eval(expr, env, manager, service_name).await?;
+            let val = eval(expr, env, ctx).await?;
             match (op, val) {
                 (UnOp::Neg, Value::Number { val: v }) => Ok(Value::Number { val: -v }),
                 (UnOp::Not, Value::Bool { val: v })   => Ok(Value::Bool { val: !v }),
@@ -90,18 +96,17 @@ pub async fn eval(
         }
 
         Expr::If { cond, expr1, expr2 } => {
-            let cond_val = eval(cond, env, manager, service_name).await?;
+            let cond_val = eval(cond, env, ctx).await?;
             match cond_val {
-                Value::Bool { val: true }  => eval(expr1, env, manager, service_name).await,
-                Value::Bool { val: false } => eval(expr2, env, manager, service_name).await,
+                Value::Bool { val: true }  => eval(expr1, env, ctx).await,
+                Value::Bool { val: false } => eval(expr2, env, ctx).await,
                 _ => Err(EvalError::TypeError("Condition must be boolean".to_string())),
             }
         }
 
         Expr::Func { params, body } => {
             let var_binded: HashSet<String> = params.iter().cloned().collect();
-            let reactive_names = HashSet::new();
-            let free_vars = body.free_var(&reactive_names, &var_binded);
+            let free_vars = body.free_var(&HashSet::new(), &var_binded);
             let captured_env: Vec<(String, Value)> = env.iter()
                 .filter(|(name, _)| free_vars.contains(name))
                 .cloned()
@@ -117,7 +122,7 @@ pub async fn eval(
             // TODO: optimize by computing free vars for ActionStmt
             Ok(Value::ActionClosure {
                 stmts: stmts.clone(),
-                env: env.clone(),
+                env: env.to_vec(),
             })
         }
 
@@ -134,26 +139,29 @@ mod tests {
     #[tokio::test]
     async fn test_literal() {
         let mut manager = Manager::default();
+        let mut ctx = EvalContext { manager: &mut manager, service_name: "" };
         let expr = Expr::Literal { val: Value::Number { val: 42 } };
-        let result = eval(&expr, &vec![], &mut manager, "").await.unwrap();
+        let result = eval(&expr, &[], &mut ctx).await.unwrap();
         assert_eq!(result, Value::Number { val: 42 });
     }
 
     #[tokio::test]
     async fn test_binop_add() {
         let mut manager = Manager::default();
+        let mut ctx = EvalContext { manager: &mut manager, service_name: "" };
         let expr = Expr::Binop {
             op: BinOp::Add,
             expr1: Box::new(Expr::Literal { val: Value::Number { val: 2 } }),
             expr2: Box::new(Expr::Literal { val: Value::Number { val: 3 } }),
         };
-        let result = eval(&expr, &vec![], &mut manager, "").await.unwrap();
+        let result = eval(&expr, &[], &mut ctx).await.unwrap();
         assert_eq!(result, Value::Number { val: 5 });
     }
 
     #[tokio::test]
     async fn test_func_and_call() {
         let mut manager = Manager::default();
+        let mut ctx = EvalContext { manager: &mut manager, service_name: "" };
         let func_expr = Expr::Func {
             params: vec!["x".to_string()],
             body: Box::new(Expr::Binop {
@@ -166,20 +174,21 @@ mod tests {
             func: Box::new(func_expr),
             args: vec![Expr::Literal { val: Value::Number { val: 5 } }],
         };
-        let result = eval(&call_expr, &vec![], &mut manager, "").await.unwrap();
+        let result = eval(&call_expr, &[], &mut ctx).await.unwrap();
         assert_eq!(result, Value::Number { val: 15 });
     }
 
     #[tokio::test]
     async fn test_action_creation() {
         let mut manager = Manager::default();
+        let mut ctx = EvalContext { manager: &mut manager, service_name: "" };
         let action_expr = Expr::Action(vec![
             ActionStmt::Assign {
                 var: "x".to_string(),
                 expr: Expr::Literal { val: Value::Number { val: 5 } },
             },
         ]);
-        let result = eval(&action_expr, &vec![], &mut manager, "").await.unwrap();
+        let result = eval(&action_expr, &[], &mut ctx).await.unwrap();
         match result {
             Value::ActionClosure { stmts, env: _ } => assert_eq!(stmts.len(), 1),
             _ => panic!("Expected ActionClosure"),
@@ -189,6 +198,7 @@ mod tests {
     #[tokio::test]
     async fn test_closure_captures_only_free_vars() {
         let mut manager = Manager::default();
+        let mut ctx = EvalContext { manager: &mut manager, service_name: "" };
         let env = vec![
             ("a".to_string(), Value::Number { val: 1 }),
             ("b".to_string(), Value::Number { val: 2 }),
@@ -202,7 +212,7 @@ mod tests {
                 expr2: Box::new(Expr::Variable { ident: "a".to_string() }),
             }),
         };
-        let result = eval(&func_expr, &env, &mut manager, "").await.unwrap();
+        let result = eval(&func_expr, &env, &mut ctx).await.unwrap();
         match result {
             Value::Closure { params, body: _, env: captured_env } => {
                 assert_eq!(params.len(), 1);

--- a/meerkat-lib/src/runtime/interpreter/mod.rs
+++ b/meerkat-lib/src/runtime/interpreter/mod.rs
@@ -1,3 +1,4 @@
 pub mod evaluator;
 pub use evaluator::eval;
+pub use evaluator::EvalContext;
 pub use evaluator::EvalError;

--- a/meerkat-lib/src/runtime/manager/mod.rs
+++ b/meerkat-lib/src/runtime/manager/mod.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 use super::ast::{Value, Decl};
-use super::interpreter::{eval, EvalError};
+use super::interpreter::{eval, EvalContext, EvalError};
 
 pub struct Service {
     pub name: String,
@@ -33,7 +33,7 @@ impl Manager {
             match decl {
                 Decl::VarDecl { name, val } |
                 Decl::DefDecl { name, val, .. } => {
-                    let value = eval(&val, &env, self, &svc_name).await?;
+                    let value = eval(&val, &env, &mut EvalContext { manager: self, service_name: &svc_name }).await?;
                     env.push((name.clone(), value.clone()));
                     service.vars.insert(name, value);
                 }


### PR DESCRIPTION
Implements the Manager to track services and their evaluated vars/defs, and introduces EvalContext to simplify the evaluator signature.

Changes: 
- Manager tracks services and evaluates their vars/defs
- Removes current_service; service name passed explicitly through eval
- Introduces EvalContext to group manager and service_name
- 3 unit tests for service creation and lookup