### PR TITLE
feat: add `--check` CLI for static check only mode

### DIFF
--- a/meerkat/src/main.rs
+++ b/meerkat/src/main.rs
@@ -79,8 +79,8 @@ pub async fn main() -> Result<(), Box<dyn Error>> {
             }
         }
         None => {
-            if args.server {
-                return Err("-s/--server requires a file (-f). Pass a .mkt file containing the services to host.".into());
+            if args.server || args.check_only {
+                return Err("Expected a .mkt file (-f).".into());
             }
             let mut manager = Manager::new();
             manager.local = args.local;

--- a/meerkat/src/main.rs
+++ b/meerkat/src/main.rs
@@ -34,6 +34,10 @@ struct Args {
     /// Bind to loopback/localhost only (force 127.0.0.1 instead of public IP)
     #[arg(long = "local", default_value_t = false)]
     local: bool,
+
+    /// Perform static checks and terminate immediately
+    #[arg(long = "check", default_value_t = false)]
+    check_only: bool,
 }
 
 #[tokio::main]
@@ -62,6 +66,11 @@ pub async fn main() -> Result<(), Box<dyn Error>> {
         Some(ref file) => {
             let prog = meerkat_lib::runtime::parser::parser::parse_file(file)
                 .map_err(|e| format!("Parse error: {}", e))?;
+
+            if args.check_only {
+                // TODO: Insert static checks here
+                return Ok(());
+            }
 
             if args.server {
                 run_server(prog, remote_url_map, args.port, args.local).await


### PR DESCRIPTION
Adds a `--check` CLI that is intended to run static checks and then terminate without running the program. It is currently a stub. This option makes the edit-test cycle much faster. Name resolution and type checking features depend on this PR for work on Issue #34.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `--check` command-line flag to parse and validate input files without executing server mode, client operations, service loading, or starting the interactive REPL.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->