### PR TITLE
fix(ci): move codeql to no build mode

### DIFF
--- a/.github/workflows/weekly-security.yml
+++ b/.github/workflows/weekly-security.yml
@@ -46,10 +46,7 @@ jobs:
         with:
           languages: rust
           queries: security-and-quality
-          build-mode: manual
-
-      - name: Build for CodeQL
-        run: cargo build --locked --workspace --all-targets --all-features
+          build-mode: none
 
       - name: Perform CodeQL analysis
         uses: github/codeql-action/analyze@9e0d7b8d25671d64c341c19c0152d693099fb5ba  # v4.35.5


### PR DESCRIPTION
CodeQL for Rust no longer requires a manual build step. It can directly use the `rust_analyzer` to analyze files without full compilation. This PR fixes CodeQL in Weekly Security by switching it to no build mode.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated security scanning workflow configuration to optimize code analysis operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->