### PR TITLE
fix: correct circuit relay test and related bugs

### DIFF
--- a/meerkat-lib/src/net/actor.rs
+++ b/meerkat-lib/src/net/actor.rs
@@ -491,6 +491,32 @@ impl NetworkActor {
                 }
                 //println!("Identify event: {:?}", event);
             }
+            libp2p::swarm::SwarmEvent::OutgoingConnectionError { peer_id, error, .. } => {
+                // Resolve any pending relay dial so the caller is not left waiting
+                if let Some((_, reply_tx)) = pending_relay.take() {
+                    let _ = reply_tx.send(Err(format!("Relay dial failed: {:?}", error)));
+                }
+
+                // Emit `SendFailed` for any messages queued for this peer and clean up
+                if let Some(peer_id) = peer_id {
+                    if let Some(messages) = pending_sends.remove(&peer_id) {
+                        for (msg_id, _) in messages {
+                            let _ = event_tx.send(NetworkEvent::SendFailed {
+                                msg_id,
+                                error: SendError::ProtocolError(format!(
+                                    "Outgoing connection failed: {:?}",
+                                    error
+                                )),
+                            });
+                        }
+                    }
+                }
+            }
+            libp2p::swarm::SwarmEvent::ListenerError { error, .. } => {
+                if let Some(tx) = pending_listen.take() {
+                    let _ = tx.send(Err(format!("Listener error: {:?}", error)));
+                }
+            }
             _ => {}
         }
     }

--- a/meerkat-lib/src/net/actor.rs
+++ b/meerkat-lib/src/net/actor.rs
@@ -394,16 +394,22 @@ impl NetworkActor {
         if swarm.is_connected(&peer_id) {
             Self::send_to_peer(control, peer_id, msg_id, msg, event_tx).await;
         } else {
+            // Track if we are already dialing this peer to prevent duplicate dials
+            let is_dialing = pending_sends.contains_key(&peer_id);
             pending_sends
                 .entry(peer_id)
                 .or_default()
                 .push((msg_id, msg));
-            if let Err(e) = swarm.dial(multiaddr) {
-                let _ = event_tx.send(NetworkEvent::SendFailed {
-                    msg_id,
-                    error: SendError::ProtocolError(format!("Dial failed: {:?}", e)),
-                });
-                pending_sends.remove(&peer_id);
+
+            if !is_dialing {
+                // Dial the target peer since no active dial request exists
+                if let Err(e) = swarm.dial(multiaddr) {
+                    let _ = event_tx.send(NetworkEvent::SendFailed {
+                        msg_id,
+                        error: SendError::ProtocolError(format!("Dial failed: {:?}", e)),
+                    });
+                    pending_sends.remove(&peer_id);
+                }
             }
         }
     }

--- a/meerkat-lib/src/net/actor.rs
+++ b/meerkat-lib/src/net/actor.rs
@@ -3,12 +3,14 @@ use futures::AsyncWriteExt;
 use futures::StreamExt;
 use kameo::Actor;
 use libp2p::core::multiaddr::Protocol;
+use libp2p::core::transport::ListenerId;
 use libp2p::Stream;
 use libp2p::{Multiaddr, PeerId};
 use libp2p_stream as stream;
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicU64, Ordering};
 use tokio::sync::mpsc;
