### PR TITLE
Corrected build error for `meerkat-lib` using supplied example in readme for `wasm32-unknown-unknown`.

### DIFF
--- a/meerkat-lib/Cargo.toml
+++ b/meerkat-lib/Cargo.toml
@@ -14,7 +14,6 @@ serde_json = "1.0.61"
 strum_macros = "0.25.3"
 lalrpop-util = { version = "0.20.2", features = ["lexer", "unicode"] }
 kameo = "0.16"
-tokio = { version = "1", features = ["full"] }
 json = "0.12.4"
 futures = "0.3"
 dashmap = "5"
@@ -26,10 +25,12 @@ thiserror = "1"
 async-recursion = "1.0"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+tokio = { version = "1", features = ["full"] }
 libp2p = { version = "0.56", features = ["tokio", "tcp", "dns", "websocket", "noise", "yamux", "relay", "dcutr", "identify", "macros"] }
 libp2p-stream = "0.4.0-alpha"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
+tokio = { version = "1", features = ["sync", "macros", "io-util", "rt", "time"] }
 libp2p = { version = "0.56", default-features = false, features = ["macros", "wasm-bindgen", "websocket-websys", "noise", "yamux", "relay", "identify"] }
 libp2p-stream = "0.4.0-alpha"
 wasm-bindgen = "0.2"


### PR DESCRIPTION
Discussed this issue with Professor Aldrich 2026-05-28 in person. Distinction between tokio in "full" and piecemeal for a wasm32-unknown-unknown target, where it does not have same system calls (or any) as it does for native builds/targets.