### PR TITLE
Fix transitive remote lookup bug (Issue #40)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ target
 
 #!src/utils/debug/ 
 
+# Temporary folders
+tmp/

--- a/meerkat-lib/src/runtime/interpreter/evaluator.rs
+++ b/meerkat-lib/src/runtime/interpreter/evaluator.rs
@@ -68,7 +68,7 @@ pub async fn eval(
                     return Ok(var_val.clone());
                 }
             }
-            ctx.manager.lookup(ident, ctx.service_name).await
+            ctx.manager.lookup(ident, ctx.service_name, "").await
         }
 
         Expr::Binop { op, expr1, expr2 } => {
@@ -149,7 +149,7 @@ pub async fn eval(
 
         Expr::MemberAccess { service, member } => {
             // Manager figures out whether service is local or remote
-            ctx.manager.lookup(member, service).await
+            ctx.manager.lookup(member, service, ctx.service_name).await
         }
         _ => Err(EvalError::NotImplemented),
     }

--- a/meerkat-lib/src/runtime/manager/mod.rs
+++ b/meerkat-lib/src/runtime/manager/mod.rs
@@ -24,8 +24,6 @@ pub struct Manager {
     pub network: Option<NetworkActor>,
     /// Pending reply channels keyed by request_id
     pub pending_replies: HashMap<u64, oneshot::Sender<MeerkatMessage>>,
-    /// Used to enumerate hidden bindings in proxy closures.
-    pub next_proxy_id: u64,
 }
 
 impl Manager {
@@ -35,7 +33,6 @@ impl Manager {
             remote_services: HashMap::new(),
             network: None,
             pending_replies: HashMap::new(),
-            next_proxy_id: 1,
         }
     }
 
@@ -59,6 +56,7 @@ impl Manager {
             match decl {
                 Decl::VarDecl { name: var_name, val } => {
                     let value = eval(&val, &env, &mut EvalContext { manager: self, service_name: &svc_name }).await?;
+                    let value = wrap_value(value, &svc_name);
                     env.push((var_name.clone(), value.clone()));
                     if let Some(s) = self.services.get_mut(&svc_name) {
                         s.vars.insert(var_name, VarState::new(value));
@@ -66,6 +64,7 @@ impl Manager {
                 }
                 Decl::DefDecl { name: def_name, val, .. } => {
                     let value = eval(&val, &env, &mut EvalContext { manager: self, service_name: &svc_name }).await?;
+                    let value = wrap_value(value, &svc_name);
                     env.push((def_name.clone(), value.clone()));
                     if let Some(s) = self.services.get_mut(&svc_name) {
                         s.vars.insert(def_name.clone(), VarState::new(value));
@@ -102,7 +101,8 @@ impl Manager {
                 .get(service_name)
                 .map(|s| s.vars.iter().map(|(k, v)| (k.clone(), v.value.clone())).collect())
                 .unwrap_or_default();
-            return eval(&expr, &env, &mut EvalContext { manager: self, service_name }).await;
+            let value = eval(&expr, &env, &mut EvalContext { manager: self, service_name }).await?;
+            return Ok(wrap_value(value, service_name));
         }
 
         // Otherwise return stored var value
@@ -138,63 +138,12 @@ impl Manager {
             MeerkatMessage::LookupResponse { value, .. } => {
                 let val: Value = serde_json::from_str(&value)
                     .map_err(|e| EvalError::NetworkError(e.to_string()))?;
-                Ok(val)
+                Ok(wrap_value(val, target_node))
             }
             MeerkatMessage::LookupError { error, .. } => {
                 Err(EvalError::LookupError(error))
             }
             _ => Err(EvalError::NetworkError("Unexpected reply to lookup request".to_string())),
-        }
-    }
-
-    pub fn wrap_value(&mut self, value: Value, current_service: &str) -> Value {
-        let is_remote = match &value {
-            Value::ActionClosure { service_name, .. } | Value::Closure { service_name, .. } => {
-                service_name != current_service
-            }
-            _ => false,
-        };
-
-        if !is_remote {
-            return value;
-        }
-
-        let var_name = format!("$x{}", self.next_proxy_id);
-        self.next_proxy_id += 1;
-
-        match value {
-            Value::ActionClosure { stmts, env, service_name } => {
-                let original_action = Value::ActionClosure { stmts, env, service_name };
-                if let Some(service) = self.services.get_mut(current_service) {
-                    service.vars.insert(var_name.clone(), crate::runtime::txn::VarState::new(original_action));
-                }
-                Value::ActionClosure {
-                    stmts: vec![ActionStmt::Do(Expr::Variable { ident: var_name.clone() })],
-                    env: vec![],
-                    service_name: current_service.to_string(),
-                }
-            }
-            Value::Closure { params, body, env, service_name } => {
-                let original_closure = Value::Closure {
-                    params: params.clone(),
-                    body: body.clone(),
-                    env: env.clone(),
-                    service_name,
-                };
-                if let Some(service) = self.services.get_mut(current_service) {
-                    service.vars.insert(var_name.clone(), crate::runtime::txn::VarState::new(original_closure));
-                }
-                Value::Closure {
-                    params: params.clone(),
-                    body: Box::new(Expr::Call {
-                        func: Box::new(Expr::Variable { ident: var_name.clone() }),
-                        args: params.iter().map(|p| Expr::Variable { ident: p.clone() }).collect(),
-                    }),
-                    env: vec![],
-                    service_name: current_service.to_string(),
-                }
-            }
-            other => other,
         }
     }
 
@@ -247,6 +196,7 @@ impl Manager {
                         .unwrap_or_default();
 
                     let value = eval(&expr, &env, &mut EvalContext { manager: self, service_name }).await?;
+                    let value = wrap_value(value, service_name);
 
                     if let Some(service) = self.services.get_mut(service_name) {
                         if let Some(var_state) = service.vars.get_mut(&def_name) {
@@ -671,5 +621,139 @@ mod tests {
         manager.assign("foo", "x", Value::Number { val: 5 }).await.unwrap();
         let result = manager.lookup("f", "foo", "").await.unwrap();
         assert_eq!(result, Value::Number { val: 15 });
+    }
+
+    /// Verify that `propagate` wraps remote closures after re-evaluation.
+    ///
+    /// Setup: service "origin" has `var x` and `pub def act = action { x = x + 1; }`.
+    ///        service "gateway" has `var flag = 0` and
+    ///        `def delegated = if flag == 1 then origin.act else action {}`.
+    ///
+    /// When flag is changed to 1, `propagate` re-evaluates `delegated`.
+    /// The resulting ActionClosure must be wrapped so its service_name is
+    /// "gateway", not "origin".
+    #[tokio::test]
+    async fn test_propagate_wraps_remote_closure() {
+        let mut manager = Manager::new();
+
+        // -- origin service: var x = 0; pub def act = action { x = x + 1; };
+        let origin_decls = vec![
+            Decl::VarDecl {
+                name: "x".to_string(),
+                val: Expr::Literal { val: Value::Number { val: 0 } },
+            },
+            Decl::DefDecl {
+                name: "act".to_string(),
+                val: Expr::Action(vec![
+                    ActionStmt::Assign {
+                        var: "x".to_string(),
+                        expr: Expr::Binop {
+                            op: crate::ast::BinOp::Add,
+                            expr1: Box::new(Expr::Variable { ident: "x".to_string() }),
+                            expr2: Box::new(Expr::Literal { val: Value::Number { val: 1 } }),
+                        },
+                    },
+                ]),
+                is_pub: true,
+            },
+        ];
+        manager.create_service("origin".to_string(), origin_decls).await.unwrap();
+
+        // -- gateway service: var flag = 0; def delegated = if flag == 1 then <origin's act> else action {};
+        //
+        // We simulate the "remote import" by directly inserting the origin
+        // action closure as a literal in the def expression, which is what
+        // the evaluator would produce for a MemberAccess on a remote service.
+        let origin_act = manager.lookup("act", "origin", "").await.unwrap();
+
+        let gateway_decls = vec![
+            Decl::VarDecl {
+                name: "flag".to_string(),
+                val: Expr::Literal { val: Value::Number { val: 0 } },
+            },
+            Decl::DefDecl {
+                name: "delegated".to_string(),
+                val: Expr::If {
+                    cond: Box::new(Expr::Binop {
+                        op: crate::ast::BinOp::Eq,
+                        expr1: Box::new(Expr::Variable { ident: "flag".to_string() }),
+                        expr2: Box::new(Expr::Literal { val: Value::Number { val: 1 } }),
+                    }),
+                    expr1: Box::new(Expr::Literal { val: origin_act }),
+                    expr2: Box::new(Expr::Action(vec![])),
+                },
+                is_pub: true,
+            },
+        ];
+        manager.create_service("gateway".to_string(), gateway_decls).await.unwrap();
+
+        // Initially flag=0, so delegated is the empty action (local)
+        let initial = manager.lookup("delegated", "gateway", "").await.unwrap();
+        match &initial {
+            Value::ActionClosure { service_name, .. } => {
+                assert_eq!(service_name, "gateway", "empty action should be homed to gateway");
+            }
+            other => panic!("expected ActionClosure, got {:?}", other),
+        }
+
+        // Change flag to 1 — propagate re-evaluates delegated
+        manager.assign("gateway", "flag", Value::Number { val: 1 }).await.unwrap();
+
+        let updated = manager.lookup("delegated", "gateway", "").await.unwrap();
+        match &updated {
+            Value::ActionClosure { service_name, .. } => {
+                assert_eq!(
+                    service_name, "gateway",
+                    "after propagation the remote action closure must be wrapped and homed to gateway, \
+                     but got service_name='{}'", service_name
+                );
+            }
+            other => panic!("expected ActionClosure, got {:?}", other),
+        }
+    }
+}
+
+/// Wrap a remote closure/action so it is homed to `current_service`.
+/// The original value is embedded as an `Expr::Literal` inside a new
+/// closure whose `service_name` is `current_service`.
+fn wrap_value(value: Value, current_service: &str) -> Value {
+    let is_remote = match &value {
+        Value::ActionClosure { service_name, .. } | Value::Closure { service_name, .. } => {
+            service_name != current_service
+        }
+        _ => false,
+    };
+
+    if !is_remote {
+        return value;
+    }
+
+    match value {
+        Value::ActionClosure { stmts, env, service_name } => {
+            let original_action = Value::ActionClosure { stmts, env, service_name };
+            Value::ActionClosure {
+                stmts: vec![ActionStmt::Do(Expr::Literal { val: original_action })],
+                env: vec![],
+                service_name: current_service.to_string(),
+            }
+        }
+        Value::Closure { params, body, env, service_name } => {
+            let original_closure = Value::Closure {
+                params: params.clone(),
+                body: body.clone(),
+                env: env.clone(),
+                service_name,
+            };
+            Value::Closure {
+                params: params.clone(),
+                body: Box::new(Expr::Call {
+                    func: Box::new(Expr::Literal { val: original_closure }),
+                    args: params.iter().map(|p| Expr::Variable { ident: p.clone() }).collect(),
+                }),
+                env: vec![],
+                service_name: current_service.to_string(),
+            }
+        }
+        other => other,
     }
 }

--- a/meerkat-lib/src/runtime/manager/mod.rs
+++ b/meerkat-lib/src/runtime/manager/mod.rs
@@ -74,10 +74,15 @@ impl Manager {
         Ok(())
     }
 
-    pub async fn lookup(&mut self, ident: &str, service_name: &str) -> Result<Value, EvalError> {
+    pub async fn lookup(&mut self, ident: &str, service_name: &str, current_context: &str) -> Result<Value, EvalError> {
         // Check if service is remote
         if self.remote_services.contains_key(service_name) {
             return self.remote_lookup(service_name, ident).await;
+        }
+
+        // If it's an unknown service, but we are inside a closure from a remote service, proxy it!
+        if current_context != "" && current_context != service_name && self.remote_services.contains_key(current_context) {
+            return self.proxy_remote_lookup(current_context, service_name, ident).await;
         }
 
         // If it's a def, re-evaluate from stored expression for freshness
@@ -99,7 +104,96 @@ impl Manager {
                 return Ok(var_state.value.clone());
             }
         }
+        if let Some(service) = self.services.get(service_name) {
+            println!("DEBUG: Lookup failed for {} in {}. Available vars: {:?}", ident, service_name, service.vars.keys());
+        } else {
+            println!("DEBUG: Lookup failed for {} in {}. Service not found locally.", ident, service_name);
+        }
         Err(EvalError::LookupError(format!("Variable '{}' not found in service '{}'", ident, service_name)))
+    }
+
+    pub async fn proxy_remote_lookup(&mut self, target_node: &str, target_service: &str, member: &str) -> Result<Value, EvalError> {
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static NEXT_ID: AtomicU64 = AtomicU64::new(1);
+
+        let addr = self.remote_addr(target_node)?;
+        let request_id = NEXT_ID.fetch_add(1, Ordering::SeqCst);
+        let reply_to = self.local_reply_addr().await;
+
+        let msg = MeerkatMessage::LookupRequest {
+            request_id,
+            service: target_service.to_string(),
+            member: member.to_string(),
+            reply_to,
+        };
+
+        let reply = self.send_and_await_reply(
+            addr, msg, request_id,
+            format!("Timeout waiting for remote lookup of {}.{}", target_service, member),
+        ).await?;
+
+        match reply {
+            MeerkatMessage::LookupResponse { value, .. } => {
+                let val: Value = serde_json::from_str(&value)
+                    .map_err(|e| EvalError::NetworkError(e.to_string()))?;
+                Ok(val)
+            }
+            MeerkatMessage::LookupError { error, .. } => {
+                Err(EvalError::LookupError(error))
+            }
+            _ => Err(EvalError::NetworkError("Unexpected reply to lookup request".to_string())),
+        }
+    }
+
+    pub fn wrap_value(&mut self, value: Value, current_service: &str, next_id: &mut u64) -> Value {
+        let is_remote = match &value {
+            Value::ActionClosure { service_name, .. } | Value::Closure { service_name, .. } => {
+                service_name != current_service
+            }
+            _ => false,
+        };
+
+        if !is_remote {
+            return value;
+        }
+
+        let var_name = format!("$x{}", *next_id);
+        *next_id += 1;
+
+        match value {
+            Value::ActionClosure { stmts, env, service_name } => {
+                let original_action = Value::ActionClosure { stmts, env, service_name };
+                if let Some(service) = self.services.get_mut(current_service) {
+                    service.vars.insert(var_name.clone(), crate::runtime::txn::VarState::new(original_action));
+                }
+                Value::ActionClosure {
+                    stmts: vec![ActionStmt::Do(Expr::Variable { ident: var_name.clone() })],
+                    env: vec![],
+                    service_name: current_service.to_string(),
+                }
+            }
+            Value::Closure { params, body, env, service_name } => {
+                let original_closure = Value::Closure {
+                    params: params.clone(),
+                    body: body.clone(),
+                    env: env.clone(),
+                    service_name,
+                };
+                if let Some(service) = self.services.get_mut(current_service) {
+                    service.vars.insert(var_name.clone(), crate::runtime::txn::VarState::new(original_closure));
+                }
+                Value::Closure {
+                    params: params.clone(),
+                    body: Box::new(Expr::Call {
+                        func: Box::new(Expr::Variable { ident: var_name.clone() }),
+                        args: params.iter().map(|p| Expr::Variable { ident: p.clone() }).collect(),
+                    }),
+                    env: vec![],
+                    service_name: current_service.to_string(),
+                }
+            }
+            other => other,
+        }
     }
 
     pub async fn assign(&mut self, service_name: &str, var: &str, value: Value) -> Result<(), EvalError> {
@@ -271,6 +365,9 @@ impl Manager {
 
     /// Get the local machine's outbound IP address (non-loopback)
     pub fn get_public_ip() -> String {
+        if std::env::var("MEERKAT_LOCAL").is_ok() {
+            return "127.0.0.1".to_string();
+        }
         use std::net::UdpSocket;
         UdpSocket::bind("0.0.0.0:0")
             .and_then(|s| { s.connect("8.8.8.8:80")?; s.local_addr() })
@@ -508,7 +605,7 @@ mod tests {
             },
         ];
         manager.create_service("foo".to_string(), decls).await.unwrap();
-        let result = manager.lookup("x", "foo").await.unwrap();
+        let result = manager.lookup("x", "foo", "").await.unwrap();
         assert_eq!(result, Value::Number { val: 1 });
     }
 
@@ -531,7 +628,7 @@ mod tests {
             },
         ];
         manager.create_service("foo".to_string(), decls).await.unwrap();
-        let result = manager.lookup("f", "foo").await.unwrap();
+        let result = manager.lookup("f", "foo", "").await.unwrap();
         assert_eq!(result, Value::Number { val: 5 });
     }
 
@@ -539,7 +636,7 @@ mod tests {
     async fn test_lookup_missing_var_returns_error() {
         let mut manager = Manager::new();
         manager.create_service("foo".to_string(), vec![]).await.unwrap();
-        let result = manager.lookup("nonexistent", "foo").await;
+        let result = manager.lookup("nonexistent", "foo", "").await;
         assert!(result.is_err());
     }
 
@@ -565,12 +662,12 @@ mod tests {
         manager.create_service("foo".to_string(), decls).await.unwrap();
 
         // f should be 11 initially
-        let result = manager.lookup("f", "foo").await.unwrap();
+        let result = manager.lookup("f", "foo", "").await.unwrap();
         assert_eq!(result, Value::Number { val: 11 });
 
         // update x to 5, f should become 15
         manager.assign("foo", "x", Value::Number { val: 5 }).await.unwrap();
-        let result = manager.lookup("f", "foo").await.unwrap();
+        let result = manager.lookup("f", "foo", "").await.unwrap();
         assert_eq!(result, Value::Number { val: 15 });
     }
 }

--- a/meerkat-lib/src/runtime/manager/mod.rs
+++ b/meerkat-lib/src/runtime/manager/mod.rs
@@ -24,6 +24,8 @@ pub struct Manager {
     pub network: Option<NetworkActor>,
     /// Pending reply channels keyed by request_id
     pub pending_replies: HashMap<u64, oneshot::Sender<MeerkatMessage>>,
+    /// Used to enumerate hidden bindings in proxy closures.
+    pub next_proxy_id: u64,
 }
 
 impl Manager {
@@ -33,6 +35,7 @@ impl Manager {
             remote_services: HashMap::new(),
             network: None,
             pending_replies: HashMap::new(),
+            next_proxy_id: 1,
         }
     }
 
@@ -41,28 +44,33 @@ impl Manager {
     {
         let dep = calc_dep_srv(&decls);
 
-        let mut service = Service {
+        let service = Service {
             name: name.clone(),
             vars: HashMap::new(),
             defs: HashMap::new(),
             dep,
         };
+        self.services.insert(name.clone(), service);
 
         let mut env: Vec<(String, Value)> = vec![];
         let svc_name = name.clone();
 
         for decl in decls {
             match decl {
-                Decl::VarDecl { name, val } => {
+                Decl::VarDecl { name: var_name, val } => {
                     let value = eval(&val, &env, &mut EvalContext { manager: self, service_name: &svc_name }).await?;
-                    env.push((name.clone(), value.clone()));
-                    service.vars.insert(name, VarState::new(value));
+                    env.push((var_name.clone(), value.clone()));
+                    if let Some(s) = self.services.get_mut(&svc_name) {
+                        s.vars.insert(var_name, VarState::new(value));
+                    }
                 }
-                Decl::DefDecl { name, val, .. } => {
+                Decl::DefDecl { name: def_name, val, .. } => {
                     let value = eval(&val, &env, &mut EvalContext { manager: self, service_name: &svc_name }).await?;
-                    env.push((name.clone(), value.clone()));
-                    service.vars.insert(name.clone(), VarState::new(value));
-                    service.defs.insert(name, val);  // store original expr
+                    env.push((def_name.clone(), value.clone()));
+                    if let Some(s) = self.services.get_mut(&svc_name) {
+                        s.vars.insert(def_name.clone(), VarState::new(value));
+                        s.defs.insert(def_name, val);  // store original expr
+                    }
                 }
                 Decl::TableDecl { .. } => {
                     return Err(EvalError::NotImplemented);
@@ -70,7 +78,6 @@ impl Manager {
             }
         }
 
-        self.services.insert(name.clone(), service);
         Ok(())
     }
 
@@ -80,7 +87,7 @@ impl Manager {
             return self.remote_lookup(service_name, ident).await;
         }
 
-        // If it's an unknown service, but we are inside a closure from a remote service, proxy it!
+        // If it's an unknown service, but we are inside a closure from a remote service, proxy it.
         if current_context != "" && current_context != service_name && self.remote_services.contains_key(current_context) {
             return self.proxy_remote_lookup(current_context, service_name, ident).await;
         }
@@ -103,11 +110,6 @@ impl Manager {
             if let Some(var_state) = service.vars.get(ident) {
                 return Ok(var_state.value.clone());
             }
-        }
-        if let Some(service) = self.services.get(service_name) {
-            println!("DEBUG: Lookup failed for {} in {}. Available vars: {:?}", ident, service_name, service.vars.keys());
-        } else {
-            println!("DEBUG: Lookup failed for {} in {}. Service not found locally.", ident, service_name);
         }
         Err(EvalError::LookupError(format!("Variable '{}' not found in service '{}'", ident, service_name)))
     }
@@ -145,7 +147,7 @@ impl Manager {
         }
     }
 
-    pub fn wrap_value(&mut self, value: Value, current_service: &str, next_id: &mut u64) -> Value {
+    pub fn wrap_value(&mut self, value: Value, current_service: &str) -> Value {
         let is_remote = match &value {
             Value::ActionClosure { service_name, .. } | Value::Closure { service_name, .. } => {
                 service_name != current_service
@@ -157,8 +159,8 @@ impl Manager {
             return value;
         }
 
-        let var_name = format!("$x{}", *next_id);
-        *next_id += 1;
+        let var_name = format!("$x{}", self.next_proxy_id);
+        self.next_proxy_id += 1;
 
         match value {
             Value::ActionClosure { stmts, env, service_name } => {

--- a/meerkat-lib/src/runtime/manager/mod.rs
+++ b/meerkat-lib/src/runtime/manager/mod.rs
@@ -26,6 +26,51 @@ pub struct Manager {
     pub pending_replies: HashMap<u64, oneshot::Sender<MeerkatMessage>>,
 }
 
+/// Wrap a remote closure/action so it is homed to `current_service`.
+/// The original value is embedded as an `Expr::Literal` inside a new
+/// closure whose `service_name` is `current_service`.
+fn wrap_value(value: Value, current_service: &str) -> Value {
+    let is_remote = match &value {
+        Value::ActionClosure { service_name, .. } | Value::Closure { service_name, .. } => {
+            service_name != current_service
+        }
+        _ => false,
+    };
+
+    if !is_remote {
+        return value;
+    }
+
+    match value {
+        Value::ActionClosure { stmts, env, service_name } => {
+            let original_action = Value::ActionClosure { stmts, env, service_name };
+            Value::ActionClosure {
+                stmts: vec![ActionStmt::Do(Expr::Literal { val: original_action })],
+                env: vec![],
+                service_name: current_service.to_string(),
+            }
+        }
+        Value::Closure { params, body, env, service_name } => {
+            let original_closure = Value::Closure {
+                params: params.clone(),
+                body: body.clone(),
+                env: env.clone(),
+                service_name,
+            };
+            Value::Closure {
+                params: params.clone(),
+                body: Box::new(Expr::Call {
+                    func: Box::new(Expr::Literal { val: original_closure }),
+                    args: params.iter().map(|p| Expr::Variable { ident: p.clone() }).collect(),
+                }),
+                env: vec![],
+                service_name: current_service.to_string(),
+            }
+        }
+        other => other,
+    }
+}
+
 impl Manager {
     pub fn new() -> Self {
         Manager {
@@ -710,50 +755,5 @@ mod tests {
             }
             other => panic!("expected ActionClosure, got {:?}", other),
         }
-    }
-}
-
-/// Wrap a remote closure/action so it is homed to `current_service`.
-/// The original value is embedded as an `Expr::Literal` inside a new
-/// closure whose `service_name` is `current_service`.
-fn wrap_value(value: Value, current_service: &str) -> Value {
-    let is_remote = match &value {
-        Value::ActionClosure { service_name, .. } | Value::Closure { service_name, .. } => {
-            service_name != current_service
-        }
-        _ => false,
-    };
-
-    if !is_remote {
-        return value;
-    }
-
-    match value {
-        Value::ActionClosure { stmts, env, service_name } => {
-            let original_action = Value::ActionClosure { stmts, env, service_name };
-            Value::ActionClosure {
-                stmts: vec![ActionStmt::Do(Expr::Literal { val: original_action })],
-                env: vec![],
-                service_name: current_service.to_string(),
-            }
-        }
-        Value::Closure { params, body, env, service_name } => {
-            let original_closure = Value::Closure {
-                params: params.clone(),
-                body: body.clone(),
-                env: env.clone(),
-                service_name,
-            };
-            Value::Closure {
-                params: params.clone(),
-                body: Box::new(Expr::Call {
-                    func: Box::new(Expr::Literal { val: original_closure }),
-                    args: params.iter().map(|p| Expr::Variable { ident: p.clone() }).collect(),
-                }),
-                env: vec![],
-                service_name: current_service.to_string(),
-            }
-        }
-        other => other,
     }
 }

--- a/meerkat/src/main.rs
+++ b/meerkat/src/main.rs
@@ -136,14 +136,9 @@ async fn run_server(prog: Vec<Stmt>, remote_url_map: std::collections::HashMap<S
                             let result = manager.lookup(&member, &service, "").await;
                             let response = match result {
                                 Ok(val) => {
-                                    let wrapped_val = if member.starts_with('$') {
-                                        val
-                                    } else {
-                                        manager.wrap_value(val, &service)
-                                    };
                                     MeerkatMessage::LookupResponse {
                                         request_id,
-                                        value: serde_json::to_string(&wrapped_val).unwrap_or_default(),
+                                        value: serde_json::to_string(&val).unwrap_or_default(),
                                     }
                                 }
                                 Err(e) => MeerkatMessage::LookupError {

--- a/meerkat/src/main.rs
+++ b/meerkat/src/main.rs
@@ -133,12 +133,20 @@ async fn run_server(prog: Vec<Stmt>, remote_url_map: std::collections::HashMap<S
                 NetworkEvent::MessageReceived { peer: _, msg } => {
                     match msg {
                         MeerkatMessage::LookupRequest { request_id, service, member, reply_to } => {
-                            let result = manager.lookup(&member, &service).await;
+                            let result = manager.lookup(&member, &service, "").await;
                             let response = match result {
-                                Ok(val) => MeerkatMessage::LookupResponse {
-                                    request_id,
-                                    value: serde_json::to_string(&val).unwrap_or_default(),
-                                },
+                                Ok(val) => {
+                                    let wrapped_val = if member.starts_with('$') {
+                                        val
+                                    } else {
+                                        let local_svc = manager.services.keys().next().cloned().unwrap_or_default();
+                                        manager.wrap_value(val, &local_svc)
+                                    };
+                                    MeerkatMessage::LookupResponse {
+                                        request_id,
+                                        value: serde_json::to_string(&wrapped_val).unwrap_or_default(),
+                                    }
+                                }
                                 Err(e) => MeerkatMessage::LookupError {
                                     request_id,
                                     error: e.to_string(),

--- a/meerkat/src/main.rs
+++ b/meerkat/src/main.rs
@@ -139,8 +139,7 @@ async fn run_server(prog: Vec<Stmt>, remote_url_map: std::collections::HashMap<S
                                     let wrapped_val = if member.starts_with('$') {
                                         val
                                     } else {
-                                        let local_svc = manager.services.keys().next().cloned().unwrap_or_default();
-                                        manager.wrap_value(val, &local_svc)
+                                        manager.wrap_value(val, &service)
                                     };
                                     MeerkatMessage::LookupResponse {
                                         request_id,

--- a/meerkat/tests/s_multi.mkt
+++ b/meerkat/tests/s_multi.mkt
@@ -1,0 +1,11 @@
+service s_multi_1 {
+    var x = 10;
+    pub def get_closure = fn n => action { x = x + n; };
+    pub def get_x = x;
+}
+
+service s_multi_2 {
+    var y = 20;
+    pub def get_closure = fn n => action { y = y + n; };
+    pub def get_y = y;
+}

--- a/meerkat/tests/test_multi_client.mkt
+++ b/meerkat/tests/test_multi_client.mkt
@@ -1,0 +1,21 @@
+import s_multi_1
+import s_multi_2
+
+service s_client {
+    pub def c1 = s_multi_1.get_closure(5);
+    pub def c2 = s_multi_2.get_closure(10);
+    
+    pub def x_val = s_multi_1.get_x;
+    pub def y_val = s_multi_2.get_y;
+}
+
+@test(s_client) {
+    assert(x_val == 10);
+    assert(y_val == 20);
+    
+    do c1;
+    assert(x_val == 15);
+    
+    do c2;
+    assert(y_val == 30);
+}

--- a/scripts/default_manifest.txt
+++ b/scripts/default_manifest.txt
@@ -10,3 +10,9 @@ s2: meerkat/tests/test_client.mkt: 9002: s1
 
 # 3. Downstream consumer/test runner, importing s2
 s3: meerkat/tests/s3.mkt: client: s2
+
+# 4. Multi-service backend server (regression test for HashMap non-determinism)
+s_multi: meerkat/tests/s_multi.mkt: 9003:
+
+# 5. Client for multi-service backend server testing
+test_multi: meerkat/tests/test_multi_client.mkt: client: s_multi_1, s_multi_2

--- a/scripts/default_manifest.txt
+++ b/scripts/default_manifest.txt
@@ -1,0 +1,12 @@
+# Meerkat Network Orchestration Manifest
+# Format: node_name:file_path:port:imports
+# Use 'client' as the port for client-only nodes.
+
+# 1. Base backend server
+s1: meerkat/tests/s1.mkt: 9001:
+
+# 2. Intermediate gateway server, importing s1
+s2: meerkat/tests/test_client.mkt: 9002: s1
+
+# 3. Downstream consumer/test runner, importing s2
+s3: meerkat/tests/s3.mkt: client: s2

--- a/scripts/run_network.py
+++ b/scripts/run_network.py
@@ -22,6 +22,7 @@ import subprocess
 import signal
 import re
 import shutil
+import atexit
 
 # Enable loopback-only local bindings by default
 os.environ["MEERKAT_LOCAL"] = "1"
@@ -29,7 +30,10 @@ os.environ["MEERKAT_LOCAL"] = "1"
 LOG_DIR = os.path.join("tmp", "logs")
 processes = []
 
-def cleanup(sig=None, frame=None):
+def cleanup_processes():
+    global processes
+    if not processes:
+        return
     print("\nShutting down all Meerkat nodes...")
     for node_name, proc in processes:
         if proc.poll() is None:
@@ -41,8 +45,14 @@ def cleanup(sig=None, frame=None):
                 proc.kill()
             except Exception:
                 pass
+    processes = []
     print("Cleanup complete.")
+
+def cleanup(sig=None, frame=None):
     sys.exit(0)
+
+# Register atexit handler to ensure processes are always killed
+atexit.register(cleanup_processes)
 
 # Register signal handlers for clean exits
 signal.signal(signal.SIGINT, cleanup)
@@ -119,7 +129,7 @@ def main():
         if port.lower() == "client":
             # Client Node (runs in foreground)
             print(f"[{node_name}] Starting client node running '{file_path}'...")
-            cmd = ["cargo", "run", "--", "-f", file_path] + import_flags
+            cmd = ["./target/debug/meerkat", "-f", file_path] + import_flags
             print(f"Executing: {' '.join(cmd)}")
             print("---------------------------------------------------")
             
@@ -134,7 +144,7 @@ def main():
         else:
             # Server Node (runs in background)
             print(f"[{node_name}] Starting server node on port {port} running '{file_path}'...")
-            cmd = ["cargo", "run", "--", "-s", "-f", file_path, "-p", port] + import_flags
+            cmd = ["./target/debug/meerkat", "-s", "-f", file_path, "-p", port] + import_flags
             
             log_file = open(log_file_path, "w")
             proc = subprocess.Popen(cmd, stdout=log_file, stderr=subprocess.STDOUT, text=True)

--- a/scripts/run_network.py
+++ b/scripts/run_network.py
@@ -169,9 +169,12 @@ def main():
                 if os.path.exists(log_file_path):
                     with open(log_file_path, "r") as lf:
                         content = lf.read()
-                        match = re.search(r"Service URL:\s+(\S+)", content)
-                        if match:
-                            svc_url = match.group(1)
+                        matches = re.findall(r"Service URL:\s+(\S+)", content)
+                        if matches:
+                            for url in matches:
+                                svc_name = url.split('/')[-1]
+                                service_urls[svc_name] = url
+                            svc_url = matches[0]
                             url_found = True
                             break
 

--- a/scripts/run_network.py
+++ b/scripts/run_network.py
@@ -48,8 +48,10 @@ def cleanup_processes():
     processes = []
     print("Cleanup complete.")
 
-def cleanup(sig=None, frame=None):
-    sys.exit(0)
+def cleanup(sig=None, frame=None, exit_code=0):
+    if isinstance(sig, int):
+        sys.exit(128 + sig)
+    sys.exit(exit_code)
 
 # Register atexit handler to ensure processes are always killed
 atexit.register(cleanup_processes)
@@ -120,7 +122,7 @@ def main():
                 
                 if not resolved_url:
                     print(f"Error: Node '{node_name}' imports '{imp}', but '{imp}' has not been started yet.")
-                    cleanup()
+                    cleanup(exit_code=1)
 
                 import_flags.extend(["-i", resolved_url])
 
@@ -162,7 +164,7 @@ def main():
                     log_file.close()
                     with open(log_file_path, "r") as lf:
                         print(lf.read())
-                    cleanup()
+                    cleanup(exit_code=1)
 
                 if os.path.exists(log_file_path):
                     with open(log_file_path, "r") as lf:
@@ -178,7 +180,7 @@ def main():
                 log_file.close()
                 with open(log_file_path, "r") as lf:
                     print(lf.read())
-                cleanup()
+                cleanup(exit_code=1)
 
             log_file.close()
             service_urls[node_name] = svc_url

--- a/scripts/run_network.py
+++ b/scripts/run_network.py
@@ -1,0 +1,190 @@
+"""
+Meerkat Network Orchestrator
+
+Purpose:
+  Orchestrates and tests multi-node, relay, and multi-hop distributed topologies
+  for the Meerkat programming language. It dynamically parses a network manifest,
+  launches background server nodes, captures their runtime Peer IDs and service URLs,
+  wires dependent nodes together, runs client tests in the foreground, and performs
+  a clean shutdown of all background processes when completed.
+
+Usage:
+  python3 scripts/run_network.py [manifest_file_path]
+
+Default manifest:
+  scripts/default_manifest.txt
+"""
+
+import os
+import sys
+import time
+import subprocess
+import signal
+import re
+import shutil
+
+# Enable loopback-only local bindings by default
+os.environ["MEERKAT_LOCAL"] = "1"
+
+LOG_DIR = os.path.join("tmp", "logs")
+processes = []
+
+def cleanup(sig=None, frame=None):
+    print("\nShutting down all Meerkat nodes...")
+    for node_name, proc in processes:
+        if proc.poll() is None:
+            print(f"Stopping server '{node_name}' (PID: {proc.pid})...")
+            try:
+                proc.terminate()
+                proc.wait(timeout=2)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+            except Exception:
+                pass
+    print("Cleanup complete.")
+    sys.exit(0)
+
+# Register signal handlers for clean exits
+signal.signal(signal.SIGINT, cleanup)
+signal.signal(signal.SIGTERM, cleanup)
+
+def main():
+    global processes
+
+    # Parse arguments
+    manifest_path = "scripts/default_manifest.txt"
+    if len(sys.argv) > 1:
+        if sys.argv[1] in ("-h", "--help"):
+            print("Usage: python3 scripts/run_network.py [manifest_file_path]")
+            print("Default manifest: scripts/default_manifest.txt")
+            sys.exit(0)
+        manifest_path = sys.argv[1]
+
+    if not os.path.isfile(manifest_path):
+        print(f"Error: Manifest file '{manifest_path}' not found.")
+        sys.exit(1)
+
+    # Clean and recreate log directory
+    if os.path.exists(LOG_DIR):
+        shutil.rmtree(LOG_DIR)
+    os.makedirs(LOG_DIR, exist_ok=True)
+
+    print("===================================================")
+    print("       Starting Meerkat Orchestrated Network       ")
+    print("===================================================")
+    print(f"Using manifest: {manifest_path}")
+    print(f"Logs will be written to: {LOG_DIR}/")
+    print("Offline/loopback mode is active (MEERKAT_LOCAL=1)")
+    print("---------------------------------------------------")
+
+    # Read manifest nodes
+    nodes = []
+    with open(manifest_path, 'r') as f:
+        for line in f:
+            line = line.strip()
+            if not line or line.startswith('#'):
+                continue
+            parts = [p.strip() for p in line.split(':')]
+            if len(parts) < 3:
+                continue
+            node_name = parts[0]
+            file_path = parts[1]
+            port = parts[2]
+            imports = parts[3] if len(parts) > 3 else ""
+            nodes.append((node_name, file_path, port, imports))
+
+    # Track started node URLs
+    service_urls = {}
+
+    for node_name, file_path, port, imports in nodes:
+        # Resolve imports
+        import_flags = []
+        if imports:
+            for imp in [i.strip() for i in imports.split(',') if i.strip()]:
+                resolved_url = service_urls.get(imp)
+                if not resolved_url:
+                    url_file = os.path.join(LOG_DIR, f"{imp}.url")
+                    if os.path.exists(url_file):
+                        with open(url_file, 'r') as uf:
+                            resolved_url = uf.read().strip()
+                
+                if not resolved_url:
+                    print(f"Error: Node '{node_name}' imports '{imp}', but '{imp}' has not been started yet.")
+                    cleanup()
+
+                import_flags.extend(["-i", resolved_url])
+
+        log_file_path = os.path.join(LOG_DIR, f"{node_name}.log")
+
+        if port.lower() == "client":
+            # Client Node (runs in foreground)
+            print(f"[{node_name}] Starting client node running '{file_path}'...")
+            cmd = ["cargo", "run", "--", "-f", file_path] + import_flags
+            print(f"Executing: {' '.join(cmd)}")
+            print("---------------------------------------------------")
+            
+            try:
+                res = subprocess.run(cmd)
+                if res.returncode != 0:
+                    print(f"[{node_name}] Execution failed with code {res.returncode}. Output above.")
+                    sys.exit(res.returncode)
+            except Exception as e:
+                print(f"[{node_name}] Execution failed: {e}")
+                sys.exit(1)
+        else:
+            # Server Node (runs in background)
+            print(f"[{node_name}] Starting server node on port {port} running '{file_path}'...")
+            cmd = ["cargo", "run", "--", "-s", "-f", file_path, "-p", port] + import_flags
+            
+            log_file = open(log_file_path, "w")
+            proc = subprocess.Popen(cmd, stdout=log_file, stderr=subprocess.STDOUT, text=True)
+            processes.append((node_name, proc))
+
+            # Wait for the node to print its Service URL
+            print(f"Waiting for '{node_name}' to generate its URL...")
+            url_found = False
+            svc_url = None
+            
+            for _ in range(100): # Up to 20 seconds
+                time.sleep(0.2)
+                if proc.poll() is not None:
+                    print(f"Error: Server '{node_name}' crashed during startup. Log output:")
+                    log_file.close()
+                    with open(log_file_path, "r") as lf:
+                        print(lf.read())
+                    cleanup()
+
+                if os.path.exists(log_file_path):
+                    with open(log_file_path, "r") as lf:
+                        content = lf.read()
+                        match = re.search(r"Service URL:\s+(\S+)", content)
+                        if match:
+                            svc_url = match.group(1)
+                            url_found = True
+                            break
+
+            if not url_found:
+                print(f"Error: Timeout waiting for server '{node_name}' to start. Log output:")
+                log_file.close()
+                with open(log_file_path, "r") as lf:
+                    print(lf.read())
+                cleanup()
+
+            log_file.close()
+            service_urls[node_name] = svc_url
+            
+            # Save URL file for team integration
+            url_file_path = os.path.join(LOG_DIR, f"{node_name}.url")
+            with open(url_file_path, "w") as uf:
+                uf.write(svc_url)
+                
+            print(f"[{node_name}] Started successfully! Service URL: {svc_url}\n")
+
+    # If all nodes finished successfully
+    print("\n===================================================")
+    print("      All manifest nodes completed successfully     ")
+    print("===================================================")
+    cleanup()
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
- [x] Introduced a Python script in `/scripts` with configurable manifest file. This enables setting up arbitrary network topologies for testing, reproduction, and development. Documented well; see files for usage. This allows single command execution for multiple nodes without having to manually copy-paste node IDs and maintain multiple terminal windows. All outputs from nodes are logged in `/tmp/logs` for inspection and legibility. This also makes this workflow fully exposed to agentic AI to accelerate further development.
- [x] Introduced a MEERKAT_LOCAL environment variable concept to allow local network loopback for offline or local development. This allows Meerkat to bind to local host 127.0.0.1 instead of binding to the public IP. This required small modifications to `Manager` to look for this flag.
- [x] Fixed issue #40 by introducing an additional layer of wrapping for remote services. For example, in the given bug report: `s1` is put online. `s2` is put online and imports `s1`. `s3` is put online and then evaluates its definitions that refer to `s2`. When `s2` processes this request it now detects `s1` in `fn n => s1.inc_x` as remote. It contacts `s1` as it should and then wraps the result of that in a closure that will ensure that it is evaluated in the context of `s2`. Then `s2` sends this wrapped closure to `s3`, effectively implementing a dynamic delegation protocol.
- [x] Enhanced network orchestrator script to better capture all early termination paths, including signals, to ensure no dangling nodes or services are left in operation, which could confound testing scripts from stale URLs, which are always freshly generated on node startup. 
- [x] Added multi-service features to the network orchestrator to detect multiple service URLs.
- [x] Added integration test to close test coverage gap for multi-service topologies/network configurations.