+use tokio::sync::oneshot::Sender;
 
 #[derive(libp2p::swarm::NetworkBehaviour)]
 struct MeerkatBehaviour {
@@ -16,6 +18,14 @@ struct MeerkatBehaviour {
     relay: libp2p::relay::Behaviour,
     relay_client: libp2p::relay::client::Behaviour,
     identify: libp2p::identify::Behaviour,
+}
+
+/// State of a pending relay reservation attempt
+enum PendingRelayState {
+    /// Actively dialing the relay server before we can listen
+    Dialing(Address, Sender<Result<Address, String>>),
+    /// Dial completed and currently listening on the circuit relay address
+    Listening(Address, Sender<Result<Address, String>>, ListenerId),
 }
 
 enum SwarmCommand {
@@ -26,11 +36,11 @@ enum SwarmCommand {
     },
     Listen {
         addr: Address,
-        reply_tx: tokio::sync::oneshot::Sender<Result<Address, String>>,
+        reply_tx: Sender<Result<Address, String>>,
     },
     ListenViaRelay {
         relay_addr: Address,
-        reply_tx: tokio::sync::oneshot::Sender<Result<Address, String>>,
+        reply_tx: Sender<Result<Address, String>>,
     },
 }
 
@@ -248,12 +258,8 @@ impl NetworkActor {
         let mut control = swarm.behaviour().stream.new_control();
         let mut incoming = control.accept(MEERKAT_PROTOCOL).unwrap();
         let mut pending_sends: HashMap<PeerId, Vec<(MessageId, MeerkatMessage)>> = HashMap::new();
-        let mut pending_listen: Option<tokio::sync::oneshot::Sender<Result<Address, String>>> =
-            None;
-        let mut pending_relay: Option<(
-            Address,
-            tokio::sync::oneshot::Sender<Result<Address, String>>,
-        )> = None;
+        let mut pending_listen: Option<(ListenerId, Sender<Result<Address, String>>)> = None;
+        let mut pending_relay: Option<PendingRelayState> = None;
 
         loop {
             tokio::select! {
@@ -273,10 +279,13 @@ impl NetworkActor {
                         SwarmCommand::Listen { addr, reply_tx } => {
                             match addr.0.parse::<Multiaddr>() {
                                 Ok(multiaddr) => {
-                                    if let Err(e) = swarm.listen_on(multiaddr) {
-                                        let _ = reply_tx.send(Err(format!("{:?}", e)));
-                                    } else {
-                                        pending_listen = Some(reply_tx);
+                                    match swarm.listen_on(multiaddr) {
+                                        Ok(listener_id) => {
+                                            pending_listen = Some((listener_id, reply_tx));
+                                        }
+                                        Err(e) => {
+                                            let _ = reply_tx.send(Err(format!("{:?}", e)));
+                                        }
                                     }
                                 }
                                 Err(e) => {
@@ -293,8 +302,12 @@ impl NetworkActor {
                                             // Already connected listen via relay immediately
                                             let circuit_listen_addr = relay_multiaddr.with(Protocol::P2pCircuit);
                                             match swarm.listen_on(circuit_listen_addr) {
-                                                Ok(_) => {
-                                                    pending_relay = Some((relay_addr, reply_tx));
+                                                Ok(listener_id) => {
+                                                    pending_relay = Some(PendingRelayState::Listening(
+                                                        relay_addr,
+                                                        reply_tx,
+                                                        listener_id,
+                                                    ));
                                                 }
                                                 Err(e) => {
                                                     let _ = reply_tx.send(Err(format!("Failed to listen on relay: {:?}", e)));
@@ -305,7 +318,10 @@ impl NetworkActor {
                                             if let Err(e) = swarm.dial(relay_multiaddr.clone()) {
                                                 let _ = reply_tx.send(Err(format!("Failed to dial relay: {:?}", e)));
                                             } else {
-                                                pending_relay = Some((relay_addr, reply_tx));
+                                                pending_relay = Some(PendingRelayState::Dialing(
+                                                    relay_addr,
+                                                    reply_tx,
+                                                ));
                                             }
                                         }
                                     } else {
@@ -443,58 +459,96 @@ impl NetworkActor {
         control: &mut stream::Control,
         pending_sends: &mut HashMap<PeerId, Vec<(MessageId, MeerkatMessage)>>,
         event_tx: &mpsc::UnboundedSender<NetworkEvent>,
-        pending_listen: &mut Option<tokio::sync::oneshot::Sender<Result<Address, String>>>,
-        pending_relay: &mut Option<(
-            Address,
-            tokio::sync::oneshot::Sender<Result<Address, String>>,
-        )>,
+        pending_listen: &mut Option<(ListenerId, Sender<Result<Address, String>>)>,
+        pending_relay: &mut Option<PendingRelayState>,
     ) {
         match event {
-            libp2p::swarm::SwarmEvent::NewListenAddr { address, .. } => {
+            libp2p::swarm::SwarmEvent::NewListenAddr {
+                listener_id,
+                address,
+            } => {
                 swarm.add_external_address(address.clone());
                 let addr = Address(address.to_string());
-                //println!("New listen addr: {}", addr.0);
 
-                if addr.0.contains("/p2p-circuit") {
-                    //println!("Circuit relay address detected!");
-                    if let Some((_, reply_tx)) = pending_relay.take() {
-                        //println!("✓ Sending circuit address to pending_relay: {}", addr.0);
+                // Check if this listen address belongs to our pending relay reservation
+                let mut matched_relay = false;
+                if let Some(PendingRelayState::Listening(_, _, expected_id)) = pending_relay {
+                    if *expected_id == listener_id {
+                        matched_relay = true;
+                    }
+                }
+
+                // If matched resolve the pending relay oneshot channel and clear the state
+                if matched_relay {
+                    if let Some(PendingRelayState::Listening(_, reply_tx, _)) = pending_relay.take()
+                    {
                         let _ = reply_tx.send(Ok(addr));
                         return;
                     }
                 }
 
-                if let Some(tx) = pending_listen.take() {
-                    let _ = tx.send(Ok(addr));
+                // Check if this address belongs to a normal listener attempt
+                let mut matched_listen = false;
+                if let Some((expected_id, _)) = pending_listen {
+                    if *expected_id == listener_id {
+                        matched_listen = true;
+                    }
+                }
+
+                // If matched resolve the pending normal listen oneshot channel
+                if matched_listen {
+                    if let Some((_, tx)) = pending_listen.take() {
+                        let _ = tx.send(Ok(addr));
+                    }
                 }
             }
             libp2p::swarm::SwarmEvent::ConnectionEstablished { peer_id, .. } => {
-                //println!("Connection established with {}", peer_id);
                 let _ = event_tx.send(NetworkEvent::PeerConnected {
                     peer: peer_id.to_string(),
                 });
 
-                if let Some((relay_addr, _)) = pending_relay.as_ref() {
+                // Check if we were actively dialing the relay server and the dial completed
+                let mut to_listen = None;
+                if let Some(PendingRelayState::Dialing(relay_addr, _)) = pending_relay {
                     if let Ok(relay_multiaddr) = relay_addr.0.parse::<Multiaddr>() {
                         if let Some(relay_peer) = Self::extract_peer_id(&relay_multiaddr) {
                             if relay_peer == peer_id {
-                                //println!("Connected to relay {}, now listening via circuit", peer_id);
                                 let circuit_listen_addr =
                                     relay_multiaddr.with(Protocol::P2pCircuit);
-                                //println!("Calling listen_on with: {}", circuit_listen_addr);
-                                if let Err(e) = swarm.listen_on(circuit_listen_addr) {
-                                    if let Some((_, reply_tx)) = pending_relay.take() {
-                                        let _ = reply_tx.send(Err(format!(
-                                            "Failed to listen on relay: {:?}",
-                                            e
-                                        )));
-                                    }
-                                }
+                                to_listen = Some(circuit_listen_addr);
                             }
                         }
                     }
                 }
 
+                // If dialing completed start listening on the relay circuit immediately
+                if let Some(circuit_listen_addr) = to_listen {
+                    match swarm.listen_on(circuit_listen_addr) {
+                        Ok(listener_id) => {
+                            // Transition state from Dialing to Listening with the listener ID
+                            if let Some(PendingRelayState::Dialing(relay_addr, reply_tx)) =
+                                pending_relay.take()
+                            {
+                                *pending_relay = Some(PendingRelayState::Listening(
+                                    relay_addr,
+                                    reply_tx,
+                                    listener_id,
+                                ));
+                            }
+                        }
+                        Err(e) => {
+                            // If listen_on failed synchronously resolve the channel with an error
+                            if let Some(PendingRelayState::Dialing(_, reply_tx)) =
+                                pending_relay.take()
+                            {
+                                let _ = reply_tx
+                                    .send(Err(format!("Failed to listen on relay: {:?}", e)));
+                            }
+                        }
+                    }
+                }
+
+                // Send any queued messages that were waiting for connection establishment
                 if let Some(messages) = pending_sends.remove(&peer_id) {
                     for (msg_id, msg) in messages {
                         Self::send_to_peer(control, peer_id, msg_id, msg, event_tx).await;
@@ -506,10 +560,14 @@ impl NetworkActor {
                     peer: peer_id.to_string(),
                 });
 
-                // If the connection to our expected relay closed fail the pending relay dial
+                // If connection to the expected relay closed fail the pending attempt
                 if Self::get_pending_relay_peer(pending_relay) == Some(peer_id) {
-                    if let Some((_, reply_tx)) = pending_relay.take() {
-                        let _ = reply_tx.send(Err("Relay connection closed".to_string()));
+                    if let Some(state) = pending_relay.take() {
+                        let tx = match state {
+                            PendingRelayState::Dialing(_, tx) => tx,
+                            PendingRelayState::Listening(_, tx, _) => tx,
+                        };
+                        let _ = tx.send(Err("Relay connection closed".to_string()));
                     }
                 }
             }
@@ -527,20 +585,24 @@ impl NetworkActor {
                 //println!("Identify event: {:?}", event);
             }
             libp2p::swarm::SwarmEvent::OutgoingConnectionError { peer_id, error, .. } => {
-                // Resolve pending relay dial if the failure is for the expected peer
-                // or if the connection failed early before peer ID negotiation
+                // Determine if this failure affects our expected relay server
                 let matches_relay = Self::get_pending_relay_peer(pending_relay)
                     .map_or(false, |relay_peer| {
                         peer_id.map_or(true, |failed_peer| failed_peer == relay_peer)
                     });
 
+                // If the relay dial failed fail the pending relay reservation
                 if matches_relay {
-                    if let Some((_, reply_tx)) = pending_relay.take() {
-                        let _ = reply_tx.send(Err(format!("Relay dial failed: {:?}", error)));
+                    if let Some(state) = pending_relay.take() {
+                        let tx = match state {
+                            PendingRelayState::Dialing(_, tx) => tx,
+                            PendingRelayState::Listening(_, tx, _) => tx,
+                        };
+                        let _ = tx.send(Err(format!("Relay dial failed: {:?}", error)));
                     }
                 }
 
-                // Emit `SendFailed` for any messages queued for this peer and clean up
+                // Fail any message sends that were queued up waiting for this connection
                 if let Some(peer_id) = peer_id {
                     if let Some(messages) = pending_sends.remove(&peer_id) {
                         for (msg_id, _) in messages {
@@ -555,19 +617,51 @@ impl NetworkActor {
                     }
                 }
             }
-            libp2p::swarm::SwarmEvent::ListenerError { error, .. } => {
-                if let Some(tx) = pending_listen.take() {
-                    let _ = tx.send(Err(format!("Listener error: {:?}", error)));
+            libp2p::swarm::SwarmEvent::ListenerError {
+                listener_id, error, ..
+            } => {
+                // Check if this error belongs to our normal listener
+                let mut matched_listen = false;
+                if let Some((expected_id, _)) = pending_listen {
+                    if *expected_id == listener_id {
+                        matched_listen = true;
+                    }
                 }
-                // Resolve pending relay dial if listener failed
-                if let Some((_, reply_tx)) = pending_relay.take() {
-                    let _ = reply_tx.send(Err(format!("Relay listener error: {:?}", error)));
+                if matched_listen {
+                    if let Some((_, tx)) = pending_listen.take() {
+                        let _ = tx.send(Err(format!("Listener error: {:?}", error)));
+                    }
+                }
+
+                // Check if this error belongs to our circuit relay listener
+                let mut matched_relay = false;
+                if let Some(PendingRelayState::Listening(_, _, expected_id)) = pending_relay {
+                    if *expected_id == listener_id {
+                        matched_relay = true;
+                    }
+                }
+                if matched_relay {
+                    if let Some(PendingRelayState::Listening(_, tx, _)) = pending_relay.take() {
+                        let _ = tx.send(Err(format!("Relay listener error: {:?}", error)));
+                    }
                 }
             }
-            libp2p::swarm::SwarmEvent::ListenerClosed { reason, .. } => {
-                // Resolve pending relay dial if listener closed
-                if let Some((_, reply_tx)) = pending_relay.take() {
-                    let _ = reply_tx.send(Err(format!("Relay listener closed: {:?}", reason)));
+            libp2p::swarm::SwarmEvent::ListenerClosed {
+                listener_id,
+                reason,
+                ..
+            } => {
+                // Check if this closed listener belongs to our relay listener
+                let mut matched_relay = false;
+                if let Some(PendingRelayState::Listening(_, _, expected_id)) = pending_relay {
+                    if *expected_id == listener_id {
+                        matched_relay = true;
+                    }
+                }
+                if matched_relay {
+                    if let Some(PendingRelayState::Listening(_, tx, _)) = pending_relay.take() {
+                        let _ = tx.send(Err(format!("Relay listener closed: {:?}", reason)));
+                    }
                 }
             }
             _ => {}
@@ -592,14 +686,12 @@ impl NetworkActor {
         peer_ids.pop()
     }
 
-    /// Extracts the peer ID of the expected relay server from a pending relay reservation
-    fn get_pending_relay_peer(
-        pending_relay: &Option<(
-            Address,
-            tokio::sync::oneshot::Sender<Result<Address, String>>,
-        )>,
-    ) -> Option<PeerId> {
-        let (relay_addr, _) = pending_relay.as_ref()?;
+    /// Extracts the peer ID of the expected relay server from a pending relay state
+    fn get_pending_relay_peer(pending_relay: &Option<PendingRelayState>) -> Option<PeerId> {
+        let relay_addr = match pending_relay.as_ref()? {
+            PendingRelayState::Dialing(addr, _) => addr,
+            PendingRelayState::Listening(addr, _, _) => addr,
+        };
         let multiaddr = relay_addr.0.parse::<Multiaddr>().ok()?;
         Self::extract_peer_id(&multiaddr)
     }

--- a/meerkat-lib/src/net/actor.rs
+++ b/meerkat-lib/src/net/actor.rs
@@ -585,13 +585,13 @@ impl NetworkActor {
                 //println!("Identify event: {:?}", event);
             }
             libp2p::swarm::SwarmEvent::OutgoingConnectionError { peer_id, error, .. } => {
-                // Determine if this failure affects our expected relay server
+                // Check if this connection error matches our pending relay peer
                 let matches_relay = Self::get_pending_relay_peer(pending_relay)
                     .map_or(false, |relay_peer| {
-                        peer_id.map_or(true, |failed_peer| failed_peer == relay_peer)
+                        peer_id.map_or(false, |failed_peer| failed_peer == relay_peer)
                     });
 
-                // If the relay dial failed fail the pending relay reservation
+                // Fail the pending relay reservation if it matches the dial error
                 if matches_relay {
                     if let Some(state) = pending_relay.take() {
                         let tx = match state {

--- a/meerkat-lib/src/net/actor.rs
+++ b/meerkat-lib/src/net/actor.rs
@@ -197,13 +197,16 @@ impl NetworkActor {
                     relay_addr,
                     reply_tx,
                 });
-                match reply_rx.await {
-                    Ok(Ok(circuit_addr)) => {
-                        self.local_addrs.push(circuit_addr.clone());
-                        NetworkReply::ListenSuccess { addr: circuit_addr }
+                match tokio::time::timeout(std::time::Duration::from_secs(10), reply_rx).await {
+                    Ok(Ok(Ok(addr))) => {
+                        self.local_addrs.push(addr.clone());
+                        NetworkReply::ListenSuccess { addr }
                     }
-                    Ok(Err(e)) => NetworkReply::Failure(e),
-                    Err(_) => NetworkReply::Failure("Event loop dropped".to_string()),
+                    Ok(Ok(Err(e))) => NetworkReply::Failure(e),
+                    Ok(Err(_)) => NetworkReply::Failure("Event loop dropped".to_string()),
+                    Err(_) => {
+                        NetworkReply::Failure("Timeout waiting for relay reservation".to_string())
+                    }
                 }
             }
         }
@@ -285,11 +288,28 @@ impl NetworkActor {
                             //println!("ListenViaRelay command received for relay: {}", relay_addr.0);
                             match relay_addr.0.parse::<Multiaddr>() {
                                 Ok(relay_multiaddr) => {
-                                    //println!("Dialing relay at: {}", relay_multiaddr);
-                                    if let Err(e) = swarm.dial(relay_multiaddr.clone()) {
-                                        let _ = reply_tx.send(Err(format!("Failed to dial relay: {:?}", e)));
+                                    if let Some(relay_peer) = Self::extract_peer_id(&relay_multiaddr) {
+                                        if swarm.is_connected(&relay_peer) {
+                                            // Already connected listen via relay immediately
+                                            let circuit_listen_addr = relay_multiaddr.with(Protocol::P2pCircuit);
+                                            match swarm.listen_on(circuit_listen_addr) {
+                                                Ok(_) => {
+                                                    pending_relay = Some((relay_addr, reply_tx));
+                                                }
+                                                Err(e) => {
+                                                    let _ = reply_tx.send(Err(format!("Failed to listen on relay: {:?}", e)));
+                                                }
+                                            }
+                                        } else {
+                                            // Not connected dial the relay
+                                            if let Err(e) = swarm.dial(relay_multiaddr.clone()) {
+                                                let _ = reply_tx.send(Err(format!("Failed to dial relay: {:?}", e)));
+                                            } else {
+                                                pending_relay = Some((relay_addr, reply_tx));
+                                            }
+                                        }
                                     } else {
-                                        pending_relay = Some((relay_addr, reply_tx));
+                                        let _ = reply_tx.send(Err("No peer ID in relay address".to_string()));
                                     }
                                 }
                                 Err(e) => {
@@ -431,6 +451,7 @@ impl NetworkActor {
     ) {
         match event {
             libp2p::swarm::SwarmEvent::NewListenAddr { address, .. } => {
+                swarm.add_external_address(address.clone());
                 let addr = Address(address.to_string());
                 //println!("New listen addr: {}", addr.0);
 
@@ -461,7 +482,14 @@ impl NetworkActor {
                                 let circuit_listen_addr =
                                     relay_multiaddr.with(Protocol::P2pCircuit);
                                 //println!("Calling listen_on with: {}", circuit_listen_addr);
-                                swarm.listen_on(circuit_listen_addr).ok();
+                                if let Err(e) = swarm.listen_on(circuit_listen_addr) {
+                                    if let Some((_, reply_tx)) = pending_relay.take() {
+                                        let _ = reply_tx.send(Err(format!(
+                                            "Failed to listen on relay: {:?}",
+                                            e
+                                        )));
+                                    }
+                                }
                             }
                         }
                     }
@@ -477,9 +505,16 @@ impl NetworkActor {
                 let _ = event_tx.send(NetworkEvent::PeerDisconnected {
                     peer: peer_id.to_string(),
                 });
+
+                // If the connection to our expected relay closed fail the pending relay dial
+                if Self::get_pending_relay_peer(pending_relay) == Some(peer_id) {
+                    if let Some((_, reply_tx)) = pending_relay.take() {
+                        let _ = reply_tx.send(Err("Relay connection closed".to_string()));
+                    }
+                }
             }
-            libp2p::swarm::SwarmEvent::Behaviour(MeerkatBehaviourEvent::RelayClient(_event)) => {
-                //println!("Relay client event: {:?}", event);
+            libp2p::swarm::SwarmEvent::Behaviour(MeerkatBehaviourEvent::RelayClient(event)) => {
+                log::debug!("Relay client event: {:?}", event);
             }
             libp2p::swarm::SwarmEvent::Behaviour(MeerkatBehaviourEvent::Relay(_event)) => {
                 //println!("Relay server event: {:?}", event);
@@ -492,9 +527,17 @@ impl NetworkActor {
                 //println!("Identify event: {:?}", event);
             }
             libp2p::swarm::SwarmEvent::OutgoingConnectionError { peer_id, error, .. } => {
-                // Resolve any pending relay dial so the caller is not left waiting
-                if let Some((_, reply_tx)) = pending_relay.take() {
-                    let _ = reply_tx.send(Err(format!("Relay dial failed: {:?}", error)));
+                // Resolve pending relay dial if the failure is for the expected peer
+                // or if the connection failed early before peer ID negotiation
+                let matches_relay = Self::get_pending_relay_peer(pending_relay)
+                    .map_or(false, |relay_peer| {
+                        peer_id.map_or(true, |failed_peer| failed_peer == relay_peer)
+                    });
+
+                if matches_relay {
+                    if let Some((_, reply_tx)) = pending_relay.take() {
+                        let _ = reply_tx.send(Err(format!("Relay dial failed: {:?}", error)));
+                    }
                 }
 
                 // Emit `SendFailed` for any messages queued for this peer and clean up
@@ -516,13 +559,23 @@ impl NetworkActor {
                 if let Some(tx) = pending_listen.take() {
                     let _ = tx.send(Err(format!("Listener error: {:?}", error)));
                 }
+                // Resolve pending relay dial if listener failed
+                if let Some((_, reply_tx)) = pending_relay.take() {
+                    let _ = reply_tx.send(Err(format!("Relay listener error: {:?}", error)));
+                }
+            }
+            libp2p::swarm::SwarmEvent::ListenerClosed { reason, .. } => {
+                // Resolve pending relay dial if listener closed
+                if let Some((_, reply_tx)) = pending_relay.take() {
+                    let _ = reply_tx.send(Err(format!("Relay listener closed: {:?}", reason)));
+                }
             }
             _ => {}
         }
     }
 
     fn extract_peer_id(addr: &Multiaddr) -> Option<PeerId> {
-        // For circuit relay addresses, we need the LAST peer ID (the destination)
+        // For circuit relay addresses we need the LAST peer ID which is the destination
         // Format: /ip4/.../p2p/RELAY/p2p-circuit/p2p/DEST
         let mut peer_ids: Vec<PeerId> = addr
             .iter()
@@ -535,8 +588,20 @@ impl NetworkActor {
             })
             .collect();
 
-        // Return the last peer ID found (for circuits, this is the destination)
+        // Return the last peer ID found for circuits this is the destination
         peer_ids.pop()
+    }
+
+    /// Extracts the peer ID of the expected relay server from a pending relay reservation
+    fn get_pending_relay_peer(
+        pending_relay: &Option<(
+            Address,
+            tokio::sync::oneshot::Sender<Result<Address, String>>,
+        )>,
+    ) -> Option<PeerId> {
+        let (relay_addr, _) = pending_relay.as_ref()?;
+        let multiaddr = relay_addr.0.parse::<Multiaddr>().ok()?;
+        Self::extract_peer_id(&multiaddr)
     }
 }
 

--- a/meerkat-lib/src/net/actor.rs
+++ b/meerkat-lib/src/net/actor.rs
@@ -12,6 +12,13 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use tokio::sync::mpsc;
 use tokio::sync::oneshot::Sender;
 
+/// The connection timeout for idle swarm connections
+#[cfg(not(target_arch = "wasm32"))]
+const IDLE_CONNECTION_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(60);
+
+/// The maximum duration to wait for a relay reservation response
+const RELAY_RESERVATION_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+
 #[derive(libp2p::swarm::NetworkBehaviour)]
 struct MeerkatBehaviour {
     stream: stream::Behaviour,
@@ -22,7 +29,7 @@ struct MeerkatBehaviour {
 
 /// State of a pending relay reservation attempt
 enum PendingRelayState {
-    /// Actively dialing the relay server before we can listen
+    /// Actively dialing the relay server before calling `swarm.listen_on`
     Dialing(Address, Sender<Result<Address, String>>),
     /// Dial completed and currently listening on the circuit relay address
     Listening(Address, Sender<Result<Address, String>>, ListenerId),
@@ -86,7 +93,7 @@ async fn build_swarm() -> anyhow::Result<(libp2p::Swarm<MeerkatBehaviour>, PeerI
                 )),
             })
         })?
-        .with_swarm_config(|c| c.with_idle_connection_timeout(std::time::Duration::from_secs(60)))
+        .with_swarm_config(|c| c.with_idle_connection_timeout(IDLE_CONNECTION_TIMEOUT))
         .build();
 
     let peer_id = *swarm.local_peer_id();
@@ -207,7 +214,7 @@ impl NetworkActor {
                     relay_addr,
                     reply_tx,
                 });
-                match tokio::time::timeout(std::time::Duration::from_secs(10), reply_rx).await {
+                match tokio::time::timeout(RELAY_RESERVATION_TIMEOUT, reply_rx).await {
                     Ok(Ok(Ok(addr))) => {
                         self.local_addrs.push(addr.clone());
                         NetworkReply::ListenSuccess { addr }
@@ -394,7 +401,7 @@ impl NetworkActor {
         if swarm.is_connected(&peer_id) {
             Self::send_to_peer(control, peer_id, msg_id, msg, event_tx).await;
         } else {
-            // Track if we are already dialing this peer to prevent duplicate dials
+            // Track if we are already dialing this `peer_id` inside `pending_sends` to prevent duplicate dials
             let is_dialing = pending_sends.contains_key(&peer_id);
             pending_sends
                 .entry(peer_id)
@@ -402,7 +409,7 @@ impl NetworkActor {
                 .push((msg_id, msg));
 
             if !is_dialing {
-                // Dial the target peer since no active dial request exists
+                // Call `swarm.dial` for the target peer since no active dial request exists
                 if let Err(e) = swarm.dial(multiaddr) {
                     let _ = event_tx.send(NetworkEvent::SendFailed {
                         msg_id,
@@ -476,7 +483,7 @@ impl NetworkActor {
                 swarm.add_external_address(address.clone());
                 let addr = Address(address.to_string());
 
-                // Check if this listen address belongs to our pending relay reservation
+                // Check if this `NewListenAddr` belongs to our `pending_relay` reservation
                 let mut matched_relay = false;
                 if let Some(PendingRelayState::Listening(_, _, expected_id)) = pending_relay {
                     if *expected_id == listener_id {
@@ -484,7 +491,7 @@ impl NetworkActor {
                     }
                 }
 
-                // If matched resolve the pending relay oneshot channel and clear the state
+                // If matched resolve the `pending_relay` oneshot channel and clear the state
                 if matched_relay {
                     if let Some(PendingRelayState::Listening(_, reply_tx, _)) = pending_relay.take()
                     {
@@ -493,7 +500,7 @@ impl NetworkActor {
                     }
                 }
 
-                // Check if this address belongs to a normal listener attempt
+                // Check if this address belongs to a `pending_listen` attempt
                 let mut matched_listen = false;
                 if let Some((expected_id, _)) = pending_listen {
                     if *expected_id == listener_id {
@@ -501,7 +508,7 @@ impl NetworkActor {
                     }
                 }
 
-                // If matched resolve the pending normal listen oneshot channel
+                // If matched resolve the `pending_listen` oneshot channel
                 if matched_listen {
                     if let Some((_, tx)) = pending_listen.take() {
                         let _ = tx.send(Ok(addr));
@@ -531,7 +538,7 @@ impl NetworkActor {
                 if let Some(circuit_listen_addr) = to_listen {
                     match swarm.listen_on(circuit_listen_addr) {
                         Ok(listener_id) => {
-                            // Transition state from Dialing to Listening with the listener ID
+                            // Transition `pending_relay` from `Dialing` to `Listening` with the `ListenerId`
                             if let Some(PendingRelayState::Dialing(relay_addr, reply_tx)) =
                                 pending_relay.take()
                             {
@@ -543,7 +550,7 @@ impl NetworkActor {
                             }
                         }
                         Err(e) => {
-                            // If listen_on failed synchronously resolve the channel with an error
+                            // If `swarm.listen_on` failed synchronously resolve the channel with an error
                             if let Some(PendingRelayState::Dialing(_, reply_tx)) =
                                 pending_relay.take()
                             {
@@ -554,7 +561,7 @@ impl NetworkActor {
                     }
                 }
 
-                // Send any queued messages that were waiting for connection establishment
+                // Send any queued messages in `pending_sends` waiting for connection establishment
                 if let Some(messages) = pending_sends.remove(&peer_id) {
                     for (msg_id, msg) in messages {
                         Self::send_to_peer(control, peer_id, msg_id, msg, event_tx).await;
@@ -566,7 +573,7 @@ impl NetworkActor {
                     peer: peer_id.to_string(),
                 });
 
-                // If connection to the expected relay closed fail the pending attempt
+                // If connection to the expected relay closed fail the `pending_relay` attempt
                 if Self::get_pending_relay_peer(pending_relay) == Some(peer_id) {
                     if let Some(state) = pending_relay.take() {
                         let tx = match state {
@@ -591,13 +598,13 @@ impl NetworkActor {
                 //println!("Identify event: {:?}", event);
             }
             libp2p::swarm::SwarmEvent::OutgoingConnectionError { peer_id, error, .. } => {
-                // Check if this connection error matches our pending relay peer
+                // Check if this `OutgoingConnectionError` matches our `pending_relay` peer
                 let matches_relay = Self::get_pending_relay_peer(pending_relay)
                     .map_or(false, |relay_peer| {
                         peer_id.map_or(false, |failed_peer| failed_peer == relay_peer)
                     });
 
-                // Fail the pending relay reservation if it matches the dial error
+                // Fail the `pending_relay` reservation if it matches the dial error
                 if matches_relay {
                     if let Some(state) = pending_relay.take() {
                         let tx = match state {
@@ -608,7 +615,7 @@ impl NetworkActor {
                     }
                 }
 
-                // Fail any message sends that were queued up waiting for this connection
+                // Fail any message sends in `pending_sends` that were queued up waiting for this connection
                 if let Some(peer_id) = peer_id {
                     if let Some(messages) = pending_sends.remove(&peer_id) {
                         for (msg_id, _) in messages {
@@ -626,7 +633,7 @@ impl NetworkActor {
             libp2p::swarm::SwarmEvent::ListenerError {
                 listener_id, error, ..
             } => {
-                // Check if this error belongs to our normal listener
+                // Check if this error belongs to our `pending_listen` attempt
                 let mut matched_listen = false;
                 if let Some((expected_id, _)) = pending_listen {
                     if *expected_id == listener_id {
@@ -639,7 +646,7 @@ impl NetworkActor {
                     }
                 }
 
-                // Check if this error belongs to our circuit relay listener
+                // Check if this error belongs to our `pending_relay` listener
                 let mut matched_relay = false;
                 if let Some(PendingRelayState::Listening(_, _, expected_id)) = pending_relay {
                     if *expected_id == listener_id {
@@ -657,7 +664,7 @@ impl NetworkActor {
                 reason,
                 ..
             } => {
-                // Check if this closed listener belongs to our relay listener
+                // Check if this closed listener belongs to our `pending_relay` listener
                 let mut matched_relay = false;
                 if let Some(PendingRelayState::Listening(_, _, expected_id)) = pending_relay {
                     if *expected_id == listener_id {
@@ -675,7 +682,7 @@ impl NetworkActor {
     }
 
     fn extract_peer_id(addr: &Multiaddr) -> Option<PeerId> {
-        // For circuit relay addresses we need the LAST peer ID which is the destination
+        // For circuit relay addresses we need the last `PeerId` which is the destination
         // Format: /ip4/.../p2p/RELAY/p2p-circuit/p2p/DEST
         let mut peer_ids: Vec<PeerId> = addr
             .iter()
@@ -688,11 +695,11 @@ impl NetworkActor {
             })
             .collect();
 
-        // Return the last peer ID found for circuits this is the destination
+        // Return the last `PeerId` found for circuits as the destination
         peer_ids.pop()
     }
 
-    /// Extracts the peer ID of the expected relay server from a pending relay state
+    /// Extracts the `PeerId` of the expected relay server from a `PendingRelayState`
     fn get_pending_relay_peer(pending_relay: &Option<PendingRelayState>) -> Option<PeerId> {
         let relay_addr = match pending_relay.as_ref()? {
             PendingRelayState::Dialing(addr, _) => addr,

--- a/meerkat-lib/tests/net_integration_test.rs
+++ b/meerkat-lib/tests/net_integration_test.rs
@@ -114,17 +114,17 @@ async fn test_multiple_messages() {
     }
 
     let mut received = 0;
-    for _ in 0..100 {
-        sleep(Duration::from_millis(100)).await;
-        while let Ok(event) = server.event_rx.try_recv() {
+    let _ = tokio::time::timeout(tokio::time::Duration::from_secs(10), async {
+        while let Some(event) = server.event_rx.recv().await {
             if let NetworkEvent::MessageReceived { .. } = event {
                 received += 1;
+                if received >= 5 {
+                    break;
+                }
             }
         }
-        if received >= 5 {
-            break;
-        }
-    }
+    })
+    .await;
 
     assert_eq!(
         received, 5,

--- a/meerkat-lib/tests/net_integration_test.rs
+++ b/meerkat-lib/tests/net_integration_test.rs
@@ -324,7 +324,7 @@ async fn test_circuit_relay() {
     use std::time::Duration;
     use tokio::time::sleep;
 
-    // ── Step 1: Start relay server ────────────────────────────────────────────
+    // Start relay server
     let mut relay_server = NetworkActor::new(NodeType::Server).await.unwrap();
 
     let relay_listen_reply = relay_server
@@ -335,7 +335,7 @@ async fn test_circuit_relay() {
 
     let relay_addr = match relay_listen_reply {
         NetworkReply::ListenSuccess { addr } => addr,
-        other => panic!("Relay listen failed: {:?}", other),
+        other => panic!("relay listen failed: {:?}", other),
     };
 
     let relay_full_addr = Address::new(format!(
@@ -343,16 +343,14 @@ async fn test_circuit_relay() {
         relay_addr.0,
         relay_server.local_peer_id()
     ));
-    println!("Relay server address: {}", relay_full_addr.0);
+    println!("relay server: {}", relay_full_addr.0);
 
-    // ── Step 2: Start client2, get circuit relay address ─────────────────────
+    // Start `client2` and register circuit relay reservation
     let mut client2 = NetworkActor::new(NodeType::BrowserClient {
         relay_server: relay_full_addr.clone(),
     })
     .await
     .unwrap();
-
-    let _client2_peer_id = client2.local_peer_id();
 
     let circuit_reply = client2
         .handle_command(NetworkCommand::ListenViaRelay {
@@ -362,76 +360,147 @@ async fn test_circuit_relay() {
 
     let client2_circuit_addr = match circuit_reply {
         NetworkReply::ListenSuccess { addr } => addr,
-        other => panic!("Circuit relay listen failed: {:?}", other),
+        other => panic!("`ListenViaRelay` failed: {:?}", other),
     };
 
-    println!("client2 circuit relay address: {}", client2_circuit_addr.0);
+    println!("client2 circuit addr: {}", client2_circuit_addr.0);
     assert!(
         client2_circuit_addr.0.contains("p2p-circuit"),
-        "Expected circuit relay address, got: {}",
+        "expected circuit relay address, got: {}",
         client2_circuit_addr.0
     );
 
-    // Wait for relay server to confirm reservation before client1 dials through it
-    sleep(Duration::from_secs(2)).await;
-    while let Ok(e) = relay_server.event_rx.try_recv() {
-        println!("relay server event (pre-send): {:?}", e);
+    // Wait for relay server to confirm `client2` connection before `client1` dials
+    let mut client2_connected = false;
+    for _ in 0..50 {
+        while let Ok(e) = relay_server.event_rx.try_recv() {
+            println!("relay server: {:?}", e);
+            if let NetworkEvent::PeerConnected { peer } = &e {
+                if *peer == client2.local_peer_id() {
+                    client2_connected = true;
+                }
+            }
+        }
+        if client2_connected {
+            break;
+        }
+        sleep(Duration::from_millis(100)).await;
     }
-    println!("Starting client1 send...");
+    assert!(
+        client2_connected,
+        "`client2` never connected to the relay server"
+    );
 
-    // ── Step 3: Start client1, also a relay client (needs relay transport to dial circuit addrs)
+    // Start `client1` and send to `client2` through the relay.
+    // `client1` does not auto-dial the relay on creation; the relay transport
+    // connects as part of dialling the circuit address in `SendMessage`
     let mut client1 = NetworkActor::new(NodeType::BrowserClient {
         relay_server: relay_full_addr.clone(),
     })
     .await
     .unwrap();
 
-    // Wait for client1 to finish identify with relay before sending via circuit
-    sleep(Duration::from_secs(3)).await;
+    // Retry send with a hard 10-second timeout (5 attempts x 10 polls x 100ms)
+    let received = tokio::time::timeout(Duration::from_secs(10), async {
+        for attempt in 0..5usize {
+            client1
+                .handle_command(NetworkCommand::SendMessage {
+                    addr: client2_circuit_addr.clone(),
+                    msg: MeerkatMessage::Ping {
+                        content: "hello via relay".to_string(),
+                    },
+                })
+                .await;
 
-    client1
-        .handle_command(NetworkCommand::SendMessage {
-            addr: client2_circuit_addr.clone(),
-            msg: MeerkatMessage::Ping {
-                content: "hello via relay".to_string(),
-            },
-        })
-        .await;
+            for _ in 0..10usize {
+                sleep(Duration::from_millis(100)).await;
 
-    // ── Step 4: Poll until client2 receives the message ──────────────────────
-    let mut received = false;
-    for _ in 0..300 {
-        sleep(Duration::from_millis(200)).await;
+                while let Ok(e) = client2.event_rx.try_recv() {
+                    println!("client2: {:?}", e);
+                    if let NetworkEvent::MessageReceived {
+                        msg: MeerkatMessage::Ping { content },
+                        ..
+                    } = e
+                    {
+                        if content == "hello via relay" {
+                            return true;
+                        }
+                    }
+                }
 
-        while let Ok(e) = client2.event_rx.try_recv() {
-            println!("client2 got: {:?}", e);
-            if let NetworkEvent::MessageReceived {
-                msg: MeerkatMessage::Ping { content },
-                ..
-            } = e
-            {
-                if content == "hello via relay" {
-                    received = true;
+                // Drain other queues to keep event loops responsive
+                while let Ok(e) = relay_server.event_rx.try_recv() {
+                    println!("relay server: {:?}", e);
+                }
+                while let Ok(e) = client1.event_rx.try_recv() {
+                    println!("client1: {:?}", e);
                 }
             }
+            println!("attempt {} failed, retrying", attempt + 1);
         }
-
-        while let Ok(e) = relay_server.event_rx.try_recv() {
-            println!("relay server event: {:?}", e);
-        }
-
-        while let Ok(e) = client1.event_rx.try_recv() {
-            println!("client1 event: {:?}", e);
-        }
-
-        if received {
-            break;
-        }
-    }
+        false
+    })
+    .await
+    .unwrap_or(false);
 
     assert!(
         received,
         "client2 never received the message via circuit relay"
     );
-    println!("✓ Circuit relay test passed!");
+
+    // Send to a peer not registered with the relay; the relay rejects the circuit,
+    // producing `OutgoingConnectionError`. Verify `SendFailed` is emitted
+    let fake_peer = Address::new(format!(
+        "{}/p2p-circuit/p2p/12D3KooW8Zr3nQ7mL4xK9vJ2pY6sF1gT5hR",
+        relay_full_addr.0,
+    ));
+    client1
+        .handle_command(NetworkCommand::SendMessage {
+            addr: fake_peer,
+            msg: MeerkatMessage::Ping {
+                content: "should fail".to_string(),
+            },
+        })
+        .await;
+
+    let send_failed = tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            while let Ok(e) = client1.event_rx.try_recv() {
+                if matches!(e, NetworkEvent::SendFailed { .. }) {
+                    return true;
+                }
+            }
+            sleep(Duration::from_millis(50)).await;
+        }
+    })
+    .await
+    .unwrap_or(false);
+    assert!(
+        send_failed,
+        "`SendFailed` not received after `OutgoingConnectionError`"
+    );
+
+    // Verify `ListenViaRelay` on an unreachable relay returns `Failure` promptly
+    let dead_relay = Address::new("/ip4/127.0.0.1/tcp/19998/p2p/12D3KooW4nR7qL2mK8vJ3pY9sF6gT1hX");
+    let mut orphan = NetworkActor::new(NodeType::BrowserClient {
+        relay_server: dead_relay.clone(),
+    })
+    .await
+    .unwrap();
+
+    let relay_reply = tokio::time::timeout(
+        Duration::from_secs(5),
+        orphan.handle_command(NetworkCommand::ListenViaRelay {
+            relay_addr: dead_relay,
+        }),
+    )
+    .await
+    .expect("`ListenViaRelay` on unreachable relay must not hang");
+
+    assert!(
+        matches!(relay_reply, NetworkReply::Failure(_)),
+        "`ListenViaRelay` on unreachable relay returned {:?}, expected `Failure`",
+        relay_reply
+    );
+    println!("circuit relay test passed");
 }


### PR DESCRIPTION
Fix for Issue #62 due to circuit relay test being non-deterministic and polling based using timers, and two bugs in the Meerkat library related to the use of wildcard `match` arms that did not force exhaustiveness on the error paths related to net code logic. This PR corrects those issues. Full hand-written diagnosis follows: 

# The Circuit Relay Test

In file `meerkat/meerkat-lib/tests/net_integration_test.rs`:

There are two problems with this test:

1. The test uses `sleep`. This is not deterministic, which can cause problems and affects the reproducibility of the test.
2. It has no timeout guard.

Even if the test is corrected there is another problem in the library itself.

# Bugs in Net Code in Library

In the library there are two scenarios:

1. A catch-all `match` arm using `_` does not handle `OutgoingConnectionError`, leading to never responding to the failure case of this subsystem. This causes memory leaks and a slow failure (60 seconds or so) before it responds. This is not an indefinite hang, so it unlikely to be the root cause of the 30 minute IC timeout.
2. The `do_send` event loop blocks on `swarm.dial` or `send_to_peer`, an error occurs that blocks the event loop, and `event_rx.try_recv()` never receives a message and the test hangs indefinitely. This is likely the cause of the 30 minute IC timeouts and local system hangs when running full tests on the workspace.

# Conclusion

All tests now passing (and very quickly). Ready for review.

> [!NOTE]
> **Recommendation:** I propose that once this is reviewed and merged that we do a rebase on our existing open PRs so that they must be forced to pass CI. Currently, at least two open PRs are not passing CI due to a 30 minute timeout from the indefinite hang caused by (2) above in the library code. This should fix that and once we all rebase, the CIs should pass and continue to safeguard `main` branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable relay listening and connection handling: explicit pending-relay reservation state, deterministic completion/failure, 10s relay reservation timeout with distinct failure, correct relay peer-id extraction for circuit addresses, avoidance of duplicate dials, and consistent failure propagation on listener/connection errors.

* **Tests**
  * Hardened circuit-relay integration tests: replaced fixed sleeps with event-driven waits, added timeouts and bounded retries, and added explicit checks for send failures and unreachable-relay behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->