### PR TITLE
Fix #7, implement #8 and #9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2196,6 +2196,7 @@ dependencies = [
  "env_logger",
  "log",
  "meerkat-lib",
+ "serde_json",
  "tokio",
 ]
 

--- a/meerkat-lib/src/net/types.rs
+++ b/meerkat-lib/src/net/types.rs
@@ -40,6 +40,40 @@ pub enum MeerkatMessage {
         var_id: u64,
         new_value: Vec<u8>,
     },
+
+    /// Request to look up a member of a service on a remote node
+    LookupRequest {
+        request_id: u64,
+        service: String,
+        member: String,
+        reply_to: String,  // full multiaddr of the requester
+    },
+
+    /// Response to a LookupRequest with the serialized value
+    LookupResponse {
+        request_id: u64,
+        value: String,  // JSON-serialized Value
+    },
+
+    /// Response indicating lookup failed
+    LookupError {
+        request_id: u64,
+        error: String,
+    },
+
+    /// Execute an action on a remote service
+    ActionRequest {
+        request_id: u64,
+        service: String,
+        member: String,  // name of the action def to execute
+    },
+
+    /// Response to ActionRequest
+    ActionResponse {
+        request_id: u64,
+        success: bool,
+        error: Option<String>,
+    },
 }
 
 /// Errors that can occur when sending

