### PR TITLE
Issue 32 server remote import

### DIFF
--- a/meerkat/src/main.rs
+++ b/meerkat/src/main.rs
@@ -72,15 +72,6 @@ pub async fn main() -> Result<(), Box<dyn Error>> {
 async fn run_server(prog: Vec<Stmt>, remote_url_map: std::collections::HashMap<String, String>) -> Result<(), Box<dyn Error>> {
     let mut manager = Manager::new();
 
-    // Load services
-    for stmt in &prog {
-        if let Stmt::Service { name, decls } = stmt {
-            manager.create_service(name.clone(), decls.clone()).await
-                .map_err(|e| format!("Service error: {}", e))?;
-            println!("Service '{}' loaded", name);
-        }
-    }
-
     // Start network actor as server
     let mut net = NetworkActor::new(NodeType::Server).await
         .map_err(|e| format!("Network error: {}", e))?;
@@ -118,6 +109,16 @@ async fn run_server(prog: Vec<Stmt>, remote_url_map: std::collections::HashMap<S
 
     // Wire network into manager so server can also do remote lookups
     manager.network = Some(net);
+
+    // Load services after network and remote services are ready,
+    // so that remote lookups during service initialization work correctly
+    for stmt in &prog {
+        if let Stmt::Service { name, decls } = stmt {
+            manager.create_service(name.clone(), decls.clone()).await
+                .map_err(|e| format!("Service error: {}", e))?;
+            println!("Service '{}' loaded", name);
+        }
+    }
 
     println!("Server running, press Ctrl+C to stop...");
 

--- a/meerkat/src/main.rs
+++ b/meerkat/src/main.rs
@@ -26,6 +26,10 @@ struct Args {
     /// Remote service URLs: -i <url> maps the service slug to a remote address
     #[arg(short = 'i', long = "import-url")]
     import_urls: Vec<String>,
+
+    /// Port to listen on in server mode (default: 9000)
+    #[arg(short = 'p', long = "port", default_value_t = 9000)]
+    port: u16,
 }
 
 #[tokio::main]
@@ -55,7 +59,7 @@ pub async fn main() -> Result<(), Box<dyn Error>> {
                 .map_err(|e| format!("Parse error: {}", e))?;
 
             if args.server {
-                run_server(prog, remote_url_map).await
+                run_server(prog, remote_url_map, args.port).await
             } else {
                 run_client(prog, file, remote_url_map).await
             }
@@ -69,7 +73,7 @@ pub async fn main() -> Result<(), Box<dyn Error>> {
     }
 }
 
-async fn run_server(prog: Vec<Stmt>, remote_url_map: std::collections::HashMap<String, String>) -> Result<(), Box<dyn Error>> {
+async fn run_server(prog: Vec<Stmt>, remote_url_map: std::collections::HashMap<String, String>, port: u16) -> Result<(), Box<dyn Error>> {
     let mut manager = Manager::new();
 
     // Start network actor as server
@@ -78,7 +82,7 @@ async fn run_server(prog: Vec<Stmt>, remote_url_map: std::collections::HashMap<S
 
     // Listen
     let public_ip = meerkat_lib::runtime::Manager::get_public_ip();
-    let listen_addr = Address::new("/ip4/0.0.0.0/tcp/9000");
+    let listen_addr = Address::new(&format!("/ip4/0.0.0.0/tcp/{}", port));
     let reply = net.handle_command(NetworkCommand::Listen { addr: listen_addr }).await;
     let actual_addr = match reply {
         meerkat_lib::net::NetworkReply::ListenSuccess { addr } => addr,


### PR DESCRIPTION
**Root cause:** `create_service` was called before the network actor was started and before remote services were registered. So any remote lookup during service initialization failed immediately with `Variable 'y' not found in service 's1'`.

**Fix:** Reordered `run_server` so the network is started, remote services are registered, and the network is wired into the manager — all before `create_service` is called.

Also added a `-p`/`--port` flag (default 9000) to allow running multiple servers on different ports when testing on the same machine.

**Tested:**
- `cargo run -- -s -f meerkat/tests/s1.mkt -p 9000`
- `cargo run -- -s -f meerkat/tests/test_client.mkt -p 9001 -i <s1_url>` → `Service 's2' loaded` 
- `cargo run -- -f meerkat/tests/test_client.mkt -i <s1_url>` → `@test(s2) passed` 