### PR TITLE
ci: enforce warnings as errors across all cargo builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions: {}
+    env:
+      RUSTFLAGS: "-D warnings"
     steps:
       # Monitors outbound network calls and can enforce egress policy. Audit mode
       # records unexpected traffic without blocking while CI hardening is tuned.


### PR DESCRIPTION
Add the `RUSTFLAGS: "-D warnings"` environment variable globally to the Rust CI job in `ci.yml`. This ensures that all `cargo check`, `cargo test`, `cargo run`, and `cargo build` steps treat compiler warnings as errors, covering 100% of targets, modules, and packages in the workspace (including the WASM target).

This prevents warnings from going unnoticed in pull requests. Local verification confirms that the workspace builds cleanly without warnings under this configuration.

(This will not affect local edit-test cycles; it is only part of the CI check. It is intended to safeguard `main` branch. This should be highly compatible with linters, which would generally do the same.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced internal build quality assurance processes to enforce stricter compilation standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->