### PR TITLE
Implement #14: add let and expression statements to REPL

### DIFF
--- a/meerkat-lib/src/runtime/ast/mod.rs
+++ b/meerkat-lib/src/runtime/ast/mod.rs
@@ -28,6 +28,7 @@ pub enum ActionStmt {
         name: String,
         expr: Expr,
     },
+    Expr(Expr),
     Do(Expr),
     Assert(Expr),
     Assign {
@@ -273,6 +274,7 @@ impl Display for ActionStmt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             ActionStmt::Let { name, expr } => write!(f, "let {} = {}", name, expr),
+            ActionStmt::Expr(expr) => write!(f, "{}", expr),
             ActionStmt::Do(expr) => write!(f, "do {}", expr),
             ActionStmt::Assert(expr) => write!(f, "assert {}", expr),
             ActionStmt::Assign { var, expr } => write!(f, "{} = {}", var, expr),

--- a/meerkat-lib/src/runtime/interpreter/executor.rs
+++ b/meerkat-lib/src/runtime/interpreter/executor.rs
@@ -2,34 +2,47 @@ use crate::ast::{Value, ActionStmt};
 use crate::runtime::Manager;
 use super::evaluator::{eval, EvalContext, EvalError};
 
+/// The effect produced by executing a single statement.
+pub enum ExecuteEffect {
+    /// Statement completed with no binding or value.
+    None,
+    /// A `let` binding: the name and value to add to env.
+    Binding(String, Value),
+    /// An expression statement was evaluated: the result value.
+    ExprValue(Value),
+}
+
 #[async_recursion::async_recursion]
 pub async fn execute(
     stmt: &ActionStmt,
     env: &[(String, Value)],
     manager: &mut Manager,
     service_name: &str,
-) -> Result<(), EvalError> {
+) -> Result<ExecuteEffect, EvalError> {
     match stmt {
         ActionStmt::Assign { var, expr } => {
             let value = eval(expr, env, &mut EvalContext { manager, service_name }).await?;
-            manager.assign(service_name, var, value).await
+            manager.assign(service_name, var, value).await?;
+            Ok(ExecuteEffect::None)
         }
         ActionStmt::Do(expr) => {
             let val = eval(expr, env, &mut EvalContext { manager, service_name }).await?;
             match val {
                 Value::ActionClosure { stmts, env: closure_env, service_name: action_svc } => {
                     if manager.remote_services.contains_key(&action_svc) {
-                        // Execute action remotely
                         manager.remote_action(&action_svc, stmts, closure_env).await?;
-                        // Heuristic delay to allow remote propagation to complete
                         tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
                     } else {
-                        // Execute locally
+                        let mut exec_env = closure_env.clone();
                         for s in &stmts {
-                            execute(s, &closure_env, manager, &action_svc).await?;
+                            if let ExecuteEffect::Binding(name, val) =
+                                execute(s, &exec_env, manager, &action_svc).await?
+                            {
+                                exec_env.push((name, val));
+                            }
                         }
                     }
-                    Ok(())
+                    Ok(ExecuteEffect::None)
                 }
                 _ => Err(EvalError::TypeError("do expects an action".to_string())),
             }
@@ -37,14 +50,18 @@ pub async fn execute(
         ActionStmt::Assert(expr) => {
             let val = eval(expr, env, &mut EvalContext { manager, service_name }).await?;
             match val {
-                Value::Bool { val: true } => Ok(()),
+                Value::Bool { val: true } => Ok(ExecuteEffect::None),
                 Value::Bool { val: false } => Err(EvalError::TypeError("Assertion failed".to_string())),
                 _ => Err(EvalError::TypeError("assert expects a boolean".to_string())),
             }
         }
-        ActionStmt::Let { name: _, expr } => {
-            let _val = eval(expr, env, &mut EvalContext { manager, service_name }).await?;
-            Ok(())
+        ActionStmt::Let { name, expr } => {
+            let val = eval(expr, env, &mut EvalContext { manager, service_name }).await?;
+            Ok(ExecuteEffect::Binding(name.clone(), val))
+        }
+        ActionStmt::Expr(expr) => {
+            let val = eval(expr, env, &mut EvalContext { manager, service_name }).await?;
+            Ok(ExecuteEffect::ExprValue(val))
         }
         ActionStmt::Insert { .. } => Err(EvalError::NotImplemented),
     }

--- a/meerkat-lib/src/runtime/interpreter/mod.rs
+++ b/meerkat-lib/src/runtime/interpreter/mod.rs
@@ -4,3 +4,4 @@ pub use evaluator::eval;
 pub use evaluator::EvalContext;
 pub use evaluator::EvalError;
 pub use executor::execute;
+pub use executor::ExecuteEffect;

--- a/meerkat-lib/src/runtime/manager/mod.rs
+++ b/meerkat-lib/src/runtime/manager/mod.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 use super::ast::{Value, Decl, Expr, ActionStmt};
-use super::interpreter::{eval, EvalContext, EvalError, execute};
+use super::interpreter::{eval, EvalContext, EvalError, execute, ExecuteEffect};
 use super::semantic_analysis::var_analysis::{calc_dep_srv, DependAnalysis};
 use crate::net::{Address, NetworkCommand, NetworkEvent, MeerkatMessage, NetworkActor};
 use crate::net::network_layer::NetworkLayer;
@@ -301,9 +301,13 @@ impl Manager {
         self.run_test_with_env(service_name, stmts, &[]).await
     }
 
-    pub async fn run_test_with_env(&mut self, service_name: &str, stmts: &[ActionStmt], env: &[(String, Value)]) -> Result<(), EvalError> {
+    pub async fn run_test_with_env(&mut self, service_name: &str, stmts: &[ActionStmt], initial_env: &[(String, Value)]) -> Result<(), EvalError> {
+        let mut env: Vec<(String, Value)> = initial_env.to_vec();
         for stmt in stmts {
-            execute(stmt, env, self, service_name).await?;
+            match execute(stmt, &env, self, service_name).await? {
+                ExecuteEffect::Binding(name, val) => env.push((name, val)),
+                ExecuteEffect::None | ExecuteEffect::ExprValue(_) => {}
+            }
         }
         Ok(())
     }

--- a/meerkat-lib/src/runtime/parser/lex.rs
+++ b/meerkat-lib/src/runtime/parser/lex.rs
@@ -186,7 +186,8 @@ pub enum Token<'a> {
   STRING_KW,
   #[token("bool")]
   BOOL_KW,
-  
+  #[token("let")]
+  LET_KW,
 
     #[regex(r"\s*", logos::skip)]
     #[regex(r#"(//)[^\n]*"#, logos::skip)] // Regex for a single line comment

--- a/meerkat-lib/src/runtime/parser/meerkat.lalrpop
+++ b/meerkat-lib/src/runtime/parser/meerkat.lalrpop
@@ -41,6 +41,7 @@ extern {
         "number" => Token::NUMBER_KW,
         "string" => Token::STRING_KW,
         "bool" => Token::BOOL_KW,
+        "let" => Token::LET_KW,
         ";" => Token::Semicolon,
         "." => Token::Dot,
         "=" => Token::Assgn,
@@ -90,11 +91,13 @@ Stmt: Stmt = {
     "import" <i:Ident> => {
         Stmt::Import { path: format!("{}.mkt", i), service: i }
     },
+    <a:ActionStmt> => Stmt::ActionStmt(a),
 }
 
 ActionStmts: Vec<ActionStmt> = ActionStmt*;
 
 ActionStmt: ActionStmt = {
+    "let" <i:Ident> "=" <e:Expr> ";" => ActionStmt::Let { name: i, expr: e },
     "do" <e: Expr> ";" => {
         ActionStmt::Do(e)
     },
@@ -104,7 +107,8 @@ ActionStmt: ActionStmt = {
     "insert"  <e: Expr> "into" <t: Ident> => {
         ActionStmt::Insert {row: e, table_name: t}
     },
-    <i:Ident> "=" <e:Expr> ";" => ActionStmt::Assign { var: i, expr: e }
+    <i:Ident> "=" <e:Expr> ";" => ActionStmt::Assign { var: i, expr: e },
+    <e:Expr> ";" => ActionStmt::Expr(e),
 }
 
 Decl: Decl = {

--- a/meerkat-lib/src/runtime/semantic_analysis/var_analysis/read_write.rs
+++ b/meerkat-lib/src/runtime/semantic_analysis/var_analysis/read_write.rs
@@ -69,6 +69,9 @@ impl Expr {
                         ActionStmt::Let { name: _, expr } => {
                             free_vars.extend(expr.free_var(reactive_names, var_binded));
                         }
+                        ActionStmt::Expr(expr) => {
+                            free_vars.extend(expr.free_var(reactive_names, var_binded));
+                        }
                         ActionStmt::Insert { row, .. } => {
                             free_vars.extend(row.free_var(reactive_names, var_binded));
                         }

--- a/meerkat/src/repl.rs
+++ b/meerkat/src/repl.rs
@@ -1,6 +1,7 @@
 use std::io::{self, BufRead, IsTerminal, Write};
 
-use meerkat_lib::runtime::ast::Stmt;
+use meerkat_lib::runtime::ast::{Stmt, Value};
+use meerkat_lib::runtime::interpreter::{execute, ExecuteEffect};
 use meerkat_lib::runtime::parser::ReplParseResult;
 use meerkat_lib::runtime::parser::parser::{parse_file, parse_repl};
 use meerkat_lib::runtime::Manager;
@@ -17,11 +18,10 @@ pub async fn run_repl(
 
     if is_tty {
         println!("Meerkat REPL  (Ctrl-D to exit)");
-        println!("Enter service definitions, @test blocks, or import statements.");
+        println!("Enter service definitions, @test blocks, statements, or expressions.");
         println!();
     }
 
-    // Start network actor if we have remote imports, same as run_client
     if !remote_url_map.is_empty() {
         let mut n = meerkat_lib::net::NetworkActor::new(meerkat_lib::net::types::NodeType::Server).await
             .map_err(|e| format!("Network error: {}", e))?;
@@ -29,6 +29,9 @@ pub async fn run_repl(
         n.handle_command(meerkat_lib::net::NetworkCommand::Listen { addr: listen_addr }).await;
         manager.network = Some(n);
     }
+
+    // Persistent environment for let bindings across REPL inputs
+    let mut repl_env: Vec<(String, Value)> = Vec::new();
 
     let mut buffer = String::new();
     let mut continuation = false;
@@ -70,7 +73,7 @@ pub async fn run_repl(
             }
             ReplParseResult::Complete(stmts) => {
                 for stmt in stmts {
-                    match exec_stmt(stmt, &mut manager, &remote_url_map).await {
+                    match exec_stmt(stmt, &mut manager, &mut repl_env, &remote_url_map).await {
                         Ok(Some(output)) => println!("{}", output),
                         Ok(None) => {}
                         Err(e) => eprintln!("Error: {}", e),
@@ -91,6 +94,7 @@ pub async fn run_repl(
 async fn exec_stmt(
     stmt: Stmt,
     manager: &mut Manager,
+    repl_env: &mut Vec<(String, Value)>,
     remote_url_map: &std::collections::HashMap<String, String>,
 ) -> Result<Option<String>, Box<dyn std::error::Error>> {
     match stmt {
@@ -125,6 +129,19 @@ async fn exec_stmt(
                 }
             }
             Ok(Some(format!("Imported service(s): {}.", loaded.join(", "))))
+        }
+        Stmt::ActionStmt(action_stmt) => {
+            let effect = execute(&action_stmt, repl_env, manager, "")
+                .await
+                .map_err(|e| format!("{}", e))?;
+            match effect {
+                ExecuteEffect::Binding(name, val) => {
+                    repl_env.push((name, val));
+                    Ok(None)
+                }
+                ExecuteEffect::ExprValue(val) => Ok(Some(val.to_string())),
+                ExecuteEffect::None => Ok(None),
+            }
         }
         other => {
             Ok(Some(format!(


### PR DESCRIPTION
#14 

- `let` statements bind variables in the environment for later use
- Expression statements (`a + 3;`) evaluate and print their value in the REPL
- `let` bindings persist across REPL inputs
- `let` and expression statements work inside `@test` blocks with both REPL and `-f`
- `do` and `assert` statements work as top-level REPL input

Tests passing: all existing local tests pass, plus new REPL behaviour verified manually.