### PR TITLE
Fix #25: preserve service context when calling closures

### DIFF
--- a/meerkat-lib/src/runtime/ast/mod.rs
+++ b/meerkat-lib/src/runtime/ast/mod.rs
@@ -67,6 +67,7 @@ pub enum Value {
         params: Vec<String>,
         body: Box<Expr>,
         env: Vec<(String, Value)>,
+        service_name: String,
     },
     ActionClosure {
         stmts: Vec<ActionStmt>,
@@ -206,7 +207,7 @@ impl Display for Value {
             Value::Number { val } => write!(f, "{}", val),
             Value::Bool { val } => write!(f, "{}", val),
             Value::String { val } => write!(f, "\"{}\"", val),
-            Value::Closure { params, body, env } =>
+            Value::Closure { params, body, env, service_name } =>
                 write!(f, "fn({})[{:?}]{{{}}}", params.join(","), env, body),
             Value::ActionClosure { stmts, env, service_name } =>
                 write!(f, "action[{:?}][{}]{{{:?}}}", env, service_name, stmts),  

--- a/meerkat-lib/src/runtime/interpreter/evaluator.rs
+++ b/meerkat-lib/src/runtime/interpreter/evaluator.rs
@@ -49,12 +49,12 @@ pub async fn eval(
                 arg_vals.push(eval(arg, env, ctx).await?);
             }
             match func_val {
-                Value::Closure { params, body, env: closure_env } => {
+                Value::Closure { params, body, env: closure_env, service_name: closure_svc } => {
                     let mut new_env = closure_env.clone();
                     for (param, arg_val) in params.iter().zip(arg_vals) {
                         new_env.push((param.clone(), arg_val));
                     }
-                    eval(&body, &new_env, ctx).await
+                    eval(&body, &new_env, &mut EvalContext { manager: ctx.manager, service_name: &closure_svc }).await
                 }
                 _ => Err(EvalError::TypeError("Attempting to call a non-function value".to_string())),
             }
@@ -120,6 +120,7 @@ pub async fn eval(
                 params: params.clone(),
                 body: body.clone(),
                 env: captured_env,
+                service_name: ctx.service_name.to_string(),
             })
         }
 


### PR DESCRIPTION
Fixes #25

When a closure (e.g. fn n => action { x = x + n; }) was called from the REPL or any context with a different service, the body was evaluated with the caller's service context ("") instead of the closure's original service. This caused variable lookups inside the action to fail with "not found in service ''".

Fix: Value::Closure now stores the service_name from when it was created. When the closure is called, the body is evaluated with that saved service context instead of the caller's.

All existing tests pass.