### PR TITLE
Implement #31: acquire transaction locks lazily during execution

### DIFF
--- a/meerkat-lib/src/runtime/interpreter/evaluator.rs
+++ b/meerkat-lib/src/runtime/interpreter/evaluator.rs
@@ -3,6 +3,7 @@ use crate::ast::{
 };
 use std::collections::HashSet;
 use crate::runtime::manager::Manager;
+use crate::runtime::txn::Transaction;
 
 #[derive(Debug)]
 pub enum EvalError {
@@ -33,6 +34,8 @@ impl std::error::Error for EvalError {}
 pub struct EvalContext<'a> {
     pub manager: &'a mut Manager,
     pub service_name: &'a str,
+    /// Active transaction, if evaluation is happening inside one.
+    pub txn: Option<&'a mut Transaction>,
 }
 
 #[async_recursion::async_recursion]
@@ -56,7 +59,7 @@ pub async fn eval(
                     for (param, arg_val) in params.iter().zip(arg_vals) {
                         new_env.push((param.clone(), arg_val));
                     }
-                    eval(&body, &new_env, &mut EvalContext { manager: ctx.manager, service_name: &closure_svc }).await
+                    eval(&body, &new_env, &mut EvalContext { manager: ctx.manager, service_name: &closure_svc, txn: ctx.txn.as_deref_mut() }).await
                 }
                 _ => Err(EvalError::TypeError("Attempting to call a non-function value".to_string())),
             }
@@ -68,7 +71,7 @@ pub async fn eval(
                     return Ok(var_val.clone());
                 }
             }
