### PR TITLE
Implement #15: add watch to the REPL

### DIFF
--- a/meerkat-lib/src/runtime/ast/mod.rs
+++ b/meerkat-lib/src/runtime/ast/mod.rs
@@ -49,6 +49,7 @@ pub enum Stmt {
     Import { path: String, service: String },
     Service { name: String, decls: Vec<Decl> },
     Test { service: String, stmts: Vec<ActionStmt> },
+    Watch { expr: Expr },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]

--- a/meerkat-lib/src/runtime/parser/lex.rs
+++ b/meerkat-lib/src/runtime/parser/lex.rs
@@ -188,6 +188,8 @@ pub enum Token<'a> {
   BOOL_KW,
   #[token("let")]
   LET_KW,
+  #[token("watch")]
+  WATCH_KW,
 
     #[regex(r"\s*", logos::skip)]
     #[regex(r#"(//)[^\n]*"#, logos::skip)] // Regex for a single line comment

--- a/meerkat-lib/src/runtime/parser/meerkat.lalrpop
+++ b/meerkat-lib/src/runtime/parser/meerkat.lalrpop
@@ -42,6 +42,7 @@ extern {
         "string" => Token::STRING_KW,
         "bool" => Token::BOOL_KW,
         "let" => Token::LET_KW,
+        "watch" => Token::WATCH_KW,
         ";" => Token::Semicolon,
         "." => Token::Dot,
         "=" => Token::Assgn,
@@ -92,6 +93,7 @@ Stmt: Stmt = {
         Stmt::Import { path: format!("{}.mkt", i), service: i }
     },
     <a:ActionStmt> => Stmt::ActionStmt(a),
+    "watch" <e:Expr> ";" => Stmt::Watch { expr: e },
 }
 
 ActionStmts: Vec<ActionStmt> = ActionStmt*;

--- a/meerkat/src/repl.rs
+++ b/meerkat/src/repl.rs
@@ -1,13 +1,44 @@
 use std::io::{self, BufRead, IsTerminal, Write};
 
-use meerkat_lib::runtime::ast::{Stmt, Value};
-use meerkat_lib::runtime::interpreter::{execute, ExecuteEffect};
+use meerkat_lib::runtime::ast::{Expr, Stmt, Value};
+use meerkat_lib::runtime::interpreter::{eval, execute, EvalContext, ExecuteEffect};
 use meerkat_lib::runtime::parser::ReplParseResult;
 use meerkat_lib::runtime::parser::parser::{parse_file, parse_repl};
 use meerkat_lib::runtime::Manager;
 
 const PROMPT: &str = "meerkat> ";
 const PROMPT_CONT: &str = "       > ";
+
+/// A registered watch: the original source text, the expression, and its last known value.
+struct Watch {
+    label: String,
+    expr: Expr,
+    last: Option<Value>,
+}
+
+/// Re-evaluate all watches and print any that have changed.
+async fn check_watches(watches: &mut Vec<Watch>, manager: &mut Manager, repl_env: &[(String, Value)]) {
+    for w in watches.iter_mut() {
+        let result = eval(
+            &w.expr,
+            repl_env,
+            &mut EvalContext { manager, service_name: "" },
+        ).await;
+        match result {
+            Ok(new_val) => {
+                let changed = w.last.as_ref().map_or(true, |old| old != &new_val);
+                if changed {
+                    match &w.last {
+                        None    => println!("[watch] {} = {}", w.label, new_val),
+                        Some(old) => println!("[watch] {}: {} => {}", w.label, old, new_val),
+                    }
+                    w.last = Some(new_val);
+                }
+            }
+            Err(e) => eprintln!("[watch] {}: error: {}", w.label, e),
+        }
+    }
+}
 
 pub async fn run_repl(
     mut manager: Manager,
@@ -30,8 +61,8 @@ pub async fn run_repl(
         manager.network = Some(n);
     }
 
-    // Persistent environment for let bindings across REPL inputs
     let mut repl_env: Vec<(String, Value)> = Vec::new();
+    let mut watches: Vec<Watch> = Vec::new();
 
     let mut buffer = String::new();
     let mut continuation = false;
@@ -56,9 +87,11 @@ pub async fn run_repl(
         buffer.push_str(&line);
         buffer.push('\n');
 
+        // Empty line: just check watches and re-prompt
         if buffer.trim().is_empty() {
             buffer.clear();
             continuation = false;
+            check_watches(&mut watches, &mut manager, &repl_env).await;
             continue;
         }
 
@@ -73,12 +106,14 @@ pub async fn run_repl(
             }
             ReplParseResult::Complete(stmts) => {
                 for stmt in stmts {
-                    match exec_stmt(stmt, &mut manager, &mut repl_env, &remote_url_map).await {
+                    match exec_stmt(stmt, &mut manager, &mut repl_env, &mut watches, &remote_url_map).await {
                         Ok(Some(output)) => println!("{}", output),
                         Ok(None) => {}
                         Err(e) => eprintln!("Error: {}", e),
                     }
                 }
+                // Check watches after every complete input
+                check_watches(&mut watches, &mut manager, &repl_env).await;
                 buffer.clear();
                 continuation = false;
             }
@@ -95,6 +130,7 @@ async fn exec_stmt(
     stmt: Stmt,
     manager: &mut Manager,
     repl_env: &mut Vec<(String, Value)>,
+    watches: &mut Vec<Watch>,
     remote_url_map: &std::collections::HashMap<String, String>,
 ) -> Result<Option<String>, Box<dyn std::error::Error>> {
     match stmt {
@@ -142,6 +178,21 @@ async fn exec_stmt(
                 ExecuteEffect::ExprValue(val) => Ok(Some(val.to_string())),
                 ExecuteEffect::None => Ok(None),
             }
+        }
+        Stmt::Watch { expr } => {
+            let label = format!("{}", expr);
+            // Evaluate initial value
+            let initial = eval(
+                &expr,
+                repl_env,
+                &mut EvalContext { manager, service_name: "" },
+            ).await.ok();
+            let msg = match &initial {
+                Some(v) => format!("Watching: {} (current value: {})", label, v),
+                None    => format!("Watching: {} (not yet available)", label),
+            };
+            watches.push(Watch { label, expr, last: initial });
+            Ok(Some(msg))
         }
         other => {
             Ok(Some(format!(


### PR DESCRIPTION
- `watch <expr>;` registers an expression to monitor in the REPL
- Shows current value on registration: `Watching: foo.y (current value: 2)`
- After each complete input or empty enter, checks all watches and reports changes: `[watch] foo.y: 2 => 6`
- Works with service member access (e.g. `watch svc.x+1`), let bindings, and any valid expression
- Proposed output syntax: `[watch] <expr>: <old> => <new>` on change, `[watch] <expr> = <val>` on first registration

All existing tests pass.