### PR TITLE
refactor(meerkat-lib): resolve compiler warnings and clean up lints

### DIFF
--- a/meerkat-lib/src/error.rs
+++ b/meerkat-lib/src/error.rs
@@ -1,5 +1,3 @@
-use std::fmt::Display;
-use std::io;
 use std::result;
 
 pub type Result<T> = result::Result<T, Error>;

--- a/meerkat-lib/src/runtime/ast/mod.rs
+++ b/meerkat-lib/src/runtime/ast/mod.rs
@@ -222,10 +222,7 @@ impl Display for Value {
             Value::Bool { val } => write!(f, "{}", val),
             Value::String { val } => write!(f, "\"{}\"", val),
             Value::Closure {
-                params,
-                body,
-                env,
-                ..
+                params, body, env, ..
             } => write!(f, "fn({})[{:?}]{{{}}}", params.join(","), env, body),
             Value::ActionClosure {
                 stmts,
@@ -268,11 +265,7 @@ impl Display for Expr {
                     .join(", ")
             ),
             Expr::MemberAccess { service, member } => write!(f, "{}.{}", service, member),
-            Expr::Select {
-                table_name,
-                column_names,
-                where_clause,
-            } => write!(f, "{}", where_clause),
+            Expr::Select { where_clause, .. } => write!(f, "{}", where_clause),
             Expr::Table { records, .. } => {
                 write!(f, "[",)?;
                 for (i, record) in records.iter().enumerate() {
@@ -330,7 +323,7 @@ impl Display for Decl {
                     write!(f, "def {} = {}", name, val)
                 }
             }
-            Decl::TableDecl { name, fields } => {
+            Decl::TableDecl { name, .. } => {
                 write!(f, "table {} created", name)
             }
         }

--- a/meerkat-lib/src/runtime/interpreter/evaluator.rs
+++ b/meerkat-lib/src/runtime/interpreter/evaluator.rs
@@ -1,4 +1,4 @@
-use crate::ast::{ActionStmt, BinOp, Expr, UnOp, Value};
+use crate::ast::{BinOp, Expr, UnOp, Value};
 use crate::runtime::manager::Manager;
 use crate::runtime::txn::Transaction;
 use std::collections::HashSet;

--- a/meerkat-lib/src/runtime/parser/lex.rs
+++ b/meerkat-lib/src/runtime/parser/lex.rs
@@ -10,7 +10,7 @@
 #![allow(clippy::upper_case_acronyms)]
 use enum_as_inner::EnumAsInner;
 use logos::{Lexer, Logos, Skip};
-use std::{fmt};
+use std::fmt;
 use strum_macros::AsRefStr;
 
 fn from_num<'b>(lex: &mut Lexer<'b, Token<'b>>) -> Result<i32, String> {

--- a/meerkat-lib/src/runtime/semantic_analysis/var_analysis/alpha_rename.rs
+++ b/meerkat-lib/src/runtime/semantic_analysis/var_analysis/alpha_rename.rs
@@ -26,7 +26,7 @@ impl Expr {
                     item.alpha_rename(var_binded, renames);
                 }
             }
-            Expr::Unop { expr, ..} => {
+            Expr::Unop { expr, .. } => {
                 expr.alpha_rename(var_binded, renames);
             }
             Expr::Binop { expr1, expr2, .. } => {
@@ -70,10 +70,9 @@ impl Expr {
                 }
             }
             Expr::Fold {
-                table_name,
-                column_name,
                 operation,
                 identity,
+                ..
             } => {
                 operation.alpha_rename(var_binded, renames);
                 identity.alpha_rename(var_binded, renames);

--- a/meerkat-lib/src/runtime/semantic_analysis/var_analysis/dep_analysis.rs
+++ b/meerkat-lib/src/runtime/semantic_analysis/var_analysis/dep_analysis.rs
@@ -1,11 +1,6 @@
-use std::{
-    collections::{HashMap, HashSet},
-    vec,
-};
-
-use crate::ast;
-
 use super::DependAnalysis;
+use crate::ast;
+use std::collections::{HashMap, HashSet};
 
 impl DependAnalysis {
     pub fn new(decls: &Vec<ast::Decl>) -> DependAnalysis {

--- a/meerkat-lib/src/runtime/table_actor/handler.rs
+++ b/meerkat-lib/src/runtime/table_actor/handler.rs
@@ -81,9 +81,7 @@ impl kameo::prelude::Message<Msg> for TableActor {
 
                 Msg::Unit
             }
-
-            #[allow(unreachable_patterns)]
-            _ => panic!("VarActor should not receive message {:?}", msg),
+            _ => panic!("TableActor should not receive message {:?}", msg),
         }
     }
 }

--- a/meerkat-lib/src/runtime/var_actor/handler.rs
+++ b/meerkat-lib/src/runtime/var_actor/handler.rs
@@ -164,22 +164,6 @@ impl kameo::prelude::Message<Msg> for VarActor {
 
                 Msg::Unit
             }
-
-            Msg::TestRequestPred { from_mgr_addr, test_id } => {
-                info!("Only for asserts: Pred Request from {:?}", from_mgr_addr);
-
-                // will immediately send back latest pred id
-                let _ = from_mgr_addr.tell(
-                    Msg::TestRequestPredGranted { 
-                        from_name: self.name.clone(),
-                        test_id,
-                        pred_id: self.latest_write_txn.clone().map(|t| t.id) 
-                }).await;
-
-                Msg::Unit
-            }
-
-            #[allow(unreachable_patterns)]
             _ => panic!("VarActor should not receive message {:?}", msg),
         }
     }


### PR DESCRIPTION
Meerkat has warnings in its current workspace build. This spams logs, tests, and builds and also is generally not recommended to ignore; I try to treat warnings as errors for strong maintainability.

There were also some warning suppressions, which I caution against, as it disables the purpose of warnings and reduces safety. These have all been eliminated and the warnings they would have generated, corrected, workspace wide.

The tokenizer and parser generator were left untouched for this audit, which need their suppressions due to the way they often generate boilerplate code.

I ran local hooks and CI. All tests passing. Ready for review and merge.