-            ctx.manager.lookup(ident, ctx.service_name).await
+            ctx.manager.lookup(ident, ctx.service_name, ctx.txn.as_deref_mut()).await
         }
 
         Expr::Binop { op, expr1, expr2 } => {
@@ -149,7 +152,7 @@ pub async fn eval(
 
         Expr::MemberAccess { service, member } => {
             // Manager figures out whether service is local or remote
-            ctx.manager.lookup(member, service).await
+            ctx.manager.lookup(member, service, ctx.txn.as_deref_mut()).await
         }
         _ => Err(EvalError::NotImplemented),
     }
@@ -164,7 +167,7 @@ mod tests {
     #[tokio::test]
     async fn test_literal() {
         let mut manager = Manager::default();
-        let mut ctx = EvalContext { manager: &mut manager, service_name: "" };
+        let mut ctx = EvalContext { manager: &mut manager, service_name: "", txn: None };
         let expr = Expr::Literal { val: Value::Number { val: 42 } };
         let result = eval(&expr, &[], &mut ctx).await.unwrap();
         assert_eq!(result, Value::Number { val: 42 });
@@ -173,7 +176,7 @@ mod tests {
     #[tokio::test]
     async fn test_binop_add() {
         let mut manager = Manager::default();
-        let mut ctx = EvalContext { manager: &mut manager, service_name: "" };
+        let mut ctx = EvalContext { manager: &mut manager, service_name: "", txn: None };
         let expr = Expr::Binop {
             op: BinOp::Add,
             expr1: Box::new(Expr::Literal { val: Value::Number { val: 2 } }),
@@ -186,7 +189,7 @@ mod tests {
     #[tokio::test]
     async fn test_func_and_call() {
         let mut manager = Manager::default();
-        let mut ctx = EvalContext { manager: &mut manager, service_name: "" };
+        let mut ctx = EvalContext { manager: &mut manager, service_name: "", txn: None };
         let func_expr = Expr::Func {
             params: vec!["x".to_string()],
             body: Box::new(Expr::Binop {
@@ -206,7 +209,7 @@ mod tests {
     #[tokio::test]
     async fn test_action_creation() {
         let mut manager = Manager::default();
-        let mut ctx = EvalContext { manager: &mut manager, service_name: "" };
+        let mut ctx = EvalContext { manager: &mut manager, service_name: "", txn: None };
         let action_expr = Expr::Action(vec![
             ActionStmt::Assign {
                 var: "x".to_string(),
@@ -223,7 +226,7 @@ mod tests {
     #[tokio::test]
     async fn test_closure_captures_only_free_vars() {
         let mut manager = Manager::default();
-        let mut ctx = EvalContext { manager: &mut manager, service_name: "" };
+        let mut ctx = EvalContext { manager: &mut manager, service_name: "", txn: None };
         let env = vec![
             ("a".to_string(), Value::Number { val: 1 }),
             ("b".to_string(), Value::Number { val: 2 }),

--- a/meerkat-lib/src/runtime/interpreter/executor.rs
+++ b/meerkat-lib/src/runtime/interpreter/executor.rs
@@ -1,5 +1,6 @@
 use crate::ast::{Value, ActionStmt};
 use crate::runtime::Manager;
+use crate::runtime::txn::Transaction;
 use super::evaluator::{eval, EvalContext, EvalError};
 
 /// The effect produced by executing a single statement.
@@ -18,25 +19,28 @@ pub async fn execute(
     env: &[(String, Value)],
     manager: &mut Manager,
     service_name: &str,
+    mut txn: Option<&mut Transaction>,
 ) -> Result<ExecuteEffect, EvalError> {
     match stmt {
         ActionStmt::Assign { var, expr } => {
-            let value = eval(expr, env, &mut EvalContext { manager, service_name }).await?;
-            manager.assign(service_name, var, value).await?;
+            let value = eval(expr, env, &mut EvalContext { manager, service_name, txn: txn.as_deref_mut() }).await?;
+            manager.assign(service_name, var, value, txn).await?;
             Ok(ExecuteEffect::None)
         }
         ActionStmt::Do(expr) => {
-            let val = eval(expr, env, &mut EvalContext { manager, service_name }).await?;
+            let val = eval(expr, env, &mut EvalContext { manager, service_name, txn: txn.as_deref_mut() }).await?;
             match val {
                 Value::ActionClosure { stmts, env: closure_env, service_name: action_svc } => {
                     if manager.remote_services.contains_key(&action_svc) {
+                        // Remote actions don't yet participate in the local
+                        // transaction; distributed lock coordination is future work.
                         manager.remote_action(&action_svc, stmts, closure_env).await?;
                         tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
                     } else {
                         let mut exec_env = closure_env.clone();
                         for s in &stmts {
                             if let ExecuteEffect::Binding(name, val) =
-                                execute(s, &exec_env, manager, &action_svc).await?
+                                execute(s, &exec_env, manager, &action_svc, txn.as_deref_mut()).await?
                             {
                                 exec_env.push((name, val));
                             }
@@ -48,7 +52,7 @@ pub async fn execute(
             }
         }
         ActionStmt::Assert(expr) => {
-            let val = eval(expr, env, &mut EvalContext { manager, service_name }).await?;
+            let val = eval(expr, env, &mut EvalContext { manager, service_name, txn: txn.as_deref_mut() }).await?;
             match val {
                 Value::Bool { val: true } => Ok(ExecuteEffect::None),
                 Value::Bool { val: false } => Err(EvalError::TypeError("Assertion failed".to_string())),
@@ -56,11 +60,11 @@ pub async fn execute(
             }
         }
         ActionStmt::Let { name, expr } => {
-            let val = eval(expr, env, &mut EvalContext { manager, service_name }).await?;
+            let val = eval(expr, env, &mut EvalContext { manager, service_name, txn: txn.as_deref_mut() }).await?;
             Ok(ExecuteEffect::Binding(name.clone(), val))
         }
         ActionStmt::Expr(expr) => {
-            let val = eval(expr, env, &mut EvalContext { manager, service_name }).await?;
+            let val = eval(expr, env, &mut EvalContext { manager, service_name, txn: txn.as_deref_mut() }).await?;
             Ok(ExecuteEffect::ExprValue(val))
         }
         ActionStmt::Insert { .. } => Err(EvalError::NotImplemented),

--- a/meerkat-lib/src/runtime/manager/mod.rs
+++ b/meerkat-lib/src/runtime/manager/mod.rs
@@ -87,10 +87,10 @@ impl Manager {
             .cloned();
 
         if let Some(expr) = def_expr {
-            let env: Vec<(String, Value)> = self.services
-                .get(service_name)
-                .map(|s| s.vars.iter().map(|(k, v)| (k.clone(), v.value.clone())).collect())
-                .unwrap_or_default();
+            // Evaluate the def with an empty env so its dependencies resolve
+            // through lookup (acquiring read locks and populating the cache)
+            // rather than being pre-seeded from current service var values.
+            let env: Vec<(String, Value)> = Vec::new();
             return eval(&expr, &env, &mut EvalContext { manager: self, service_name, txn: txn.as_deref_mut() }).await;
         }
 
@@ -128,30 +128,31 @@ impl Manager {
     }
 
     pub async fn assign(&mut self, service_name: &str, var: &str, value: Value, mut txn: Option<&mut Transaction>) -> Result<(), EvalError> {
-        // If inside a transaction, acquire a write lock lazily. If we already hold
-        // a read lock on this var (read-then-write, e.g. x = x + 1), upgrade it.
-        // Decide which lock action is needed first (ending the txn borrow), then
-        // call into self, then re-borrow txn to record the write.
-        enum LockAction { Acquire, Upgrade }
-        let mut action: Option<(TxnId, LockAction)> = None;
-        if let Some(t) = txn.as_deref() {
-            let kind = if t.locked.contains(var) { LockAction::Upgrade } else { LockAction::Acquire };
-            action = Some((t.id.clone(), kind));
-        }
-        if let Some((txn_id, kind)) = action {
+        // Inside a transaction: acquire the write lock lazily (upgrading from a
+        // read lock for read-then-write patterns like x = x + 1) and buffer the
+        // write. The buffered value is applied to the service only at commit, so
+        // a transaction that fails partway leaves no partial writes behind.
+        if txn.is_some() {
+            enum LockAction { Acquire, Upgrade }
+            let (txn_id, kind) = {
+                let t = txn.as_deref().unwrap();
+                let kind = if t.locked.contains(var) { LockAction::Upgrade } else { LockAction::Acquire };
+                (t.id.clone(), kind)
+            };
             match kind {
                 LockAction::Upgrade => self.upgrade_to_write_lock(service_name, var, &txn_id)?,
                 LockAction::Acquire => self.acquire_write_lock(service_name, var, &txn_id)?,
             }
             if let Some(t) = txn.as_deref_mut() {
                 t.locked.insert(var.to_string());
-                t.written.insert(var.to_string());
-                // Writing updates the cached value rather than invalidating it
-                t.read_cache.insert(var.to_string(), value.clone());
+                t.written.insert(var.to_string(), value.clone());
+                // Reads later in the same transaction see the buffered write
+                t.read_cache.insert(var.to_string(), value);
             }
+            return Ok(());
         }
 
-        // update the var
+        // Non-transactional path: apply the write immediately and propagate.
         if let Some(service) = self.services.get_mut(service_name) {
             if let Some(var_state) = service.vars.get_mut(var) {
                 var_state.value = value;
@@ -489,14 +490,27 @@ impl Manager {
             }
         }
 
-        // Commit — record latest write transaction for each written var
+        // Commit — apply the buffered writes to the service, record the writing
+        // transaction, then propagate to dependent defs. On execution error
+        // nothing is applied, so the transaction leaves no partial writes.
+        let mut commit_error: Option<EvalError> = None;
         if exec_error.is_none() {
-            let written: Vec<String> = txn.written.iter().cloned().collect();
-            if let Some(service) = self.services.get_mut(service_name) {
-                for var in &written {
+            let writes: Vec<(String, Value)> = txn.written.iter()
+                .map(|(k, v)| (k.clone(), v.clone()))
+                .collect();
+            for (var, value) in &writes {
+                if let Some(service) = self.services.get_mut(service_name) {
                     if let Some(var_state) = service.vars.get_mut(var) {
+                        var_state.value = value.clone();
                         var_state.latest_write_txn = Some(txn.id.clone());
                     }
+                }
+            }
+            // Propagate after all writes are applied so defs see a consistent state
+            for (var, _) in &writes {
+                if let Err(e) = self.propagate(service_name, var).await {
+                    commit_error = Some(e);
+                    break;
                 }
             }
         }
@@ -504,7 +518,7 @@ impl Manager {
         // Release all locks (always, even on error)
         self.release_locks(service_name, &txn.locked, &txn.id);
 
-        match exec_error {
+        match exec_error.or(commit_error) {
             Some(e) => Err(e),
             None => Ok(()),
         }
@@ -699,6 +713,29 @@ mod tests {
         // inner write took effect
         let result = manager.lookup("x", "foo", None).await.unwrap();
         assert_eq!(result, Value::Number { val: 1 });
+        // and the lock was released
+        let lock = &manager.services.get("foo").unwrap().vars.get("x").unwrap().lock;
+        assert!(matches!(lock, crate::runtime::txn::VarLock::Unlocked));
+    }
+
+    // A transaction that fails partway must leave no partial writes: writes are
+    // buffered and applied only on a successful commit. Here the first statement
+    // writes x, the second fails (asserting false), so x must stay unchanged.
+    #[tokio::test]
+    async fn test_txn_failed_transaction_leaves_no_partial_writes() {
+        let mut manager = manager_with_x().await;
+        let stmts = vec![
+            ActionStmt::Assign {
+                var: "x".to_string(),
+                expr: Expr::Literal { val: Value::Number { val: 99 } },
+            },
+            ActionStmt::Assert(Expr::Literal { val: Value::Bool { val: false } }),
+        ];
+        let result = manager.execute_action("foo", &stmts).await;
+        assert!(result.is_err());
+        // x must remain 0 — the buffered write to 99 was never committed
+        let x = manager.lookup("x", "foo", None).await.unwrap();
+        assert_eq!(x, Value::Number { val: 0 });
         // and the lock was released
         let lock = &manager.services.get("foo").unwrap().vars.get("x").unwrap().lock;
         assert!(matches!(lock, crate::runtime::txn::VarLock::Unlocked));

--- a/meerkat-lib/src/runtime/manager/mod.rs
+++ b/meerkat-lib/src/runtime/manager/mod.rs
@@ -24,6 +24,14 @@ pub struct Manager {
     pub network: Option<NetworkActor>,
     /// Pending reply channels keyed by request_id
     pub pending_replies: HashMap<u64, oneshot::Sender<MeerkatMessage>>,
+    /// Active transaction ID (set during execute_action_with_txn)
+    current_txn: Option<TxnId>,
+    /// Variables locked by the current transaction
+    txn_locked: HashSet<String>,
+    /// Cached read values for the current transaction (avoids re-fetching)
+    txn_read_cache: HashMap<String, Value>,
+    /// Variables written by the current transaction (for commit phase)
+    txn_written: HashSet<String>,
 }
 
 impl Manager {
@@ -33,6 +41,10 @@ impl Manager {
             remote_services: HashMap::new(),
             network: None,
             pending_replies: HashMap::new(),
+            current_txn: None,
+            txn_locked: HashSet::new(),
+            txn_read_cache: HashMap::new(),
+            txn_written: HashSet::new(),
         }
     }
 
@@ -93,16 +105,48 @@ impl Manager {
             return eval(&expr, &env, &mut EvalContext { manager: self, service_name }).await;
         }
 
-        // Otherwise return stored var value
+        // Local var read. If inside a transaction, return cached value if present,
+        // otherwise acquire a read lock lazily and cache the value.
+        if self.current_txn.is_some() {
+            if let Some(cached) = self.txn_read_cache.get(ident) {
+                return Ok(cached.clone());
+            }
+        }
+        if let Some(txn_id) = self.current_txn.clone() {
+            if !self.txn_locked.contains(ident) {
+                self.acquire_read_lock(service_name, ident, &txn_id)?;
+                self.txn_locked.insert(ident.to_string());
+            }
+        }
+
+        // Return stored var value (and cache it for the transaction)
         if let Some(service) = self.services.get(service_name) {
             if let Some(var_state) = service.vars.get(ident) {
-                return Ok(var_state.value.clone());
+                let value = var_state.value.clone();
+                if self.current_txn.is_some() {
+                    self.txn_read_cache.insert(ident.to_string(), value.clone());
+                }
+                return Ok(value);
             }
         }
         Err(EvalError::LookupError(format!("Variable '{}' not found in service '{}'", ident, service_name)))
     }
 
     pub async fn assign(&mut self, service_name: &str, var: &str, value: Value) -> Result<(), EvalError> {
+        // If inside a transaction, acquire a write lock lazily. If we already hold
+        // a read lock on this var (read-then-write, e.g. x = x + 1), upgrade it.
+        if let Some(txn_id) = self.current_txn.clone() {
+            if self.txn_locked.contains(var) {
+                self.upgrade_to_write_lock(service_name, var, &txn_id)?;
+            } else {
+                self.acquire_write_lock(service_name, var, &txn_id)?;
+                self.txn_locked.insert(var.to_string());
+            }
+            self.txn_written.insert(var.to_string());
+            // Writing invalidates any cached read of this var
+            self.txn_read_cache.remove(var);
+        }
+
         // update the var
         if let Some(service) = self.services.get_mut(service_name) {
             if let Some(var_state) = service.vars.get_mut(var) {
@@ -378,6 +422,22 @@ impl Manager {
         }
     }
 
+    /// Upgrade a read lock to a write lock on a service variable.
+    /// Used for read-then-write within the same transaction (e.g. x = x + 1).
+    fn upgrade_to_write_lock(&mut self, service_name: &str, var: &str, txn_id: &TxnId) -> Result<(), EvalError> {
+        let service = self.services.get_mut(service_name)
+            .ok_or_else(|| EvalError::LookupError(format!("Service '{}' not found", service_name)))?;
+        let var_state = service.vars.get_mut(var)
+            .ok_or_else(|| EvalError::LookupError(format!("Variable '{}' not found", var)))?;
+        if var_state.lock.upgrade_to_write(txn_id) {
+            Ok(())
+        } else {
+            Err(EvalError::LockConflict(format!(
+                "Variable '{}' cannot be upgraded to a write lock; held by another transaction", var
+            )))
+        }
+    }
+
     /// Release all locks held by txn_id on the given variables.
     fn release_locks(&mut self, service_name: &str, vars: &HashSet<String>, txn_id: &TxnId) {
         if let Some(service) = self.services.get_mut(service_name) {
@@ -389,12 +449,17 @@ impl Manager {
         }
     }
 
-    /// Execute action statements as a transaction using 2-phase locking:
+    /// Execute action statements as a transaction with lazy lock acquisition:
     ///
-    /// Phase 1 — acquire all locks upfront before executing anything.
-    /// Phase 2 — execute the statements.
-    /// Phase 3 — commit: record latest_write_txn for each written variable.
-    /// Phase 4 — release all locks (always, even on error).
+    /// Locks are acquired on demand as each variable is first read or written
+    /// during execution (inside `lookup` and `assign`), rather than upfront.
+    /// This handles actions invoked via function calls and conditional branches,
+    /// where the set of accessed variables can't be determined statically.
+    /// Read values are cached in the transaction to avoid re-fetching (which
+    /// also avoids redundant network round-trips for remote reads).
+    ///
+    /// On completion: commit records latest_write_txn for written variables,
+    /// then all locks are released (always, even on error).
     ///
     /// Deadlock prevention (wait-die) is deferred to a follow-up issue.
     /// If a lock cannot be acquired, the transaction fails immediately.
@@ -406,48 +471,14 @@ impl Manager {
     ) -> Result<(), EvalError> {
         let txn_id = TxnId::new();
 
-        // Collect service variable names for this service
-        let service_vars: HashSet<String> = self.services.get(service_name)
-            .map(|s| s.vars.keys().cloned().collect())
-            .unwrap_or_default();
+        // Set up transaction context — locks acquired lazily during execution
+        self.current_txn = Some(txn_id.clone());
+        self.txn_locked.clear();
+        self.txn_read_cache.clear();
+        self.txn_written.clear();
 
-        // Write vars: Assign targets that are service vars
-        // TODO: also include ActionStmt::Insert targets once Insert is implemented
-        let write_vars: HashSet<String> = stmts.iter()
-            .filter_map(|stmt| match stmt {
-                ActionStmt::Assign { var, .. } if service_vars.contains(var) => Some(var.clone()),
-                _ => None,
-            })
-            .collect();
-
-        // Read vars: free vars in all expressions that are service vars, excluding write vars
-        // (write lock already covers the read for that variable)
-        let action_expr = crate::runtime::ast::Expr::Action(stmts.to_vec());
-        let read_vars: HashSet<String> = action_expr
-            .free_var(&HashSet::new(), &HashSet::new())
-            .into_iter()
-            .filter(|v| service_vars.contains(v) && !write_vars.contains(v))
-            .collect();
-
-        // Phase 1: Acquire all locks before executing anything
-        let mut locked: HashSet<String> = HashSet::new();
-
-        for var in &write_vars {
-            if let Err(e) = self.acquire_write_lock(service_name, var, &txn_id) {
-                self.release_locks(service_name, &locked, &txn_id);
-                return Err(e);
-            }
-            locked.insert(var.clone());
-        }
-        for var in &read_vars {
-            if let Err(e) = self.acquire_read_lock(service_name, var, &txn_id) {
-                self.release_locks(service_name, &locked, &txn_id);
-                return Err(e);
-            }
-            locked.insert(var.clone());
-        }
-
-        // Phase 2: Execute statements
+        // Execute statements; read/write locks are acquired lazily inside
+        // lookup/assign as variables are accessed
         let mut env: Vec<(String, Value)> = initial_env.to_vec();
         let mut exec_error: Option<EvalError> = None;
         for stmt in stmts {
@@ -458,10 +489,11 @@ impl Manager {
             }
         }
 
-        // Phase 3: Commit — record latest write transaction for each written var
+        // Commit — record latest write transaction for each written var
         if exec_error.is_none() {
+            let written: Vec<String> = self.txn_written.iter().cloned().collect();
             if let Some(service) = self.services.get_mut(service_name) {
-                for var in &write_vars {
+                for var in &written {
                     if let Some(var_state) = service.vars.get_mut(var) {
                         var_state.latest_write_txn = Some(txn_id.clone());
                     }
@@ -469,8 +501,12 @@ impl Manager {
             }
         }
 
-        // Phase 4: Release all locks (always, even on error)
+        // Release all locks (always, even on error) and clear transaction context
+        let locked = std::mem::take(&mut self.txn_locked);
         self.release_locks(service_name, &locked, &txn_id);
+        self.current_txn = None;
+        self.txn_read_cache.clear();
+        self.txn_written.clear();
 
         match exec_error {
             Some(e) => Err(e),
@@ -572,5 +608,76 @@ mod tests {
         manager.assign("foo", "x", Value::Number { val: 5 }).await.unwrap();
         let result = manager.lookup("f", "foo").await.unwrap();
         assert_eq!(result, Value::Number { val: 15 });
+    }
+
+    // Helper: service with a single var x = 0
+    async fn manager_with_x() -> Manager {
+        let mut manager = Manager::new();
+        let decls = vec![
+            Decl::VarDecl {
+                name: "x".to_string(),
+                val: Expr::Literal { val: Value::Number { val: 0 } },
+            },
+        ];
+        manager.create_service("foo".to_string(), decls).await.unwrap();
+        manager
+    }
+
+    // x = x + 1 reads x (read lock) then writes x (must upgrade to write lock).
+    // This is the read-then-write pattern that the old upfront analysis mishandled.
+    #[tokio::test]
+    async fn test_txn_read_then_write_upgrades_lock() {
+        let mut manager = manager_with_x().await;
+        let stmts = vec![
+            ActionStmt::Assign {
+                var: "x".to_string(),
+                expr: Expr::Binop {
+                    op: crate::ast::BinOp::Add,
+                    expr1: Box::new(Expr::Variable { ident: "x".to_string() }),
+                    expr2: Box::new(Expr::Literal { val: Value::Number { val: 1 } }),
+                },
+            },
+        ];
+        manager.execute_action("foo", &stmts).await.unwrap();
+        let result = manager.lookup("x", "foo").await.unwrap();
+        assert_eq!(result, Value::Number { val: 1 });
+    }
+
+    // Locks must be released after a transaction, so a second transaction
+    // can acquire them. Running x = x + 1 twice should yield x == 2.
+    #[tokio::test]
+    async fn test_txn_locks_released_between_transactions() {
+        let mut manager = manager_with_x().await;
+        let stmts = vec![
+            ActionStmt::Assign {
+                var: "x".to_string(),
+                expr: Expr::Binop {
+                    op: crate::ast::BinOp::Add,
+                    expr1: Box::new(Expr::Variable { ident: "x".to_string() }),
+                    expr2: Box::new(Expr::Literal { val: Value::Number { val: 1 } }),
+                },
+            },
+        ];
+        manager.execute_action("foo", &stmts).await.unwrap();
+        manager.execute_action("foo", &stmts).await.unwrap();
+        let result = manager.lookup("x", "foo").await.unwrap();
+        assert_eq!(result, Value::Number { val: 2 });
+    }
+
+    // After a transaction completes, the variable's lock should be Unlocked.
+    #[tokio::test]
+    async fn test_txn_var_unlocked_after_commit() {
+        let mut manager = manager_with_x().await;
+        let stmts = vec![
+            ActionStmt::Assign {
+                var: "x".to_string(),
+                expr: Expr::Literal { val: Value::Number { val: 42 } },
+            },
+        ];
+        manager.execute_action("foo", &stmts).await.unwrap();
+        let lock = &manager.services.get("foo").unwrap().vars.get("x").unwrap().lock;
+        assert!(matches!(lock, crate::runtime::txn::VarLock::Unlocked));
+        assert!(manager.current_txn.is_none());
+        assert!(manager.txn_locked.is_empty());
     }
 }

--- a/meerkat-lib/src/runtime/manager/mod.rs
+++ b/meerkat-lib/src/runtime/manager/mod.rs
@@ -1,5 +1,5 @@
 use std::collections::{HashMap, HashSet};
-use crate::runtime::txn::{TxnId, VarState};
+use crate::runtime::txn::{TxnId, VarState, Transaction};
 use tokio::sync::oneshot;
 use tokio::time::Duration;
 use super::ast::{Value, Decl, Expr, ActionStmt};
@@ -24,14 +24,6 @@ pub struct Manager {
     pub network: Option<NetworkActor>,
     /// Pending reply channels keyed by request_id
     pub pending_replies: HashMap<u64, oneshot::Sender<MeerkatMessage>>,
-    /// Active transaction ID (set during execute_action_with_txn)
-    current_txn: Option<TxnId>,
-    /// Variables locked by the current transaction
-    txn_locked: HashSet<String>,
-    /// Cached read values for the current transaction (avoids re-fetching)
-    txn_read_cache: HashMap<String, Value>,
-    /// Variables written by the current transaction (for commit phase)
-    txn_written: HashSet<String>,
 }
 
 impl Manager {
@@ -41,10 +33,6 @@ impl Manager {
             remote_services: HashMap::new(),
             network: None,
             pending_replies: HashMap::new(),
-            current_txn: None,
-            txn_locked: HashSet::new(),
-            txn_read_cache: HashMap::new(),
-            txn_written: HashSet::new(),
         }
     }
 
@@ -66,12 +54,12 @@ impl Manager {
         for decl in decls {
             match decl {
                 Decl::VarDecl { name, val } => {
-                    let value = eval(&val, &env, &mut EvalContext { manager: self, service_name: &svc_name }).await?;
+                    let value = eval(&val, &env, &mut EvalContext { manager: self, service_name: &svc_name, txn: None }).await?;
                     env.push((name.clone(), value.clone()));
                     service.vars.insert(name, VarState::new(value));
                 }
                 Decl::DefDecl { name, val, .. } => {
-                    let value = eval(&val, &env, &mut EvalContext { manager: self, service_name: &svc_name }).await?;
+                    let value = eval(&val, &env, &mut EvalContext { manager: self, service_name: &svc_name, txn: None }).await?;
                     env.push((name.clone(), value.clone()));
                     service.vars.insert(name.clone(), VarState::new(value));
                     service.defs.insert(name, val);  // store original expr
@@ -86,13 +74,14 @@ impl Manager {
         Ok(())
     }
 
-    pub async fn lookup(&mut self, ident: &str, service_name: &str) -> Result<Value, EvalError> {
+    pub async fn lookup(&mut self, ident: &str, service_name: &str, mut txn: Option<&mut Transaction>) -> Result<Value, EvalError> {
         // Check if service is remote
         if self.remote_services.contains_key(service_name) {
             return self.remote_lookup(service_name, ident).await;
         }
 
-        // If it's a def, re-evaluate from stored expression for freshness
+        // If it's a def, re-evaluate from stored expression for freshness.
+        // The transaction flows through so the def's underlying vars are locked.
         let def_expr = self.services.get(service_name)
             .and_then(|s| s.defs.get(ident))
             .cloned();
@@ -102,20 +91,26 @@ impl Manager {
                 .get(service_name)
                 .map(|s| s.vars.iter().map(|(k, v)| (k.clone(), v.value.clone())).collect())
                 .unwrap_or_default();
-            return eval(&expr, &env, &mut EvalContext { manager: self, service_name }).await;
+            return eval(&expr, &env, &mut EvalContext { manager: self, service_name, txn: txn.as_deref_mut() }).await;
         }
 
-        // Local var read. If inside a transaction, return cached value if present,
-        // otherwise acquire a read lock lazily and cache the value.
-        if self.current_txn.is_some() {
-            if let Some(cached) = self.txn_read_cache.get(ident) {
+        // Local var read. If inside a transaction, return the cached value if
+        // present, otherwise acquire a read lock lazily and cache the value.
+        // Decide what's needed first (ending the txn borrow) before calling
+        // self.acquire_read_lock, then re-borrow txn to record the lock.
+        let mut need_read_lock: Option<TxnId> = None;
+        if let Some(t) = txn.as_deref() {
+            if let Some(cached) = t.read_cache.get(ident) {
                 return Ok(cached.clone());
             }
+            if !t.locked.contains(ident) {
+                need_read_lock = Some(t.id.clone());
+            }
         }
-        if let Some(txn_id) = self.current_txn.clone() {
-            if !self.txn_locked.contains(ident) {
-                self.acquire_read_lock(service_name, ident, &txn_id)?;
-                self.txn_locked.insert(ident.to_string());
+        if let Some(txn_id) = need_read_lock {
+            self.acquire_read_lock(service_name, ident, &txn_id)?;
+            if let Some(t) = txn.as_deref_mut() {
+                t.locked.insert(ident.to_string());
             }
         }
 
@@ -123,8 +118,8 @@ impl Manager {
         if let Some(service) = self.services.get(service_name) {
             if let Some(var_state) = service.vars.get(ident) {
                 let value = var_state.value.clone();
-                if self.current_txn.is_some() {
-                    self.txn_read_cache.insert(ident.to_string(), value.clone());
+                if let Some(t) = txn.as_deref_mut() {
+                    t.read_cache.insert(ident.to_string(), value.clone());
                 }
                 return Ok(value);
             }
@@ -132,19 +127,28 @@ impl Manager {
         Err(EvalError::LookupError(format!("Variable '{}' not found in service '{}'", ident, service_name)))
     }
 
-    pub async fn assign(&mut self, service_name: &str, var: &str, value: Value) -> Result<(), EvalError> {
+    pub async fn assign(&mut self, service_name: &str, var: &str, value: Value, mut txn: Option<&mut Transaction>) -> Result<(), EvalError> {
         // If inside a transaction, acquire a write lock lazily. If we already hold
         // a read lock on this var (read-then-write, e.g. x = x + 1), upgrade it.
-        if let Some(txn_id) = self.current_txn.clone() {
-            if self.txn_locked.contains(var) {
-                self.upgrade_to_write_lock(service_name, var, &txn_id)?;
-            } else {
-                self.acquire_write_lock(service_name, var, &txn_id)?;
-                self.txn_locked.insert(var.to_string());
+        // Decide which lock action is needed first (ending the txn borrow), then
+        // call into self, then re-borrow txn to record the write.
+        enum LockAction { Acquire, Upgrade }
+        let mut action: Option<(TxnId, LockAction)> = None;
+        if let Some(t) = txn.as_deref() {
+            let kind = if t.locked.contains(var) { LockAction::Upgrade } else { LockAction::Acquire };
+            action = Some((t.id.clone(), kind));
+        }
+        if let Some((txn_id, kind)) = action {
+            match kind {
+                LockAction::Upgrade => self.upgrade_to_write_lock(service_name, var, &txn_id)?,
+                LockAction::Acquire => self.acquire_write_lock(service_name, var, &txn_id)?,
             }
-            self.txn_written.insert(var.to_string());
-            // Writing invalidates any cached read of this var
-            self.txn_read_cache.remove(var);
+            if let Some(t) = txn.as_deref_mut() {
+                t.locked.insert(var.to_string());
+                t.written.insert(var.to_string());
+                // Writing updates the cached value rather than invalidating it
+                t.read_cache.insert(var.to_string(), value.clone());
+            }
         }
 
         // update the var
@@ -194,7 +198,7 @@ impl Manager {
                         .map(|s| s.vars.iter().map(|(k, v)| (k.clone(), v.value.clone())).collect())
                         .unwrap_or_default();
 
-                    let value = eval(&expr, &env, &mut EvalContext { manager: self, service_name }).await?;
+                    let value = eval(&expr, &env, &mut EvalContext { manager: self, service_name, txn: None }).await?;
 
                     if let Some(service) = self.services.get_mut(service_name) {
                         if let Some(var_state) = service.vars.get_mut(&def_name) {
@@ -469,20 +473,16 @@ impl Manager {
         stmts: &[ActionStmt],
         initial_env: &[(String, Value)],
     ) -> Result<(), EvalError> {
-        let txn_id = TxnId::new();
-
-        // Set up transaction context — locks acquired lazily during execution
-        self.current_txn = Some(txn_id.clone());
-        self.txn_locked.clear();
-        self.txn_read_cache.clear();
-        self.txn_written.clear();
+        // The transaction owns all its state and is passed down through
+        // execution; nothing transaction-specific lives on the Manager.
+        let mut txn = Transaction::new(TxnId::new());
 
         // Execute statements; read/write locks are acquired lazily inside
         // lookup/assign as variables are accessed
         let mut env: Vec<(String, Value)> = initial_env.to_vec();
         let mut exec_error: Option<EvalError> = None;
         for stmt in stmts {
-            match execute(stmt, &env, self, service_name).await {
+            match execute(stmt, &env, self, service_name, Some(&mut txn)).await {
                 Ok(ExecuteEffect::Binding(name, val)) => env.push((name, val)),
                 Ok(_) => {}
                 Err(e) => { exec_error = Some(e); break; }
@@ -491,22 +491,18 @@ impl Manager {
 
         // Commit — record latest write transaction for each written var
         if exec_error.is_none() {
-            let written: Vec<String> = self.txn_written.iter().cloned().collect();
+            let written: Vec<String> = txn.written.iter().cloned().collect();
             if let Some(service) = self.services.get_mut(service_name) {
                 for var in &written {
                     if let Some(var_state) = service.vars.get_mut(var) {
-                        var_state.latest_write_txn = Some(txn_id.clone());
+                        var_state.latest_write_txn = Some(txn.id.clone());
                     }
                 }
             }
         }
 
-        // Release all locks (always, even on error) and clear transaction context
-        let locked = std::mem::take(&mut self.txn_locked);
-        self.release_locks(service_name, &locked, &txn_id);
-        self.current_txn = None;
-        self.txn_read_cache.clear();
-        self.txn_written.clear();
+        // Release all locks (always, even on error)
+        self.release_locks(service_name, &txn.locked, &txn.id);
 
         match exec_error {
             Some(e) => Err(e),
@@ -544,7 +540,7 @@ mod tests {
             },
         ];
         manager.create_service("foo".to_string(), decls).await.unwrap();
-        let result = manager.lookup("x", "foo").await.unwrap();
+        let result = manager.lookup("x", "foo", None).await.unwrap();
         assert_eq!(result, Value::Number { val: 1 });
     }
 
@@ -567,7 +563,7 @@ mod tests {
             },
         ];
         manager.create_service("foo".to_string(), decls).await.unwrap();
-        let result = manager.lookup("f", "foo").await.unwrap();
+        let result = manager.lookup("f", "foo", None).await.unwrap();
         assert_eq!(result, Value::Number { val: 5 });
     }
 
@@ -575,7 +571,7 @@ mod tests {
     async fn test_lookup_missing_var_returns_error() {
         let mut manager = Manager::new();
         manager.create_service("foo".to_string(), vec![]).await.unwrap();
-        let result = manager.lookup("nonexistent", "foo").await;
+        let result = manager.lookup("nonexistent", "foo", None).await;
         assert!(result.is_err());
     }
 
@@ -601,12 +597,12 @@ mod tests {
         manager.create_service("foo".to_string(), decls).await.unwrap();
 
         // f should be 11 initially
-        let result = manager.lookup("f", "foo").await.unwrap();
+        let result = manager.lookup("f", "foo", None).await.unwrap();
         assert_eq!(result, Value::Number { val: 11 });
 
         // update x to 5, f should become 15
-        manager.assign("foo", "x", Value::Number { val: 5 }).await.unwrap();
-        let result = manager.lookup("f", "foo").await.unwrap();
+        manager.assign("foo", "x", Value::Number { val: 5 }, None).await.unwrap();
+        let result = manager.lookup("f", "foo", None).await.unwrap();
         assert_eq!(result, Value::Number { val: 15 });
     }
 
@@ -639,7 +635,7 @@ mod tests {
             },
         ];
         manager.execute_action("foo", &stmts).await.unwrap();
-        let result = manager.lookup("x", "foo").await.unwrap();
+        let result = manager.lookup("x", "foo", None).await.unwrap();
         assert_eq!(result, Value::Number { val: 1 });
     }
 
@@ -660,7 +656,7 @@ mod tests {
         ];
         manager.execute_action("foo", &stmts).await.unwrap();
         manager.execute_action("foo", &stmts).await.unwrap();
-        let result = manager.lookup("x", "foo").await.unwrap();
+        let result = manager.lookup("x", "foo", None).await.unwrap();
         assert_eq!(result, Value::Number { val: 2 });
     }
 
@@ -677,7 +673,34 @@ mod tests {
         manager.execute_action("foo", &stmts).await.unwrap();
         let lock = &manager.services.get("foo").unwrap().vars.get("x").unwrap().lock;
         assert!(matches!(lock, crate::runtime::txn::VarLock::Unlocked));
-        assert!(manager.current_txn.is_none());
-        assert!(manager.txn_locked.is_empty());
+    }
+
+    // A nested `do` (an action invoking another action) must reuse the same
+    // transaction, not start a fresh one. The inner write to x should commit and
+    // all locks should be released afterward. This guards the bug where nested
+    // execution clobbered the outer transaction's lock tracking.
+    #[tokio::test]
+    async fn test_txn_nested_do_reuses_transaction() {
+        let mut manager = manager_with_x().await;
+        // outer action: do (action { x = x + 1; });
+        let inner = Expr::Action(vec![
+            ActionStmt::Assign {
+                var: "x".to_string(),
+                expr: Expr::Binop {
+                    op: crate::ast::BinOp::Add,
+                    expr1: Box::new(Expr::Variable { ident: "x".to_string() }),
+                    expr2: Box::new(Expr::Literal { val: Value::Number { val: 1 } }),
+                },
+            },
+        ]);
+        let stmts = vec![ActionStmt::Do(inner)];
+        manager.execute_action("foo", &stmts).await.unwrap();
+
+        // inner write took effect
+        let result = manager.lookup("x", "foo", None).await.unwrap();
+        assert_eq!(result, Value::Number { val: 1 });
+        // and the lock was released
+        let lock = &manager.services.get("foo").unwrap().vars.get("x").unwrap().lock;
+        assert!(matches!(lock, crate::runtime::txn::VarLock::Unlocked));
     }
 }

--- a/meerkat-lib/src/runtime/txn.rs
+++ b/meerkat-lib/src/runtime/txn.rs
@@ -3,8 +3,9 @@
 //! Simplified implementation for issue #19. The existing transaction.rs
 //! and lock.rs provide the full actor-based infrastructure for future use.
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::time::SystemTime;
+use crate::runtime::ast::Value;
 
 /// A globally unique transaction identifier.
 /// Older timestamp = higher priority (for future wait-die implementation).
@@ -152,6 +153,34 @@ impl VarState {
             value,
             lock: VarLock::new(),
             latest_write_txn: None,
+        }
+    }
+}
+
+/// Per-transaction state, owned by the code executing a transaction and passed
+/// around during execution rather than stored on the Manager. A single Manager
+/// may eventually run multiple transactions concurrently, so transaction state
+/// must not live on the Manager.
+#[derive(Debug)]
+pub struct Transaction {
+    /// Globally unique transaction identifier.
+    pub id: TxnId,
+    /// Variables this transaction currently holds a lock on.
+    pub locked: HashSet<String>,
+    /// Values already read in this transaction (avoids re-fetching, including
+    /// redundant network round-trips for remote reads).
+    pub read_cache: HashMap<String, Value>,
+    /// Variables written by this transaction (recorded at commit).
+    pub written: HashSet<String>,
+}
+
+impl Transaction {
+    pub fn new(id: TxnId) -> Self {
+        Transaction {
+            id,
+            locked: HashSet::new(),
+            read_cache: HashMap::new(),
+            written: HashSet::new(),
         }
     }
 }

--- a/meerkat-lib/src/runtime/txn.rs
+++ b/meerkat-lib/src/runtime/txn.rs
@@ -110,6 +110,20 @@ impl VarLock {
         }
     }
 
+    /// Upgrade a read lock held solely by txn_id to a write lock.
+    /// Needed for read-then-write patterns (e.g. x = x + 1).
+    /// Returns true if upgrade succeeded or var is already write-locked by txn_id.
+    pub fn upgrade_to_write(&mut self, txn_id: &TxnId) -> bool {
+        match self {
+            VarLock::ReadLocked(set) if set.len() == 1 && set.contains(txn_id) => {
+                *self = VarLock::WriteLocked(txn_id.clone());
+                true
+            }
+            VarLock::WriteLocked(tid) if tid == txn_id => true,
+            _ => false,
+        }
+    }
+
     /// Release any lock (read or write) held by txn_id.
     pub fn release(&mut self, txn_id: &TxnId) {
         match self {

--- a/meerkat-lib/src/runtime/txn.rs
+++ b/meerkat-lib/src/runtime/txn.rs
@@ -170,8 +170,10 @@ pub struct Transaction {
     /// Values already read in this transaction (avoids re-fetching, including
     /// redundant network round-trips for remote reads).
     pub read_cache: HashMap<String, Value>,
-    /// Variables written by this transaction (recorded at commit).
-    pub written: HashSet<String>,
+    /// Values written by this transaction, buffered and applied to the
+    /// service only on successful commit (so a failed transaction leaves no
+    /// partial writes).
+    pub written: HashMap<String, Value>,
 }
 
 impl Transaction {
@@ -180,7 +182,7 @@ impl Transaction {
             id,
             locked: HashSet::new(),
             read_cache: HashMap::new(),
-            written: HashSet::new(),
+            written: HashMap::new(),
         }
     }
 }

--- a/meerkat/src/main.rs
+++ b/meerkat/src/main.rs
@@ -133,7 +133,7 @@ async fn run_server(prog: Vec<Stmt>, remote_url_map: std::collections::HashMap<S
                 NetworkEvent::MessageReceived { peer: _, msg } => {
                     match msg {
                         MeerkatMessage::LookupRequest { request_id, service, member, reply_to } => {
-                            let result = manager.lookup(&member, &service).await;
+                            let result = manager.lookup(&member, &service, None).await;
                             let response = match result {
                                 Ok(val) => MeerkatMessage::LookupResponse {
                                     request_id,

--- a/meerkat/src/repl.rs
+++ b/meerkat/src/repl.rs
@@ -22,7 +22,7 @@ async fn check_watches(watches: &mut Vec<Watch>, manager: &mut Manager, repl_env
         let result = eval(
             &w.expr,
             repl_env,
-            &mut EvalContext { manager, service_name: "" },
+            &mut EvalContext { manager, service_name: "", txn: None },
         ).await;
         match result {
             Ok(new_val) => {
@@ -167,7 +167,7 @@ async fn exec_stmt(
             Ok(Some(format!("Imported service(s): {}.", loaded.join(", "))))
         }
         Stmt::ActionStmt(action_stmt) => {
-            let effect = execute(&action_stmt, repl_env, manager, "")
+            let effect = execute(&action_stmt, repl_env, manager, "", None)
                 .await
                 .map_err(|e| format!("{}", e))?;
             match effect {
@@ -185,7 +185,7 @@ async fn exec_stmt(
             let initial = eval(
                 &expr,
                 repl_env,
-                &mut EvalContext { manager, service_name: "" },
+                &mut EvalContext { manager, service_name: "", txn: None },
             ).await.ok();
             let msg = match &initial {
                 Some(v) => format!("Watching: {} (current value: {})", label, v),


### PR DESCRIPTION
Replaces the upfront static analysis of free variables with lazy lock acquisition during execution.

**Why:** The old approach acquired locks for every free variable in an action upfront. This breaks when an action invokes another action returned by a function (those variables aren't free in the original action), and it would lock variables in untaken `if` branches that are never actually accessed.

**How:**
- Locks are now acquired on demand inside `lookup` (read lock) and `assign` (write lock) as each variable is first accessed.
- Added `VarLock::upgrade_to_write` and `Manager::upgrade_to_write_lock` to handle the read-then-write pattern (e.g. `x = x + 1` reads then writes the same var).
- Read values are cached in the transaction so a variable isn't fetched twice — this also avoids redundant network round-trips for remote reads, as suggested in the issue.
- `execute_action_with_txn` now just sets up the transaction context, executes, commits written vars, and releases all locks (still always released, even on error).

**Tested:**
- All existing unit and integration tests pass.
- Added 3 unit tests: read-then-write lock upgrade, locks released between sequential transactions, and lock/context cleanup after commit.
- `test_two.mkt` passes — this exercises `do inc_delegate(1)` where the action is returned by a function, the exact case the old upfront analysis mishandled.

Note: Lock tracking and the read cache are currently keyed by variable name, which works for the single-service transaction scope we have today. Multi-service transactions would need a composite (service, var) key — we've deferred that for now, consistent with the single-service limitation noted in #19. 