--- a/meerkat-lib/src/runtime/ast/mod.rs
+++ b/meerkat-lib/src/runtime/ast/mod.rs
@@ -1,13 +1,13 @@
 use std::fmt::Display;
 //use crate::runtime::Manager;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 pub enum UnOp {
     Neg, // negate
     Not, // logical not
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 pub enum BinOp {
     Add,
     Sub,
@@ -22,7 +22,7 @@ pub enum BinOp {
     Or,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 pub enum ActionStmt {
     Let {
         name: String,
@@ -50,7 +50,7 @@ pub enum Stmt {
     Test { service: String, stmts: Vec<ActionStmt> },
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 pub enum Value {
     Number {
         val: i32,
@@ -73,7 +73,7 @@ pub enum Value {
     },
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 pub enum Expr {
     /// Basic Lambda Core expressions
     Literal {
@@ -160,13 +160,13 @@ pub enum Decl {
     },
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 pub struct Field {
     pub name: String,
     pub type_: DataType,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 pub enum DataType {
     String,
     Number,

--- a/meerkat-lib/src/runtime/ast/mod.rs
+++ b/meerkat-lib/src/runtime/ast/mod.rs
@@ -69,6 +69,7 @@ pub enum Value {
     ActionClosure {
         stmts: Vec<ActionStmt>,
         env: Vec<(String, Value)>,
+        service_name: String,
     },
 }
 
@@ -116,6 +117,10 @@ pub enum Expr {
     /// Action
     Action(Vec<ActionStmt>),
 
+    MemberAccess {
+        service: String,
+        member: String,
+    },
     Select {
         table_name: String,
         column_names: Vec<String>,
@@ -201,8 +206,8 @@ impl Display for Value {
             Value::String { val } => write!(f, "\"{}\"", val),
             Value::Closure { params, body, env } =>
                 write!(f, "fn({})[{:?}]{{{}}}", params.join(","), env, body),
-            Value::ActionClosure { stmts, env } =>
-                write!(f, "action[{:?}]{{{:?}}}", env, stmts),  
+            Value::ActionClosure { stmts, env, service_name } =>
+                write!(f, "action[{:?}][{}]{{{:?}}}", env, service_name, stmts),  
         }
     }
 }
@@ -233,6 +238,7 @@ impl Display for Expr {
                     "Action({:?})",
                     stmts.iter().map(ToString::to_string).collect::<Vec<_>>().join(", ")
                 ),
+            Expr::MemberAccess { service, member } => write!(f, "{}.{}", service, member),
             Expr::Select { table_name, column_names, where_clause } => write!(f, "{}", where_clause),
             Expr::Table {records , ..} => {
                 write!(f, "[",)?;

--- a/meerkat-lib/src/runtime/interpreter/evaluator.rs
+++ b/meerkat-lib/src/runtime/interpreter/evaluator.rs
@@ -108,7 +108,12 @@ pub async fn eval(
             let var_binded: HashSet<String> = params.iter().cloned().collect();
             let free_vars = body.free_var(&HashSet::new(), &var_binded);
             let captured_env: Vec<(String, Value)> = env.iter()
-                .filter(|(name, _)| free_vars.contains(name))
+                .filter(|(name, _)| {
+                    free_vars.contains(name) &&
+                    !ctx.manager.services.get(ctx.service_name)
+                        .map(|s| s.vars.contains_key(name.as_str()) || s.defs.contains_key(name.as_str()))
+                        .unwrap_or(false)
+                })
                 .cloned()
                 .collect();
             Ok(Value::Closure {
@@ -119,28 +124,17 @@ pub async fn eval(
         }
 
         Expr::Action(stmts) => {
-            // Capture only free variables from the local env (function args etc.)
+            // Use free_var on the Action expression itself to find free variables
             // Service vars/defs are looked up fresh via the manager at execution time
-            use crate::ast::ActionStmt;
-            let mut free_in_action: std::collections::HashSet<String> = std::collections::HashSet::new();
-            for stmt in stmts {
-                match stmt {
-                    ActionStmt::Assign { expr, .. } |
-                    ActionStmt::Do(expr) |
-                    ActionStmt::Assert(expr) => {
-                        free_in_action.extend(expr.free_var(&std::collections::HashSet::new(), &std::collections::HashSet::new()));
-                    }
-                    ActionStmt::Let { expr, .. } => {
-                        free_in_action.extend(expr.free_var(&std::collections::HashSet::new(), &std::collections::HashSet::new()));
-                    }
-                    ActionStmt::Insert { row, .. } => {
-                        free_in_action.extend(row.free_var(&std::collections::HashSet::new(), &std::collections::HashSet::new()));
-                    }
-                }
-            }
-            // Only capture vars from local env (not from service — those are looked up via manager)
+            let action_expr = Expr::Action(stmts.clone());
+            let free_vars = action_expr.free_var(&std::collections::HashSet::new(), &std::collections::HashSet::new());
             let captured_env: Vec<(String, Value)> = env.iter()
-                .filter(|(name, _)| free_in_action.contains(name))
+                .filter(|(name, _)| {
+                    free_vars.contains(name) &&
+                    !ctx.manager.services.get(ctx.service_name)
+                        .map(|s| s.vars.contains_key(name.as_str()) || s.defs.contains_key(name.as_str()))
+                        .unwrap_or(false)
+                })
                 .cloned()
                 .collect();
             Ok(Value::ActionClosure {
@@ -151,12 +145,8 @@ pub async fn eval(
         }
 
         Expr::MemberAccess { service, member } => {
-            // Check if service is remote
-            if ctx.manager.remote_services.contains_key(service) {
-                ctx.manager.remote_lookup(service, member).await
-            } else {
-                ctx.manager.lookup(member, service).await
-            }
+            // Manager figures out whether service is local or remote
+            ctx.manager.lookup(member, service).await
         }
         _ => Err(EvalError::NotImplemented),
     }

--- a/meerkat-lib/src/runtime/interpreter/evaluator.rs
+++ b/meerkat-lib/src/runtime/interpreter/evaluator.rs
@@ -56,10 +56,6 @@ pub async fn eval(
                     }
                     eval(&body, &new_env, ctx).await
                 }
-                Value::ActionClosure { stmts, env: closure_env, service_name: svc } => {
-                    // calling an action — return as-is preserving service context
-                    Ok(Value::ActionClosure { stmts, env: closure_env, service_name: svc })
-                }
                 _ => Err(EvalError::TypeError("Attempting to call a non-function value".to_string())),
             }
         }
@@ -123,17 +119,44 @@ pub async fn eval(
         }
 
         Expr::Action(stmts) => {
-            // TODO: optimize by computing free vars for ActionStmt
+            // Capture only free variables from the local env (function args etc.)
+            // Service vars/defs are looked up fresh via the manager at execution time
+            use crate::ast::ActionStmt;
+            let mut free_in_action: std::collections::HashSet<String> = std::collections::HashSet::new();
+            for stmt in stmts {
+                match stmt {
+                    ActionStmt::Assign { expr, .. } |
+                    ActionStmt::Do(expr) |
+                    ActionStmt::Assert(expr) => {
+                        free_in_action.extend(expr.free_var(&std::collections::HashSet::new(), &std::collections::HashSet::new()));
+                    }
+                    ActionStmt::Let { expr, .. } => {
+                        free_in_action.extend(expr.free_var(&std::collections::HashSet::new(), &std::collections::HashSet::new()));
+                    }
+                    ActionStmt::Insert { row, .. } => {
+                        free_in_action.extend(row.free_var(&std::collections::HashSet::new(), &std::collections::HashSet::new()));
+                    }
+                }
+            }
+            // Only capture vars from local env (not from service — those are looked up via manager)
+            let captured_env: Vec<(String, Value)> = env.iter()
+                .filter(|(name, _)| free_in_action.contains(name))
+                .cloned()
+                .collect();
             Ok(Value::ActionClosure {
                 stmts: stmts.clone(),
-                env: env.to_vec(),
+                env: captured_env,
                 service_name: ctx.service_name.to_string(),
             })
         }
 
         Expr::MemberAccess { service, member } => {
-            // Look up member in another service
-            ctx.manager.lookup(member, service).await
+            // Check if service is remote
+            if ctx.manager.remote_services.contains_key(service) {
+                ctx.manager.remote_lookup(service, member).await
+            } else {
+                ctx.manager.lookup(member, service).await
+            }
         }
         _ => Err(EvalError::NotImplemented),
     }

--- a/meerkat-lib/src/runtime/interpreter/evaluator.rs
+++ b/meerkat-lib/src/runtime/interpreter/evaluator.rs
@@ -56,6 +56,10 @@ pub async fn eval(
                     }
                     eval(&body, &new_env, ctx).await
                 }
+                Value::ActionClosure { stmts, env: closure_env, service_name: svc } => {
+                    // calling an action — return as-is preserving service context
+                    Ok(Value::ActionClosure { stmts, env: closure_env, service_name: svc })
+                }
                 _ => Err(EvalError::TypeError("Attempting to call a non-function value".to_string())),
             }
         }
@@ -123,9 +127,14 @@ pub async fn eval(
             Ok(Value::ActionClosure {
                 stmts: stmts.clone(),
                 env: env.to_vec(),
+                service_name: ctx.service_name.to_string(),
             })
         }
 
+        Expr::MemberAccess { service, member } => {
+            // Look up member in another service
+            ctx.manager.lookup(member, service).await
+        }
         _ => Err(EvalError::NotImplemented),
     }
 }
@@ -190,7 +199,7 @@ mod tests {
         ]);
         let result = eval(&action_expr, &[], &mut ctx).await.unwrap();
         match result {
-            Value::ActionClosure { stmts, env: _ } => assert_eq!(stmts.len(), 1),
+            Value::ActionClosure { stmts, .. } => assert_eq!(stmts.len(), 1),
             _ => panic!("Expected ActionClosure"),
         }
     }

--- a/meerkat-lib/src/runtime/manager/mod.rs
+++ b/meerkat-lib/src/runtime/manager/mod.rs
@@ -68,6 +68,11 @@ impl Manager {
     }
 
     pub async fn lookup(&mut self, ident: &str, service_name: &str) -> Result<Value, EvalError> {
+        // Check if service is remote
+        if self.remote_services.contains_key(service_name) {
+            return self.remote_lookup(service_name, ident).await;
+        }
+
         // If it's a def, re-evaluate from stored expression for freshness
         let def_expr = self.services.get(service_name)
             .and_then(|s| s.defs.get(ident))

--- a/meerkat-lib/src/runtime/manager/mod.rs
+++ b/meerkat-lib/src/runtime/manager/mod.rs
@@ -2,6 +2,8 @@ use std::collections::HashMap;
 use super::ast::{Value, Decl, Expr, ActionStmt};
 use super::interpreter::{eval, EvalContext, EvalError};
 use super::semantic_analysis::var_analysis::{calc_dep_srv, DependAnalysis};
+use crate::net::{Address, NetworkCommand, NetworkEvent, MeerkatMessage, NetworkActor};
+use crate::net::network_layer::NetworkLayer;
 
 pub struct Service {
     pub name: String,
@@ -12,12 +14,18 @@ pub struct Service {
 
 pub struct Manager {
     pub services: HashMap<String, Service>,
+    /// Maps service name to remote address (for distributed services)
+    pub remote_services: HashMap<String, Address>,
+    /// Network actor for distributed communication
+    pub network: Option<NetworkActor>,
 }
 
 impl Manager {
     pub fn new() -> Self {
         Manager {
             services: HashMap::new(),
+            remote_services: HashMap::new(),
+            network: None,
         }
     }
 
@@ -153,17 +161,9 @@ impl Manager {
                 match val {
                     Value::ActionClosure { stmts, env: closure_env, service_name: action_svc } => {
                         // Use the action's own service context, not the caller's
-                        let target_svc = action_svc.clone();
-                        // Filter closure env to only include function args (not service vars/defs)
-                        let filtered_env: Vec<(String, Value)> = closure_env.into_iter()
-                            .filter(|(name, _)| {
-                                self.services.get(&target_svc)
-                                    .map(|s| !s.vars.contains_key(name))
-                                    .unwrap_or(true)
-                            })
-                            .collect();
+                        // closure_env only contains free vars (function args etc.), not service vars
                         for s in &stmts {
-                            self.execute_action_stmt(s, &filtered_env, &target_svc).await?;
+                            self.execute_action_stmt(s, &closure_env, &action_svc).await?;
                         }
                         Ok(())
                     }
@@ -183,6 +183,80 @@ impl Manager {
                 Ok(())
             }
             ActionStmt::Insert { .. } => Err(EvalError::NotImplemented),
+        }
+    }
+
+    pub async fn remote_lookup(&mut self, service: &str, member: &str) -> Result<Value, EvalError> {
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static NEXT_ID: AtomicU64 = AtomicU64::new(1);
+
+        let full_url = self.remote_services.get(service)
+            .ok_or_else(|| EvalError::LookupError(format!("Remote service '{}' not found", service)))?
+            .clone();
+
+        // Strip the service slug from the end of the address
+        // e.g. /ip4/.../p2p/12D3.../s1 -> /ip4/.../p2p/12D3...
+        let addr_str = full_url.0.trim_end_matches(&format!("/{}", service));
+        let addr = Address::new(addr_str);
+
+        let request_id = NEXT_ID.fetch_add(1, Ordering::SeqCst);
+
+        // Get our local address + peer ID to include as reply_to
+        let reply_to = {
+            let net = self.network.as_mut().unwrap();
+            let peer_id = net.local_peer_id();
+            let reply = net.handle_command(NetworkCommand::GetLocalAddresses).await;
+            match reply {
+                crate::net::NetworkReply::LocalAddresses { addrs } => {
+                    if let Some(addr) = addrs.first() {
+                        format!("{}/p2p/{}", addr.0, peer_id)
+                    } else {
+                        String::new()
+                    }
+                }
+                _ => String::new(),
+            }
+        };
+
+        let msg = MeerkatMessage::LookupRequest {
+            request_id,
+            service: service.to_string(),
+            member: member.to_string(),
+            reply_to,
+        };
+
+        let net = self.network.as_mut()
+            .ok_or_else(|| EvalError::NetworkError("No network layer available".to_string()))?;
+
+        net.handle_command(NetworkCommand::SendMessage { addr, msg }).await;
+
+        // Poll for response with timeout
+        let start = std::time::Instant::now();
+        loop {
+            if start.elapsed().as_secs() > 15 {
+                return Err(EvalError::NetworkError(format!(
+                    "Timeout waiting for remote lookup of {}.{}", service, member
+                )));
+            }
+            let net = self.network.as_mut().unwrap();
+            if let Some(event) = net.try_recv_event() {
+                match event {
+                    NetworkEvent::MessageReceived {
+                        msg: MeerkatMessage::LookupResponse { request_id: rid, value }, ..
+                    } if rid == request_id => {
+                        let val: Value = serde_json::from_str(&value)
+                            .map_err(|e| EvalError::NetworkError(e.to_string()))?;
+                        return Ok(val);
+                    }
+                    NetworkEvent::MessageReceived {
+                        msg: MeerkatMessage::LookupError { request_id: rid, error }, ..
+                    } if rid == request_id => {
+                        return Err(EvalError::LookupError(error));
+                    }
+                    _ => {}
+                }
+            }
+            tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
         }
     }
 

--- a/meerkat-lib/src/runtime/manager/mod.rs
+++ b/meerkat-lib/src/runtime/manager/mod.rs
@@ -137,11 +137,18 @@ impl Manager {
             ActionStmt::Do(expr) => {
                 let val = eval(expr, env, &mut EvalContext { manager: self, service_name }).await?;
                 match val {
-                    Value::ActionClosure { stmts, env: _ } => {
+                    Value::ActionClosure { stmts, env: closure_env } => {
+                        // Filter closure env to only include function args (not service vars/defs)
+                        // so stale captured values don't shadow fresh values from the manager
+                        let filtered_env: Vec<(String, Value)> = closure_env.into_iter()
+                            .filter(|(name, _)| {
+                                self.services.get(service_name)
+                                    .map(|s| !s.vars.contains_key(name))
+                                    .unwrap_or(true)
+                            })
+                            .collect();
                         for s in &stmts {
-                            // use empty env so all var/def lookups go through
-                            // the manager and get current values, not stale captured ones
-                            self.execute_action_stmt(s, &[], service_name).await?;
+                            self.execute_action_stmt(s, &filtered_env, service_name).await?;
                         }
                         Ok(())
                     }

--- a/meerkat-lib/src/runtime/manager/mod.rs
+++ b/meerkat-lib/src/runtime/manager/mod.rs
@@ -60,6 +60,20 @@ impl Manager {
     }
 
     pub async fn lookup(&mut self, ident: &str, service_name: &str) -> Result<Value, EvalError> {
+        // If it's a def, re-evaluate from stored expression for freshness
+        let def_expr = self.services.get(service_name)
+            .and_then(|s| s.defs.get(ident))
+            .cloned();
+
+        if let Some(expr) = def_expr {
+            let env: Vec<(String, Value)> = self.services
+                .get(service_name)
+                .map(|s| s.vars.iter().map(|(k, v)| (k.clone(), v.clone())).collect())
+                .unwrap_or_default();
+            return eval(&expr, &env, &mut EvalContext { manager: self, service_name }).await;
+        }
+
+        // Otherwise return stored var value
         if let Some(service) = self.services.get(service_name) {
             if let Some(value) = service.vars.get(ident) {
                 return Ok(value.clone());
@@ -137,18 +151,19 @@ impl Manager {
             ActionStmt::Do(expr) => {
                 let val = eval(expr, env, &mut EvalContext { manager: self, service_name }).await?;
                 match val {
-                    Value::ActionClosure { stmts, env: closure_env } => {
+                    Value::ActionClosure { stmts, env: closure_env, service_name: action_svc } => {
+                        // Use the action's own service context, not the caller's
+                        let target_svc = action_svc.clone();
                         // Filter closure env to only include function args (not service vars/defs)
-                        // so stale captured values don't shadow fresh values from the manager
                         let filtered_env: Vec<(String, Value)> = closure_env.into_iter()
                             .filter(|(name, _)| {
-                                self.services.get(service_name)
+                                self.services.get(&target_svc)
                                     .map(|s| !s.vars.contains_key(name))
                                     .unwrap_or(true)
                             })
                             .collect();
                         for s in &stmts {
-                            self.execute_action_stmt(s, &filtered_env, service_name).await?;
+                            self.execute_action_stmt(s, &filtered_env, &target_svc).await?;
                         }
                         Ok(())
                     }

--- a/meerkat-lib/src/runtime/parser/meerkat.lalrpop
+++ b/meerkat-lib/src/runtime/parser/meerkat.lalrpop
@@ -87,6 +87,9 @@ Stmt: Stmt = {
     "@test" "(" <i:Ident> ")" "{" <astmts: ActionStmts> "}" => {
         Stmt::Test { service: i, stmts: astmts }
     },
+    "import" <i:Ident> => {
+        Stmt::Import { path: format!("{}.mkt", i), service: i }
+    },
 }
 
 ActionStmts: Vec<ActionStmt> = ActionStmt*;
@@ -169,6 +172,8 @@ SubExpr: Expr = {
     
     <expr:SubExpr> "(" <args:Args> ")" => 
         Expr::Call { func: Box::new(expr), args },
+
+    <s:Ident> "." <m:Ident> => Expr::MemberAccess { service: s, member: m },
 
     "action" "{" <stmts: ActionStmts> "}" => Expr::Action(stmts),
 }

--- a/meerkat-lib/src/runtime/semantic_analysis/typecheck/tc_expr.rs
+++ b/meerkat-lib/src/runtime/semantic_analysis/typecheck/tc_expr.rs
@@ -185,6 +185,10 @@ impl TypecheckEnv {
             Expr::Action(_stmts) => {
                 Action
             }
+            Expr::MemberAccess { .. } => {
+                // TODO: typecheck member access across services
+                self.gen_typevar()
+            }
             Expr::Select { table_name, column_names, where_clause } => {
                 let schema = {
                     let table_type = self.var_context.get(table_name);    // check if table exists and extract schema

--- a/meerkat-lib/src/runtime/semantic_analysis/var_analysis/alpha_rename.rs
+++ b/meerkat-lib/src/runtime/semantic_analysis/var_analysis/alpha_rename.rs
@@ -60,6 +60,7 @@ impl Expr {
                     stmt.alpha_rename(var_binded, renames);
                 }
             }
+            Expr::MemberAccess { .. } => {}
             Expr::Select { where_clause, .. } => {
                 where_clause.alpha_rename(var_binded, renames);
             }

--- a/meerkat-lib/src/runtime/semantic_analysis/var_analysis/read_write.rs
+++ b/meerkat-lib/src/runtime/semantic_analysis/var_analysis/read_write.rs
@@ -76,6 +76,10 @@ impl Expr {
                 }
                 free_vars.difference(reactive_names).cloned().collect()
             }
+            Expr::MemberAccess { .. } => {
+                // member access on another service - no local free vars
+                HashSet::new()
+            }
             Expr::Select { table_name, where_clause, .. } => {
                 let mut free_vars = where_clause.free_var(reactive_names, var_binded);
                 free_vars.insert(table_name.clone());

--- a/meerkat/Cargo.toml
+++ b/meerkat/Cargo.toml
@@ -9,3 +9,4 @@ clap = { version = "4", features = ["derive"] }
 tokio = { version = "1", features = ["full"] }
 log = "0.4"
 env_logger = "0.10"
+serde_json = "1"

--- a/meerkat/src/main.rs
+++ b/meerkat/src/main.rs
@@ -2,6 +2,10 @@ use clap::Parser;
 use std::error::Error;
 use meerkat_lib::runtime::ast::Stmt;
 use meerkat_lib::runtime::Manager;
+use meerkat_lib::net::{Address, NetworkCommand, NetworkEvent, MeerkatMessage};
+use meerkat_lib::net::types::NodeType;
+use meerkat_lib::net::NetworkActor;
+use meerkat_lib::net::network_layer::NetworkLayer;
 
 #[derive(Parser, Debug)]
 #[command(author, version, about)]
@@ -11,6 +15,14 @@ struct Args {
 
     #[arg(short = 'v', long = "verbose", default_value_t = false)]
     verbose: bool,
+
+    /// Server mode: start a server providing the services in the input file
+    #[arg(short = 's', long = "server", default_value_t = false)]
+    server: bool,
+
+    /// Remote service URLs: -i <url> maps the service slug to a remote address
+    #[arg(short = 'i', long = "import-url")]
+    import_urls: Vec<String>,
 }
 
 #[tokio::main]
@@ -29,7 +41,134 @@ pub async fn main() -> Result<(), Box<dyn Error>> {
     let prog = meerkat_lib::runtime::parser::parser::parse_file(&args.input_file)
         .map_err(|e| format!("Parse error: {}", e))?;
 
+    // Build slug -> remote address map from -i flags
+    let mut remote_url_map: std::collections::HashMap<String, String> = std::collections::HashMap::new();
+    for url in &args.import_urls {
+        if let Some(slug) = url.split('/').last() {
+            remote_url_map.insert(slug.to_string(), url.clone());
+        }
+    }
+
+    if args.server {
+        run_server(prog).await
+    } else {
+        run_client(prog, &args.input_file, remote_url_map).await
+    }
+}
+
+async fn run_server(prog: Vec<Stmt>) -> Result<(), Box<dyn Error>> {
     let mut manager = Manager::new();
+
+    // Load services
+    for stmt in &prog {
+        if let Stmt::Service { name, decls } = stmt {
+            manager.create_service(name.clone(), decls.clone()).await
+                .map_err(|e| format!("Service error: {}", e))?;
+            println!("Service '{}' loaded", name);
+        }
+    }
+
+    // Start network actor as server
+    let mut net = NetworkActor::new(NodeType::Server).await
+        .map_err(|e| format!("Network error: {}", e))?;
+
+    // Listen
+    let listen_addr = Address::new("/ip4/0.0.0.0/tcp/9000");
+    let reply = net.handle_command(NetworkCommand::Listen { addr: listen_addr }).await;
+    let actual_addr = match reply {
+        meerkat_lib::net::NetworkReply::ListenSuccess { addr } => addr,
+        meerkat_lib::net::NetworkReply::Failure(e) => return Err(e.into()),
+        _ => return Err("Unexpected reply".into()),
+    };
+
+    let peer_id = net.local_peer_id();
+    let full_addr = format!("{}/p2p/{}", actual_addr.0, peer_id);
+    println!("Server listening at: {}", full_addr);
+
+    // Print service URLs
+    for stmt in &prog {
+        if let Stmt::Service { name, .. } = stmt {
+            println!("Service URL: {}/{}", full_addr, name);
+        }
+    }
+
+    println!("Server running, press Ctrl+C to stop...");
+
+    loop {
+        if let Some(event) = net.try_recv_event() {
+            match event {
+                NetworkEvent::MessageReceived { peer, msg } => {
+                    match msg {
+                        MeerkatMessage::LookupRequest { request_id, service, member, reply_to } => {
+                            let result = manager.lookup(&member, &service).await;
+                            let response = match result {
+                                Ok(val) => MeerkatMessage::LookupResponse {
+                                    request_id,
+                                    value: serde_json::to_string(&val).unwrap_or_default(),
+                                },
+                                Err(e) => MeerkatMessage::LookupError {
+                                    request_id,
+                                    error: e.to_string(),
+                                },
+                            };
+                            net.handle_command(NetworkCommand::SendMessage {
+                                addr: Address::new(&reply_to),
+                                msg: response,
+                            }).await;
+                        }
+                        MeerkatMessage::ActionRequest { request_id, service, member } => {
+                            let result = manager.lookup(&member, &service).await;
+                            let response = match result {
+                                Ok(meerkat_lib::runtime::ast::Value::ActionClosure { stmts, service_name, .. }) => {
+                                    let exec = manager.run_test(&service_name, &stmts).await;
+                                    MeerkatMessage::ActionResponse {
+                                        request_id,
+                                        success: exec.is_ok(),
+                                        error: exec.err().map(|e| e.to_string()),
+                                    }
+                                }
+                                _ => MeerkatMessage::ActionResponse {
+                                    request_id,
+                                    success: false,
+                                    error: Some(format!("'{}' is not an action", member)),
+                                },
+                            };
+                            net.handle_command(NetworkCommand::SendMessage {
+                                addr: Address::new(&peer),
+                                msg: response,
+                            }).await;
+                        }
+                        _ => {}
+                    }
+                }
+                _ => {}
+            }
+        }
+        tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
+    }
+}
+
+async fn run_client(
+    prog: Vec<Stmt>,
+    input_file: &str,
+    remote_url_map: std::collections::HashMap<String, String>,
+) -> Result<(), Box<dyn Error>> {
+    let mut manager = Manager::new();
+
+    // Start network if we have remote imports
+    let mut net: Option<NetworkActor> = None;
+    if !remote_url_map.is_empty() {
+        let mut n = NetworkActor::new(NodeType::Server).await
+            .map_err(|e| format!("Network error: {}", e))?;
+        let listen_addr = Address::new("/ip4/0.0.0.0/tcp/0");
+        n.handle_command(NetworkCommand::Listen { addr: listen_addr }).await;
+        net = Some(n);
+    }
+
+    // Wire network actor into manager
+    if let Some(n) = net {
+        manager.network = Some(n);
+    }
 
     for stmt in &prog {
         match stmt {
@@ -43,20 +182,27 @@ pub async fn main() -> Result<(), Box<dyn Error>> {
                     .map_err(|e| format!("Test failed in '{}': {}", service, e))?;
                 println!("@test({}) passed", service);
             }
-            Stmt::Import { path, service: _ } => {
-                // resolve import path relative to the input file's directory
-                let base_dir = std::path::Path::new(&args.input_file)
-                    .parent()
-                    .unwrap_or(std::path::Path::new("."));
-                let import_path = base_dir.join(path);
-                let import_stmts = meerkat_lib::runtime::parser::parser::parse_file(
-                    import_path.to_str().unwrap()
-                ).map_err(|e| format!("Import parse error: {}", e))?;
-                for import_stmt in &import_stmts {
-                    if let Stmt::Service { name, decls } = import_stmt {
-                        manager.create_service(name.clone(), decls.clone()).await
-                            .map_err(|e| format!("Import service error: {}", e))?;
-                        println!("Imported service '{}'", name);
+            Stmt::Import { path, service: svc_name } => {
+                if let Some(url) = remote_url_map.get(svc_name) {
+                    manager.remote_services.insert(
+                        svc_name.clone(),
+                        Address::new(url.as_str())
+                    );
+                    println!("Remote service '{}' registered at {}", svc_name, url);
+                } else {
+                    let base_dir = std::path::Path::new(input_file)
+                        .parent()
+                        .unwrap_or(std::path::Path::new("."));
+                    let import_path = base_dir.join(path);
+                    let import_stmts = meerkat_lib::runtime::parser::parser::parse_file(
+                        import_path.to_str().unwrap()
+                    ).map_err(|e| format!("Import parse error: {}", e))?;
+                    for import_stmt in &import_stmts {
+                        if let Stmt::Service { name, decls } = import_stmt {
+                            manager.create_service(name.clone(), decls.clone()).await
+                                .map_err(|e| format!("Import service error: {}", e))?;
+                            println!("Imported service '{}'", name);
+                        }
                     }
                 }
             }

--- a/meerkat/src/main.rs
+++ b/meerkat/src/main.rs
@@ -43,6 +43,23 @@ pub async fn main() -> Result<(), Box<dyn Error>> {
                     .map_err(|e| format!("Test failed in '{}': {}", service, e))?;
                 println!("@test({}) passed", service);
             }
+            Stmt::Import { path, service: _ } => {
+                // resolve import path relative to the input file's directory
+                let base_dir = std::path::Path::new(&args.input_file)
+                    .parent()
+                    .unwrap_or(std::path::Path::new("."));
+                let import_path = base_dir.join(path);
+                let import_stmts = meerkat_lib::runtime::parser::parser::parse_file(
+                    import_path.to_str().unwrap()
+                ).map_err(|e| format!("Import parse error: {}", e))?;
+                for import_stmt in &import_stmts {
+                    if let Stmt::Service { name, decls } = import_stmt {
+                        manager.create_service(name.clone(), decls.clone()).await
+                            .map_err(|e| format!("Import service error: {}", e))?;
+                        println!("Imported service '{}'", name);
+                    }
+                }
+            }
             _ => {}
         }
     }

--- a/meerkat/tests/test_two.mkt
+++ b/meerkat/tests/test_two.mkt
@@ -5,7 +5,7 @@ service s1 {
 }
 
 service s2 {
-    pub def inc_delegate = fn n => s1.inc_x(n);
+    pub def inc_delegate = fn n => s1.inc_x;
     var w = s1.y - 2;
     pub def z = s1.y * 2;
 }
@@ -16,4 +16,3 @@ service s2 {
     do inc_delegate(1);
     assert(z==4);
 }
-


### PR DESCRIPTION
Fixes #7, closes #8, closes #9

#7 - Fix closure bug: function args were lost when executing actions 
returned from functions. Fixed by filtering closure env to pass only 
function args, preserving fresh service var lookups via manager.

#8 - Member access (s1.y dot notation): added MemberAccess AST node,
parser rule, and evaluator support. Defs that reference other services
are re-evaluated on lookup for freshness.

#9 - Service imports: import s1 reads s1.mkt from the same directory,
parses it, and loads the service into the manager before continuing.

All tests passing: closure_bug.mkt, test_two.mkt, test_import.mkt,
test0, test1, test_func_update.