### PR TITLE
Implement REPL for Meerkat (issue #13)

### DIFF
--- a/meerkat-lib/src/runtime/parser/lex.rs
+++ b/meerkat-lib/src/runtime/parser/lex.rs
@@ -58,7 +58,7 @@ fn skip_multi_line_comments<'b>(lex: &mut Lexer<'b, Token<'b>>) -> Skip {
                         balanced_comments += 1;
                     }
                 }
-                None => panic!("Reached end of file"),
+                None => break,
                 _ => {
                     lex.bump_unchecked(1);
                 }

--- a/meerkat-lib/src/runtime/parser/mod.rs
+++ b/meerkat-lib/src/runtime/parser/mod.rs
@@ -7,11 +7,22 @@ pub mod meerkat {
     include!(concat!(env!("OUT_DIR"), "/runtime/parser/meerkat.rs"));
 }
 
+/// Result of attempting to parse a REPL input buffer.
+pub enum ReplParseResult {
+    /// Input parsed successfully into one or more statements.
+    Complete(Vec<crate::ast::Stmt>),
+    /// Input is syntactically incomplete (e.g. an open brace with no matching close).
+    /// The REPL should prompt for more input and append it to the buffer.
+    Incomplete,
+    /// Input has a real syntax error that won't be resolved by adding more text.
+    Error(String),
+}
+
 pub mod parser {
     use logos::Logos;
 
     use crate::ast::Stmt;
-    
+
     pub fn parse_string(input: &str) -> Result<Vec<Stmt>, String> {
         let lex_stream = super::lex::Token::lexer(input)
             .spanned()
@@ -21,10 +32,34 @@ pub mod parser {
             .parse(lex_stream)
             .map_err(|e| format!("Parse error: {:?}", e))
     }
-    
+
     pub fn parse_file(filename: &str) -> Result<Vec<Stmt>, String> {
         let content = std::fs::read_to_string(filename)
             .map_err(|e| format!("Failed to read file: {}", e))?;
         parse_string(&content)
+    }
+
+    /// Try to parse accumulated REPL input, distinguishing incomplete input from real errors.
+    ///
+    /// Returns `Incomplete` when the grammar signals `UnrecognizedEof`, meaning the user
+    /// is mid-statement and the REPL should collect more lines before evaluating.
+    pub fn parse_repl(input: &str) -> super::ReplParseResult {
+        use super::ReplParseResult;
+        use lalrpop_util::ParseError;
+
+        if input.trim().is_empty() {
+            return ReplParseResult::Incomplete;
+        }
+
+        let lex_stream = super::lex::Token::lexer(input)
+            .spanned()
+            .map(|(t, span)| (span.start, t, span.end));
+
+        match super::meerkat::ProgParser::new().parse(lex_stream) {
+            Ok(stmts) if !stmts.is_empty() => ReplParseResult::Complete(stmts),
+            Ok(_) => ReplParseResult::Incomplete,
+            Err(ParseError::UnrecognizedEof { .. }) => ReplParseResult::Incomplete,
+            Err(e) => ReplParseResult::Error(format!("{:?}", e)),
+        }
     }
 }

--- a/meerkat/src/main.rs
+++ b/meerkat/src/main.rs
@@ -1,3 +1,5 @@
+mod repl;
+
 use clap::Parser;
 use std::error::Error;
 use meerkat_lib::runtime::ast::Stmt;
@@ -10,8 +12,9 @@ use meerkat_lib::net::network_layer::NetworkLayer;
 #[derive(Parser, Debug)]
 #[command(author, version, about)]
 struct Args {
-    #[arg(short = 'f', long = "file", default_value = "test0.meerkat")]
-    input_file: String,
+    /// Input file to run. Omit to launch the interactive REPL.
+    #[arg(short = 'f', long = "file")]
+    input_file: Option<String>,
 
     #[arg(short = 'v', long = "verbose", default_value_t = false)]
     verbose: bool,
@@ -38,9 +41,6 @@ pub async fn main() -> Result<(), Box<dyn Error>> {
         .filter_level(log_level)
         .init();
 
-    let prog = meerkat_lib::runtime::parser::parser::parse_file(&args.input_file)
-        .map_err(|e| format!("Parse error: {}", e))?;
-
     // Build slug -> remote address map from -i flags
     let mut remote_url_map: std::collections::HashMap<String, String> = std::collections::HashMap::new();
     for url in &args.import_urls {
@@ -49,10 +49,23 @@ pub async fn main() -> Result<(), Box<dyn Error>> {
         }
     }
 
-    if args.server {
-        run_server(prog, remote_url_map).await
-    } else {
-        run_client(prog, &args.input_file, remote_url_map).await
+    match args.input_file {
+        Some(ref file) => {
+            let prog = meerkat_lib::runtime::parser::parser::parse_file(file)
+                .map_err(|e| format!("Parse error: {}", e))?;
+
+            if args.server {
+                run_server(prog, remote_url_map).await
+            } else {
+                run_client(prog, file, remote_url_map).await
+            }
+        }
+        None => {
+            if args.server {
+                return Err("-s/--server requires a file (-f). Pass a .mkt file containing the services to host.".into());
+            }
+            repl::run_repl(Manager::new(), remote_url_map).await
+        }
     }
 }
 

--- a/meerkat/src/repl.rs
+++ b/meerkat/src/repl.rs
@@ -1,0 +1,127 @@
+use std::io::{self, BufRead, IsTerminal, Write};
+
+use meerkat_lib::runtime::ast::Stmt;
+use meerkat_lib::runtime::parser::ReplParseResult;
+use meerkat_lib::runtime::parser::parser::{parse_file, parse_repl};
+use meerkat_lib::runtime::Manager;
+
+const PROMPT: &str = "meerkat> ";
+const PROMPT_CONT: &str = "       > ";
+
+pub async fn run_repl(
+    mut manager: Manager,
+    remote_url_map: std::collections::HashMap<String, String>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let stdin = io::stdin();
+    let is_tty = stdin.is_terminal();
+
+    if is_tty {
+        println!("Meerkat REPL  (Ctrl-D to exit)");
+        println!("Enter service definitions, @test blocks, or import statements.");
+        println!();
+    }
+
+    let mut buffer = String::new();
+    let mut continuation = false;
+    let mut lines = stdin.lock().lines();
+
+    loop {
+        if is_tty {
+            if continuation {
+                print!("{}", PROMPT_CONT);
+            } else {
+                print!("{}", PROMPT);
+            }
+            io::stdout().flush()?;
+        }
+
+        let line = match lines.next() {
+            Some(Ok(l)) => l,
+            Some(Err(e)) => return Err(e.into()),
+            None => break,
+        };
+
+        buffer.push_str(&line);
+        buffer.push('\n');
+
+        if buffer.trim().is_empty() {
+            buffer.clear();
+            continuation = false;
+            continue;
+        }
+
+        match parse_repl(&buffer) {
+            ReplParseResult::Incomplete => {
+                continuation = true;
+            }
+            ReplParseResult::Error(msg) => {
+                eprintln!("Parse error: {}", msg);
+                buffer.clear();
+                continuation = false;
+            }
+            ReplParseResult::Complete(stmts) => {
+                for stmt in stmts {
+                    match exec_stmt(stmt, &mut manager, &remote_url_map).await {
+                        Ok(Some(output)) => println!("{}", output),
+                        Ok(None) => {}
+                        Err(e) => eprintln!("Error: {}", e),
+                    }
+                }
+                buffer.clear();
+                continuation = false;
+            }
+        }
+    }
+
+    if is_tty {
+        println!();
+    }
+    Ok(())
+}
+
+async fn exec_stmt(
+    stmt: Stmt,
+    manager: &mut Manager,
+    remote_url_map: &std::collections::HashMap<String, String>,
+) -> Result<Option<String>, Box<dyn std::error::Error>> {
+    match stmt {
+        Stmt::Service { name, decls } => {
+            manager.create_service(name.clone(), decls).await
+                .map_err(|e| format!("Service '{}': {}", name, e))?;
+            Ok(Some(format!("Service '{}' loaded.", name)))
+        }
+        Stmt::Test { service, stmts } => {
+            manager.run_test(&service, &stmts).await
+                .map_err(|e| format!("@test({}): {}", service, e))?;
+            Ok(Some(format!("@test({}) passed.", service)))
+        }
+        Stmt::Import { path, service: svc_name } => {
+            if let Some(url) = remote_url_map.get(&svc_name) {
+                manager.remote_services.insert(
+                    svc_name.clone(),
+                    meerkat_lib::net::Address::new(url.as_str()),
+                );
+                return Ok(Some(format!(
+                    "Remote service '{}' registered at {}.", svc_name, url
+                )));
+            }
+            let import_stmts = parse_file(&path)
+                .map_err(|e| format!("Import '{}': {}", path, e))?;
+            let mut loaded = Vec::new();
+            for s in import_stmts {
+                if let Stmt::Service { name, decls } = s {
+                    manager.create_service(name.clone(), decls).await
+                        .map_err(|e| format!("Imported service '{}': {}", name, e))?;
+                    loaded.push(name);
+                }
+            }
+            Ok(Some(format!("Imported service(s): {}.", loaded.join(", "))))
+        }
+        other => {
+            Ok(Some(format!(
+                "(not yet supported in REPL: {:?})",
+                std::mem::discriminant(&other)
+            )))
+        }
+    }
+}

--- a/meerkat/src/repl.rs
+++ b/meerkat/src/repl.rs
@@ -21,6 +21,15 @@ pub async fn run_repl(
         println!();
     }
 
+    // Start network actor if we have remote imports, same as run_client
+    if !remote_url_map.is_empty() {
+        let mut n = meerkat_lib::net::NetworkActor::new(meerkat_lib::net::types::NodeType::Server).await
+            .map_err(|e| format!("Network error: {}", e))?;
+        let listen_addr = meerkat_lib::net::Address::new("/ip4/0.0.0.0/tcp/0");
+        n.handle_command(meerkat_lib::net::NetworkCommand::Listen { addr: listen_addr }).await;
+        manager.network = Some(n);
+    }
+
     let mut buffer = String::new();
     let mut continuation = false;
     let mut lines = stdin.lock().lines();


### PR DESCRIPTION
Closes #13

•⁠  ⁠⁠ cargo run ⁠ with no arguments now launches an interactive REPL
•⁠  ⁠Multi-line input is handled transparently — a continuation prompt ("       >") appears until the statement is complete
•⁠  ⁠Services defined in one REPL turn are visible to ⁠ @test ⁠ blocks entered in subsequent turns (shared manager across the loop)
•⁠  ⁠Works non-interactively: pipe any test file directly ⁠ cargo run < meerkat/tests/test1.meerkat ⁠)
•⁠  ⁠All existing test files pass via both ⁠ -f ⁠ and pipe mode
•⁠  ⁠Existing ⁠ -f ⁠ and ⁠ -s ⁠ behaviour is unchanged
