### PR TITLE
Implement #10 and #11: remote service lookup and remote action execution

### DIFF
--- a/meerkat-lib/src/net/types.rs
+++ b/meerkat-lib/src/net/types.rs
@@ -65,7 +65,9 @@ pub enum MeerkatMessage {
     ActionRequest {
         request_id: u64,
         service: String,
-        member: String,  // name of the action def to execute
+        stmts: Vec<crate::ast::ActionStmt>,
+        env: Vec<(String, crate::ast::Value)>,
+        reply_to: String,
     },
 
     /// Response to ActionRequest

--- a/meerkat-lib/src/runtime/interpreter/executor.rs
+++ b/meerkat-lib/src/runtime/interpreter/executor.rs
@@ -1,0 +1,51 @@
+use crate::ast::{Value, ActionStmt};
+use crate::runtime::Manager;
+use super::evaluator::{eval, EvalContext, EvalError};
+
+#[async_recursion::async_recursion]
+pub async fn execute(
+    stmt: &ActionStmt,
+    env: &[(String, Value)],
+    manager: &mut Manager,
+    service_name: &str,
+) -> Result<(), EvalError> {
+    match stmt {
+        ActionStmt::Assign { var, expr } => {
+            let value = eval(expr, env, &mut EvalContext { manager, service_name }).await?;
+            manager.assign(service_name, var, value).await
+        }
+        ActionStmt::Do(expr) => {
+            let val = eval(expr, env, &mut EvalContext { manager, service_name }).await?;
+            match val {
+                Value::ActionClosure { stmts, env: closure_env, service_name: action_svc } => {
+                    if manager.remote_services.contains_key(&action_svc) {
+                        // Execute action remotely
+                        manager.remote_action(&action_svc, stmts, closure_env).await?;
+                        // Heuristic delay to allow remote propagation to complete
+                        tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
+                    } else {
+                        // Execute locally
+                        for s in &stmts {
+                            execute(s, &closure_env, manager, &action_svc).await?;
+                        }
+                    }
+                    Ok(())
+                }
+                _ => Err(EvalError::TypeError("do expects an action".to_string())),
+            }
+        }
+        ActionStmt::Assert(expr) => {
+            let val = eval(expr, env, &mut EvalContext { manager, service_name }).await?;
+            match val {
+                Value::Bool { val: true } => Ok(()),
+                Value::Bool { val: false } => Err(EvalError::TypeError("Assertion failed".to_string())),
+                _ => Err(EvalError::TypeError("assert expects a boolean".to_string())),
+            }
+        }
+        ActionStmt::Let { name: _, expr } => {
+            let _val = eval(expr, env, &mut EvalContext { manager, service_name }).await?;
+            Ok(())
+        }
+        ActionStmt::Insert { .. } => Err(EvalError::NotImplemented),
+    }
+}

--- a/meerkat-lib/src/runtime/interpreter/mod.rs
+++ b/meerkat-lib/src/runtime/interpreter/mod.rs
@@ -1,4 +1,6 @@
 pub mod evaluator;
+pub mod executor;
 pub use evaluator::eval;
 pub use evaluator::EvalContext;
 pub use evaluator::EvalError;
+pub use executor::execute;

--- a/meerkat-lib/src/runtime/manager/mod.rs
+++ b/meerkat-lib/src/runtime/manager/mod.rs
@@ -165,10 +165,16 @@ impl Manager {
                 let val = eval(expr, env, &mut EvalContext { manager: self, service_name }).await?;
                 match val {
                     Value::ActionClosure { stmts, env: closure_env, service_name: action_svc } => {
-                        // Use the action's own service context, not the caller's
-                        // closure_env only contains free vars (function args etc.), not service vars
-                        for s in &stmts {
-                            self.execute_action_stmt(s, &closure_env, &action_svc).await?;
+                        if self.remote_services.contains_key(&action_svc) {
+                            // Execute action remotely
+                            self.remote_action(&action_svc, stmts, closure_env).await?;
+                            // Heuristic delay to allow remote propagation to complete
+                            tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
+                        } else {
+                            // Execute locally
+                            for s in &stmts {
+                                self.execute_action_stmt(s, &closure_env, &action_svc).await?;
+                            }
                         }
                         Ok(())
                     }
@@ -191,37 +197,41 @@ impl Manager {
         }
     }
 
+    /// Get the network address for a remote service (strips the slug)
+    fn remote_addr(&self, service: &str) -> Result<Address, EvalError> {
+        let full_url = self.remote_services.get(service)
+            .ok_or_else(|| EvalError::LookupError(format!("Remote service '{}' not found", service)))?;
+        let addr_str = full_url.0.trim_end_matches(&format!("/{}", service));
+        Ok(Address::new(addr_str))
+    }
+
+    /// Get our local address with peer ID for use as reply_to
+    async fn local_reply_addr(&mut self) -> String {
+        let net = match self.network.as_mut() {
+            Some(n) => n,
+            None => return String::new(),
+        };
+        let peer_id = net.local_peer_id();
+        let reply = net.handle_command(NetworkCommand::GetLocalAddresses).await;
+        match reply {
+            crate::net::NetworkReply::LocalAddresses { addrs } => {
+                if let Some(addr) = addrs.first() {
+                    format!("{}/p2p/{}", addr.0, peer_id)
+                } else {
+                    String::new()
+                }
+            }
+            _ => String::new(),
+        }
+    }
+
     pub async fn remote_lookup(&mut self, service: &str, member: &str) -> Result<Value, EvalError> {
         use std::sync::atomic::{AtomicU64, Ordering};
         static NEXT_ID: AtomicU64 = AtomicU64::new(1);
 
-        let full_url = self.remote_services.get(service)
-            .ok_or_else(|| EvalError::LookupError(format!("Remote service '{}' not found", service)))?
-            .clone();
-
-        // Strip the service slug from the end of the address
-        // e.g. /ip4/.../p2p/12D3.../s1 -> /ip4/.../p2p/12D3...
-        let addr_str = full_url.0.trim_end_matches(&format!("/{}", service));
-        let addr = Address::new(addr_str);
-
+        let addr = self.remote_addr(service)?;
         let request_id = NEXT_ID.fetch_add(1, Ordering::SeqCst);
-
-        // Get our local address + peer ID to include as reply_to
-        let reply_to = {
-            let net = self.network.as_mut().unwrap();
-            let peer_id = net.local_peer_id();
-            let reply = net.handle_command(NetworkCommand::GetLocalAddresses).await;
-            match reply {
-                crate::net::NetworkReply::LocalAddresses { addrs } => {
-                    if let Some(addr) = addrs.first() {
-                        format!("{}/p2p/{}", addr.0, peer_id)
-                    } else {
-                        String::new()
-                    }
-                }
-                _ => String::new(),
-            }
-        };
+        let reply_to = self.local_reply_addr().await;
 
         let msg = MeerkatMessage::LookupRequest {
             request_id,
@@ -265,9 +275,63 @@ impl Manager {
         }
     }
 
+    pub async fn remote_action(&mut self, service: &str, stmts: Vec<ActionStmt>, env: Vec<(String, Value)>) -> Result<(), EvalError> {
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static NEXT_ACTION_ID: AtomicU64 = AtomicU64::new(1);
+
+        let addr = self.remote_addr(service)?;
+        let request_id = NEXT_ACTION_ID.fetch_add(1, Ordering::SeqCst);
+        let reply_to = self.local_reply_addr().await;
+
+        let msg = MeerkatMessage::ActionRequest {
+            request_id,
+            service: service.to_string(),
+            stmts,
+            env,
+            reply_to,
+        };
+
+        let net = self.network.as_mut()
+            .ok_or_else(|| EvalError::NetworkError("No network layer available".to_string()))?;
+
+        net.handle_command(NetworkCommand::SendMessage { addr, msg }).await;
+
+        // Wait for response
+        let start = std::time::Instant::now();
+        loop {
+            if start.elapsed().as_secs() > 15 {
+                return Err(EvalError::NetworkError(format!(
+                    "Timeout waiting for remote action on service '{}'", service
+                )));
+            }
+            let net = self.network.as_mut().unwrap();
+            if let Some(event) = net.try_recv_event() {
+                match event {
+                    NetworkEvent::MessageReceived {
+                        msg: MeerkatMessage::ActionResponse { request_id: rid, success, error }, ..
+                    } if rid == request_id => {
+                        if success {
+                            return Ok(());
+                        } else {
+                            return Err(EvalError::NetworkError(
+                                error.unwrap_or_else(|| "Remote action failed".to_string())
+                            ));
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+        }
+    }
+
     pub async fn run_test(&mut self, service_name: &str, stmts: &[ActionStmt]) -> Result<(), EvalError> {
+        self.run_test_with_env(service_name, stmts, &[]).await
+    }
+
+    pub async fn run_test_with_env(&mut self, service_name: &str, stmts: &[ActionStmt], env: &[(String, Value)]) -> Result<(), EvalError> {
         for stmt in stmts {
-            self.execute_action_stmt(stmt, &[], service_name).await?;
+            self.execute_action_stmt(stmt, env, service_name).await?;
         }
         Ok(())
     }

--- a/meerkat-lib/src/runtime/manager/mod.rs
+++ b/meerkat-lib/src/runtime/manager/mod.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 use super::ast::{Value, Decl, Expr, ActionStmt};
-use super::interpreter::{eval, EvalContext, EvalError};
+use super::interpreter::{eval, EvalContext, EvalError, execute};
 use super::semantic_analysis::var_analysis::{calc_dep_srv, DependAnalysis};
 use crate::net::{Address, NetworkCommand, NetworkEvent, MeerkatMessage, NetworkActor};
 use crate::net::network_layer::NetworkLayer;
@@ -154,48 +154,6 @@ impl Manager {
         Ok(())
     }
 
-    #[async_recursion::async_recursion]
-    pub async fn execute_action_stmt(&mut self, stmt: &ActionStmt, env: &[(String, Value)], service_name: &str) -> Result<(), EvalError> {
-        match stmt {
-            ActionStmt::Assign { var, expr } => {
-                let value = eval(expr, env, &mut EvalContext { manager: self, service_name }).await?;
-                self.assign(service_name, var, value).await
-            }
-            ActionStmt::Do(expr) => {
-                let val = eval(expr, env, &mut EvalContext { manager: self, service_name }).await?;
-                match val {
-                    Value::ActionClosure { stmts, env: closure_env, service_name: action_svc } => {
-                        if self.remote_services.contains_key(&action_svc) {
-                            // Execute action remotely
-                            self.remote_action(&action_svc, stmts, closure_env).await?;
-                            // Heuristic delay to allow remote propagation to complete
-                            tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
-                        } else {
-                            // Execute locally
-                            for s in &stmts {
-                                self.execute_action_stmt(s, &closure_env, &action_svc).await?;
-                            }
-                        }
-                        Ok(())
-                    }
-                    _ => Err(EvalError::TypeError("do expects an action".to_string())),
-                }
-            }
-            ActionStmt::Assert(expr) => {
-                let val = eval(expr, env, &mut EvalContext { manager: self, service_name }).await?;
-                match val {
-                    Value::Bool { val: true } => Ok(()),
-                    Value::Bool { val: false } => Err(EvalError::TypeError("Assertion failed".to_string())),
-                    _ => Err(EvalError::TypeError("assert expects a boolean".to_string())),
-                }
-            }
-            ActionStmt::Let { name: _, expr } => {
-                let _val = eval(expr, env, &mut EvalContext { manager: self, service_name }).await?;
-                Ok(())
-            }
-            ActionStmt::Insert { .. } => Err(EvalError::NotImplemented),
-        }
-    }
 
     /// Get the network address for a remote service (strips the slug)
     fn remote_addr(&self, service: &str) -> Result<Address, EvalError> {
@@ -206,6 +164,7 @@ impl Manager {
     }
 
     /// Get our local address with peer ID for use as reply_to
+    /// Replaces loopback/unspecified with the actual outbound IP
     async fn local_reply_addr(&mut self) -> String {
         let net = match self.network.as_mut() {
             Some(n) => n,
@@ -213,16 +172,29 @@ impl Manager {
         };
         let peer_id = net.local_peer_id();
         let reply = net.handle_command(NetworkCommand::GetLocalAddresses).await;
+        let public_ip = Self::get_public_ip();
         match reply {
             crate::net::NetworkReply::LocalAddresses { addrs } => {
                 if let Some(addr) = addrs.first() {
-                    format!("{}/p2p/{}", addr.0, peer_id)
+                    let addr_str = addr.0
+                        .replace("0.0.0.0", &public_ip)
+                        .replace("127.0.0.1", &public_ip);
+                    format!("{}/p2p/{}", addr_str, peer_id)
                 } else {
                     String::new()
                 }
             }
             _ => String::new(),
         }
+    }
+
+    /// Get the local machine's outbound IP address (non-loopback)
+    pub fn get_public_ip() -> String {
+        use std::net::UdpSocket;
+        UdpSocket::bind("0.0.0.0:0")
+            .and_then(|s| { s.connect("8.8.8.8:80")?; s.local_addr() })
+            .map(|addr| addr.ip().to_string())
+            .unwrap_or_else(|_| "127.0.0.1".to_string())
     }
 
     pub async fn remote_lookup(&mut self, service: &str, member: &str) -> Result<Value, EvalError> {
@@ -331,7 +303,7 @@ impl Manager {
 
     pub async fn run_test_with_env(&mut self, service_name: &str, stmts: &[ActionStmt], env: &[(String, Value)]) -> Result<(), EvalError> {
         for stmt in stmts {
-            self.execute_action_stmt(stmt, env, service_name).await?;
+            execute(stmt, env, self, service_name).await?;
         }
         Ok(())
     }

--- a/meerkat/src/main.rs
+++ b/meerkat/src/main.rs
@@ -97,7 +97,7 @@ async fn run_server(prog: Vec<Stmt>) -> Result<(), Box<dyn Error>> {
     loop {
         if let Some(event) = net.try_recv_event() {
             match event {
-                NetworkEvent::MessageReceived { peer, msg } => {
+                NetworkEvent::MessageReceived { peer: _, msg } => {
                     match msg {
                         MeerkatMessage::LookupRequest { request_id, service, member, reply_to } => {
                             let result = manager.lookup(&member, &service).await;
@@ -116,25 +116,15 @@ async fn run_server(prog: Vec<Stmt>) -> Result<(), Box<dyn Error>> {
                                 msg: response,
                             }).await;
                         }
-                        MeerkatMessage::ActionRequest { request_id, service, member } => {
-                            let result = manager.lookup(&member, &service).await;
-                            let response = match result {
-                                Ok(meerkat_lib::runtime::ast::Value::ActionClosure { stmts, service_name, .. }) => {
-                                    let exec = manager.run_test(&service_name, &stmts).await;
-                                    MeerkatMessage::ActionResponse {
-                                        request_id,
-                                        success: exec.is_ok(),
-                                        error: exec.err().map(|e| e.to_string()),
-                                    }
-                                }
-                                _ => MeerkatMessage::ActionResponse {
-                                    request_id,
-                                    success: false,
-                                    error: Some(format!("'{}' is not an action", member)),
-                                },
+                        MeerkatMessage::ActionRequest { request_id, service, stmts, env: action_env, reply_to } => {
+                            let result = manager.run_test_with_env(&service, &stmts, &action_env).await;
+                            let response = MeerkatMessage::ActionResponse {
+                                request_id,
+                                success: result.is_ok(),
+                                error: result.err().map(|e| e.to_string()),
                             };
                             net.handle_command(NetworkCommand::SendMessage {
-                                addr: Address::new(&peer),
+                                addr: Address::new(&reply_to),
                                 msg: response,
                             }).await;
                         }

--- a/meerkat/src/main.rs
+++ b/meerkat/src/main.rs
@@ -50,13 +50,13 @@ pub async fn main() -> Result<(), Box<dyn Error>> {
     }
 
     if args.server {
-        run_server(prog).await
+        run_server(prog, remote_url_map).await
     } else {
         run_client(prog, &args.input_file, remote_url_map).await
     }
 }
 
-async fn run_server(prog: Vec<Stmt>) -> Result<(), Box<dyn Error>> {
+async fn run_server(prog: Vec<Stmt>, remote_url_map: std::collections::HashMap<String, String>) -> Result<(), Box<dyn Error>> {
     let mut manager = Manager::new();
 
     // Load services
@@ -73,6 +73,7 @@ async fn run_server(prog: Vec<Stmt>) -> Result<(), Box<dyn Error>> {
         .map_err(|e| format!("Network error: {}", e))?;
 
     // Listen
+    let public_ip = meerkat_lib::runtime::Manager::get_public_ip();
     let listen_addr = Address::new("/ip4/0.0.0.0/tcp/9000");
     let reply = net.handle_command(NetworkCommand::Listen { addr: listen_addr }).await;
     let actual_addr = match reply {
@@ -82,7 +83,11 @@ async fn run_server(prog: Vec<Stmt>) -> Result<(), Box<dyn Error>> {
     };
 
     let peer_id = net.local_peer_id();
-    let full_addr = format!("{}/p2p/{}", actual_addr.0, peer_id);
+    // Replace loopback/unspecified with actual public IP
+    let actual_addr_str = actual_addr.0
+        .replace("0.0.0.0", &public_ip)
+        .replace("127.0.0.1", &public_ip);
+    let full_addr = format!("{}/p2p/{}", actual_addr_str, peer_id);
     println!("Server listening at: {}", full_addr);
 
     // Print service URLs
@@ -92,10 +97,20 @@ async fn run_server(prog: Vec<Stmt>) -> Result<(), Box<dyn Error>> {
         }
     }
 
+    // Register any remote services from -i flags
+    for (svc_name, url) in &remote_url_map {
+        manager.remote_services.insert(svc_name.clone(), Address::new(url.as_str()));
+        println!("Remote service '{}' registered at {}", svc_name, url);
+    }
+
+    // Wire network into manager so server can also do remote lookups
+    manager.network = Some(net);
+
     println!("Server running, press Ctrl+C to stop...");
 
     loop {
-        if let Some(event) = net.try_recv_event() {
+        let event = manager.network.as_mut().and_then(|n| n.try_recv_event());
+        if let Some(event) = event {
             match event {
                 NetworkEvent::MessageReceived { peer: _, msg } => {
                     match msg {
@@ -111,10 +126,12 @@ async fn run_server(prog: Vec<Stmt>) -> Result<(), Box<dyn Error>> {
                                     error: e.to_string(),
                                 },
                             };
-                            net.handle_command(NetworkCommand::SendMessage {
-                                addr: Address::new(&reply_to),
-                                msg: response,
-                            }).await;
+                            if let Some(net) = manager.network.as_mut() {
+                                net.handle_command(NetworkCommand::SendMessage {
+                                    addr: Address::new(&reply_to),
+                                    msg: response,
+                                }).await;
+                            }
                         }
                         MeerkatMessage::ActionRequest { request_id, service, stmts, env: action_env, reply_to } => {
                             let result = manager.run_test_with_env(&service, &stmts, &action_env).await;
@@ -123,10 +140,12 @@ async fn run_server(prog: Vec<Stmt>) -> Result<(), Box<dyn Error>> {
                                 success: result.is_ok(),
                                 error: result.err().map(|e| e.to_string()),
                             };
-                            net.handle_command(NetworkCommand::SendMessage {
-                                addr: Address::new(&reply_to),
-                                msg: response,
-                            }).await;
+                            if let Some(net) = manager.network.as_mut() {
+                                net.handle_command(NetworkCommand::SendMessage {
+                                    addr: Address::new(&reply_to),
+                                    msg: response,
+                                }).await;
+                            }
                         }
                         _ => {}
                     }


### PR DESCRIPTION
Closes #10, closes #11

#10 - Remote member access (s1.y where s1 is on a remote node):
- Client sends LookupRequest with reply_to address via libp2p
- Server looks up value locally and sends LookupResponse
- Remote check lives entirely in manager.lookup — evaluator unchanged
- Extracted remote_addr and local_reply_addr helpers to avoid duplication

#11 - Remote action execution:
- Client sends ActionRequest with action statements and closure env
- Server executes the action locally and sends ActionResponse
- After a remote do, a 500ms delay allows propagation to complete
- Uses heuristic delay as discussed, principled approach in future PR

Tests passing: test_distrib.mkt and test_client.mkt end-to-end,
plus all existing local tests.

Here's the exact text to copy and paste:

---

## Testing

Two terminals needed — one for the server, one for the client.

**Terminal 1 (server):**

`cargo run -- -f meerkat/tests/s1.mkt -s`

Note the Service URL printed, e.g. `/ip4/127.0.0.1/tcp/9000/p2p/12D3KooW.../s1`

**Terminal 2 — test remote lookup (#10):**

`cargo run -- -f meerkat/tests/test_distrib.mkt -i "<Service URL>"`

**Terminal 2 — test remote action + propagation (#11):**

`cargo run -- -f meerkat/tests/test_client.mkt -i "<Service URL>"`

Both should print `@test(s2) passed`.