### PR TITLE
ci: enable clippy in CI and address workspace warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,9 +53,8 @@ jobs:
       - name: Check formatting
         run: cargo fmt --all -- --check
 
-      # TODO: Re-enable after existing Clippy warnings are fixed.
-      # - name: Run Clippy
-      #   run: cargo clippy --locked --workspace --all-targets --all-features -- -D warnings
+      - name: Run Clippy
+        run: cargo clippy --locked --workspace --all-targets --all-features -- -D warnings
 
       - name: Check WASM build
         run: cargo check --locked -p meerkat-lib --target wasm32-unknown-unknown --all-features

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,13 +44,12 @@ repos:
         types: [rust]
         pass_filenames: false
 
-      # TODO: Re-enable after existing Clippy warnings are fixed.
-      # - id: cargo-clippy
-      #   name: cargo clippy
-      #   entry: cargo clippy --locked --workspace --all-targets --all-features -- -D warnings
-      #   language: system
-      #   types: [rust]
-      #   pass_filenames: false
+      - id: cargo-clippy
+        name: cargo clippy
+        entry: cargo clippy --locked --workspace --all-targets --all-features -- -D warnings
+        language: system
+        types: [rust]
+        pass_filenames: false
 
       - id: cargo-check-wasm
         name: cargo check wasm

--- a/meerkat-lib/src/net/actor.rs
+++ b/meerkat-lib/src/net/actor.rs
@@ -590,19 +590,15 @@ impl NetworkActor {
             libp2p::swarm::SwarmEvent::Behaviour(MeerkatBehaviourEvent::Relay(_event)) => {
                 //println!("Relay server event: {:?}", event);
             }
-            libp2p::swarm::SwarmEvent::Behaviour(MeerkatBehaviourEvent::Identify(event)) => {
-                if let libp2p::identify::Event::Received { info, .. } = &event {
-                    //println!("Adding external address from identify: {}", info.observed_addr);
-                    swarm.add_external_address(info.observed_addr.clone());
-                }
-                //println!("Identify event: {:?}", event);
+            libp2p::swarm::SwarmEvent::Behaviour(MeerkatBehaviourEvent::Identify(
+                libp2p::identify::Event::Received { info, .. },
+            )) => {
+                swarm.add_external_address(info.observed_addr.clone());
             }
             libp2p::swarm::SwarmEvent::OutgoingConnectionError { peer_id, error, .. } => {
                 // Check if this `OutgoingConnectionError` matches our `pending_relay` peer
                 let matches_relay = Self::get_pending_relay_peer(pending_relay)
-                    .map_or(false, |relay_peer| {
-                        peer_id.map_or(false, |failed_peer| failed_peer == relay_peer)
-                    });
+                    .is_some_and(|relay_peer| peer_id == Some(relay_peer));
 
                 // Fail the `pending_relay` reservation if it matches the dial error
                 if matches_relay {

--- a/meerkat-lib/src/net/mock.rs
+++ b/meerkat-lib/src/net/mock.rs
@@ -15,6 +15,12 @@ pub struct MockNetwork {
     pub event_rx: mpsc::UnboundedReceiver<NetworkEvent>,
 }
 
+impl Default for MockNetwork {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl MockNetwork {
     /// Create a standalone mock node with its own registry
     pub fn new() -> Self {

--- a/meerkat-lib/src/runtime/manager/mod.rs
+++ b/meerkat-lib/src/runtime/manager/mod.rs
@@ -206,7 +206,7 @@ impl Manager {
         if let Some(service) = self.services.get(service_name) {
             if let Some(var_state) = service.vars.get(ident) {
                 let value = var_state.value.clone();
-                if let Some(t) = txn.as_deref_mut() {
+                if let Some(t) = txn {
                     t.read_cache.insert(key, value.clone());
                 }
                 return Ok(value);
@@ -223,7 +223,7 @@ impl Manager {
         service_name: &str,
         var: &str,
         value: Value,
-        mut txn: Option<&mut Transaction>,
+        txn: Option<&mut Transaction>,
     ) -> Result<(), EvalError> {
         // Inside a transaction: acquire the write lock lazily (upgrading from a
         // read lock for read-then-write patterns like x = x + 1) and buffer the
@@ -248,7 +248,7 @@ impl Manager {
                 LockAction::Upgrade => self.upgrade_to_write_lock(service_name, var, &txn_id)?,
                 LockAction::Acquire => self.acquire_write_lock(service_name, var, &txn_id)?,
             }
-            if let Some(t) = txn.as_deref_mut() {
+            if let Some(t) = txn {
                 t.locked.insert(key.clone());
                 t.written.insert(key.clone(), value.clone());
                 // Reads later in the same transaction see the buffered write
@@ -354,11 +354,8 @@ impl Manager {
     /// Drain all pending network events and dispatch each to the matching
     /// oneshot channel in pending_replies. Non-matching events are dropped.
     pub fn dispatch_network_events(&mut self) {
-        loop {
-            let event = match self.network.as_mut() {
-                Some(n) => n.try_recv_event(),
-                None => break,
-            };
+        while let Some(n) = self.network.as_mut() {
+            let event = n.try_recv_event();
             match event {
                 Some(NetworkEvent::MessageReceived { msg, .. }) => {
                     let rid = match &msg {
@@ -501,7 +498,7 @@ impl Manager {
         &mut self,
         service: &str,
         member: &str,
-        mut txn: Option<&mut Transaction>,
+        txn: Option<&mut Transaction>,
     ) -> Result<Value, EvalError> {
         use std::sync::atomic::{AtomicU64, Ordering};
         static NEXT_ID: AtomicU64 = AtomicU64::new(1);
@@ -523,7 +520,7 @@ impl Manager {
         // under the shared id. Pre-register it as a participant so commit/abort
         // releases that lock even if the reply is lost.
         if shared_tid.is_some() {
-            if let Some(t) = txn.as_deref_mut() {
+            if let Some(t) = txn {
                 t.participants.insert(addr.clone());
             }
         }
@@ -594,7 +591,7 @@ impl Manager {
         service_id: &ServiceId,
         stmts: Vec<ActionStmt>,
         env: Vec<(String, Value)>,
-        mut txn: Option<&mut Transaction>,
+        txn: Option<&mut Transaction>,
     ) -> Result<(), EvalError> {
         use std::sync::atomic::{AtomicU64, Ordering};
         static NEXT_ACTION_ID: AtomicU64 = AtomicU64::new(1);
@@ -617,7 +614,7 @@ impl Manager {
         // reaches this node to release them. If the remote never received the
         // request, the Abort it gets is a harmless no-op.
         if shared_tid.is_some() {
-            if let Some(t) = txn.as_deref_mut() {
+            if let Some(t) = txn {
                 t.participants.insert(addr.clone());
             }
         }

--- a/meerkat-lib/src/runtime/parser/lex.rs
+++ b/meerkat-lib/src/runtime/parser/lex.rs
@@ -16,12 +16,10 @@ use strum_macros::AsRefStr;
 fn from_num<'b>(lex: &mut Lexer<'b, Token<'b>>) -> Result<i32, String> {
     let slice = lex.slice();
 
-    let res = slice.parse();
-
-    if res.is_err() {
-        return Err(format!("Parsing failed with Error {:?}", res.unwrap_err()));
-    }
-    let out: i64 = res.unwrap();
+    let out: i64 = match slice.parse() {
+        Ok(val) => val,
+        Err(e) => return Err(format!("Parsing failed with Error {:?}", e)),
+    };
     if out > ((i32::MIN as i64).abs()) {
         // All numbers are positive because - is lexed separately
         return Err(format!("Number {} is out of bounds", out));

--- a/meerkat-lib/src/runtime/parser/mod.rs
+++ b/meerkat-lib/src/runtime/parser/mod.rs
@@ -18,48 +18,45 @@ pub enum ReplParseResult {
     Error(String),
 }
 
-pub mod parser {
-    use logos::Logos;
+use logos::Logos;
 
-    use crate::ast::Stmt;
+use crate::ast::Stmt;
 
-    pub fn parse_string(input: &str) -> Result<Vec<Stmt>, String> {
-        let lex_stream = super::lex::Token::lexer(input)
-            .spanned()
-            .map(|(t, span)| (span.start, t, span.end));
+pub fn parse_string(input: &str) -> Result<Vec<Stmt>, String> {
+    let lex_stream = lex::Token::lexer(input)
+        .spanned()
+        .map(|(t, span)| (span.start, t, span.end));
 
-        super::meerkat::ProgParser::new()
-            .parse(lex_stream)
-            .map_err(|e| format!("Parse error: {:?}", e))
+    meerkat::ProgParser::new()
+        .parse(lex_stream)
+        .map_err(|e| format!("Parse error: {:?}", e))
+}
+
+pub fn parse_file(filename: &str) -> Result<Vec<Stmt>, String> {
+    let content =
+        std::fs::read_to_string(filename).map_err(|e| format!("Failed to read file: {}", e))?;
+    parse_string(&content)
+}
+
+/// Try to parse accumulated REPL input, distinguishing incomplete input from real errors.
+///
+/// Returns `Incomplete` when the grammar signals `UnrecognizedEof`, meaning the user
+/// is mid-statement and the REPL should collect more lines before evaluating.
+pub fn parse_repl(input: &str) -> ReplParseResult {
+    use lalrpop_util::ParseError;
+
+    if input.trim().is_empty() {
+        return ReplParseResult::Incomplete;
     }
 
-    pub fn parse_file(filename: &str) -> Result<Vec<Stmt>, String> {
-        let content =
-            std::fs::read_to_string(filename).map_err(|e| format!("Failed to read file: {}", e))?;
-        parse_string(&content)
-    }
+    let lex_stream = lex::Token::lexer(input)
+        .spanned()
+        .map(|(t, span)| (span.start, t, span.end));
 
-    /// Try to parse accumulated REPL input, distinguishing incomplete input from real errors.
-    ///
-    /// Returns `Incomplete` when the grammar signals `UnrecognizedEof`, meaning the user
-    /// is mid-statement and the REPL should collect more lines before evaluating.
-    pub fn parse_repl(input: &str) -> super::ReplParseResult {
-        use super::ReplParseResult;
-        use lalrpop_util::ParseError;
-
-        if input.trim().is_empty() {
-            return ReplParseResult::Incomplete;
-        }
-
-        let lex_stream = super::lex::Token::lexer(input)
-            .spanned()
-            .map(|(t, span)| (span.start, t, span.end));
-
-        match super::meerkat::ProgParser::new().parse(lex_stream) {
-            Ok(stmts) if !stmts.is_empty() => ReplParseResult::Complete(stmts),
-            Ok(_) => ReplParseResult::Incomplete,
-            Err(ParseError::UnrecognizedEof { .. }) => ReplParseResult::Incomplete,
-            Err(e) => ReplParseResult::Error(format!("{:?}", e)),
-        }
+    match meerkat::ProgParser::new().parse(lex_stream) {
+        Ok(stmts) if !stmts.is_empty() => ReplParseResult::Complete(stmts),
+        Ok(_) => ReplParseResult::Incomplete,
+        Err(ParseError::UnrecognizedEof { .. }) => ReplParseResult::Incomplete,
+        Err(e) => ReplParseResult::Error(format!("{:?}", e)),
     }
 }

--- a/meerkat-lib/src/runtime/semantic_analysis/var_analysis/dep_analysis.rs
+++ b/meerkat-lib/src/runtime/semantic_analysis/var_analysis/dep_analysis.rs
@@ -3,7 +3,7 @@ use crate::ast;
 use std::collections::{HashMap, HashSet};
 
 impl DependAnalysis {
-    pub fn new(decls: &Vec<ast::Decl>) -> DependAnalysis {
+    pub fn new(decls: &[ast::Decl]) -> DependAnalysis {
         let mut vars: HashSet<String> = HashSet::new();
         let mut defs: HashSet<String> = HashSet::new();
         let mut reactive_names = HashSet::new();
@@ -51,7 +51,7 @@ impl DependAnalysis {
     /// * `tables` - set of table names (no dependencies).
     /// * `visited` - set of visited nodes in dfs.
     /// * `calced` - map of def to their computed dependencies, only appeared
-    ///    when finished computing for a def.
+    ///   when finished computing for a def.
     /// # Panics
     /// * panic if a cycle is detected in the graph.
     fn dfs_helper(
@@ -84,17 +84,18 @@ impl DependAnalysis {
 
         for dep_name in graph
             .get(name)
-            .expect(&format!("No such name in dep graph: {}", name))
+            .unwrap_or_else(|| panic!("No such name in dep graph: {}", name))
         {
             Self::dfs_helper(graph, vars, tables, visited, finished, calced, dep_name);
             dep.extend(
                 calced
                     .get(dep_name)
-                    .expect(&format!(
-                        "Not finished transitive dependency 
-                        calculation of: {}",
-                        dep_name
-                    ))
+                    .unwrap_or_else(|| {
+                        panic!(
+                            "Not finished transitive dependency calculation of: {}",
+                            dep_name
+                        )
+                    })
                     .clone(),
             );
             dep.insert(dep_name.clone());
@@ -133,7 +134,7 @@ impl DependAnalysis {
                 name.clone(),
                 self.dep_transitive
                     .get(name)
-                    .expect(&format!("cannot find def {} in trans dep", name))
+                    .unwrap_or_else(|| panic!("cannot find def {} in trans dep", name))
                     .intersection(&vars_and_tables)
                     .cloned()
                     .collect(),

--- a/meerkat-lib/src/runtime/semantic_analysis/var_analysis/mod.rs
+++ b/meerkat-lib/src/runtime/semantic_analysis/var_analysis/mod.rs
@@ -27,33 +27,33 @@ pub struct DependAnalysis {
 
 impl Display for DependAnalysis {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "Dependency Graph \n")?;
+        writeln!(f, "Dependency Graph ")?;
         for (name, deps) in self.dep_graph.iter() {
             write!(f, "{} -> ", name)?;
             for dep in deps.iter() {
                 write!(f, "{},", dep)?;
             }
-            write!(f, "\n")?;
+            writeln!(f)?;
         }
-        write!(f, "Transitive Dependency (Var only) \n")?;
+        writeln!(f, "Transitive Dependency (Var only) ")?;
         for (name, deps) in self.dep_vars.iter() {
             write!(f, "{} -> ", name)?;
             for dep in deps.iter() {
                 write!(f, "{},", dep)?;
             }
-            write!(f, "\n")?;
+            writeln!(f)?;
         }
 
-        write!(f, "Topological Order \n")?;
+        writeln!(f, "Topological Order ")?;
         for name in self.topo_order.iter() {
             write!(f, "{} ", name)?;
         }
-        write!(f, "\n")?;
+        writeln!(f)?;
         Ok(())
     }
 }
 
-pub fn calc_dep_srv(decls: &Vec<ast::Decl>) -> DependAnalysis {
+pub fn calc_dep_srv(decls: &[ast::Decl]) -> DependAnalysis {
     let mut da = DependAnalysis::new(decls);
     da.calc_dep_vars();
     //println!("{}", da);
@@ -61,7 +61,7 @@ pub fn calc_dep_srv(decls: &Vec<ast::Decl>) -> DependAnalysis {
 }
 
 // enumerate services and call calc_dep_srv on each one
-pub fn calc_dep_prog(stmts: &Vec<ast::Stmt>) {
+pub fn calc_dep_prog(stmts: &[ast::Stmt]) {
     for stmt in stmts.iter() {
         match stmt {
             ast::Stmt::Service { decls, .. } | ast::Stmt::Update { decls, .. } => {

--- a/meerkat-lib/src/runtime/txn.rs
+++ b/meerkat-lib/src/runtime/txn.rs
@@ -97,6 +97,12 @@ pub enum VarLock {
     WriteLocked(TxnId),
 }
 
+impl Default for VarLock {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl VarLock {
     pub fn new() -> Self {
         VarLock::Unlocked

--- a/meerkat-lib/tests/net_integration_test.rs
+++ b/meerkat-lib/tests/net_integration_test.rs
@@ -38,12 +38,14 @@ async fn test_send_and_receive() {
         sleep(Duration::from_millis(100)).await;
         if let Ok(event) = server.event_rx.try_recv() {
             println!("Server got event: {:?}", event);
-            if let NetworkEvent::MessageReceived { msg, .. } = event {
-                if let MeerkatMessage::Ping { content } = msg {
-                    assert_eq!(content, "hello from client");
-                    received = true;
-                    break;
-                }
+            if let NetworkEvent::MessageReceived {
+                msg: MeerkatMessage::Ping { content },
+                ..
+            } = event
+            {
+                assert_eq!(content, "hello from client");
+                received = true;
+                break;
             }
         }
     }
@@ -307,11 +309,9 @@ async fn test_trait_with_real_network() {
     let mut received = false;
     for _ in 0..50 {
         sleep(Duration::from_millis(100)).await;
-        if let Some(event) = server.try_recv_event() {
-            if let NetworkEvent::MessageReceived { .. } = event {
-                received = true;
-                break;
-            }
+        if let Some(NetworkEvent::MessageReceived { .. }) = server.try_recv_event() {
+            received = true;
+            break;
         }
     }
 

--- a/meerkat/src/main.rs
+++ b/meerkat/src/main.rs
@@ -57,14 +57,14 @@ pub async fn main() -> Result<(), Box<dyn Error>> {
     let mut remote_url_map: std::collections::HashMap<String, String> =
         std::collections::HashMap::new();
     for url in &args.import_urls {
-        if let Some(slug) = url.split('/').last() {
+        if let Some(slug) = url.split('/').next_back() {
             remote_url_map.insert(slug.to_string(), url.clone());
         }
     }
 
     match args.input_file {
         Some(ref file) => {
-            let prog = meerkat_lib::runtime::parser::parser::parse_file(file)
+            let prog = meerkat_lib::runtime::parser::parse_file(file)
                 .map_err(|e| format!("Parse error: {}", e))?;
 
             if args.check_only {
@@ -101,7 +101,7 @@ async fn run_server(
 
     let node_ip = manager.get_node_ip();
     let listen_ip = if local { "127.0.0.1" } else { "0.0.0.0" };
-    let listen_addr = Address::new(&format!("/ip4/{}/tcp/{}", listen_ip, port));
+    let listen_addr = Address::new(format!("/ip4/{}/tcp/{}", listen_ip, port));
     let reply = net
         .handle_command(NetworkCommand::Listen { addr: listen_addr })
         .await;
@@ -156,120 +156,111 @@ async fn run_server(
     println!("Server running, press Ctrl+C to stop...");
 
     loop {
-        let event = manager.network.as_mut().and_then(|n| n.try_recv_event());
-        if let Some(event) = event {
-            match event {
-                NetworkEvent::MessageReceived { peer: _, msg } => {
-                    match msg {
-                        MeerkatMessage::LookupRequest {
-                            request_id,
-                            service,
-                            member,
-                            reply_to,
-                            txn_id,
-                        } => {
-                            // Transactional read: acquire and hold a read lock
-                            // under the shared id. Plain read otherwise.
-                            let result = match txn_id {
-                                Some(tid) => {
-                                    manager
-                                        .remote_read_participant(&service, &member, tid)
-                                        .await
-                                }
-                                None => manager.lookup(&member, &service, None).await,
-                            };
-                            let response = match result {
-                                Ok(val) => MeerkatMessage::LookupResponse {
-                                    request_id,
-                                    value: serde_json::to_string(&val).unwrap_or_default(),
-                                },
-                                Err(e) => MeerkatMessage::LookupError {
-                                    request_id,
-                                    error: e.to_string(),
-                                },
-                            };
-                            if let Some(net) = manager.network.as_mut() {
-                                net.handle_command(NetworkCommand::SendMessage {
-                                    addr: Address::new(&reply_to),
-                                    msg: response,
-                                })
-                                .await;
-                            }
+        if let Some(NetworkEvent::MessageReceived { peer: _, msg }) =
+            manager.network.as_mut().and_then(|n| n.try_recv_event())
+        {
+            match msg {
+                MeerkatMessage::LookupRequest {
+                    request_id,
+                    service,
+                    member,
+                    reply_to,
+                    txn_id,
+                } => {
+                    // Transactional read: acquire and hold a read lock
+                    // under the shared id. Plain read otherwise.
+                    let result = match txn_id {
+                        Some(tid) => {
+                            manager
+                                .remote_read_participant(&service, &member, tid)
+                                .await
                         }
-                        MeerkatMessage::ActionRequest {
+                        None => manager.lookup(&member, &service, None).await,
+                    };
+                    let response = match result {
+                        Ok(val) => MeerkatMessage::LookupResponse {
                             request_id,
-                            service,
-                            stmts,
-                            env: action_env,
-                            reply_to,
-                            txn_id,
-                        } => {
-                            // Part of a distributed transaction: execute under the
-                            // shared id and hold. Standalone: commit immediately.
-                            let result = match txn_id {
-                                Some(tid) => {
-                                    manager
-                                        .execute_action_participant(
-                                            &service,
-                                            &stmts,
-                                            &action_env,
-                                            tid,
-                                        )
-                                        .await
-                                }
-                                None => {
-                                    manager
-                                        .execute_action_with_env(&service, &stmts, &action_env)
-                                        .await
-                                }
-                            };
-                            let response = MeerkatMessage::ActionResponse {
-                                request_id,
-                                success: result.is_ok(),
-                                error: result.err().map(|e| e.to_string()),
-                            };
-                            if let Some(net) = manager.network.as_mut() {
-                                net.handle_command(NetworkCommand::SendMessage {
-                                    addr: Address::new(&reply_to),
-                                    msg: response,
-                                })
-                                .await;
-                            }
-                        }
-                        MeerkatMessage::Commit {
+                            value: serde_json::to_string(&val).unwrap_or_default(),
+                        },
+                        Err(e) => MeerkatMessage::LookupError {
                             request_id,
-                            txn_id,
-                            reply_to,
-                        } => {
-                            let result = manager.commit_participant(&txn_id).await;
-                            let response = MeerkatMessage::CommitResponse {
-                                request_id,
-                                success: result.is_ok(),
-                                error: result.err().map(|e| e.to_string()),
-                            };
-                            if let Some(net) = manager.network.as_mut() {
-                                net.handle_command(NetworkCommand::SendMessage {
-                                    addr: Address::new(&reply_to),
-                                    msg: response,
-                                })
-                                .await;
-                            }
+                            error: e.to_string(),
+                        },
+                    };
+                    if let Some(net) = manager.network.as_mut() {
+                        net.handle_command(NetworkCommand::SendMessage {
+                            addr: Address::new(&reply_to),
+                            msg: response,
+                        })
+                        .await;
+                    }
+                }
+                MeerkatMessage::ActionRequest {
+                    request_id,
+                    service,
+                    stmts,
+                    env: action_env,
+                    reply_to,
+                    txn_id,
+                } => {
+                    // Part of a distributed transaction: execute under the
+                    // shared id and hold. Standalone: commit immediately.
+                    let result = match txn_id {
+                        Some(tid) => {
+                            manager
+                                .execute_action_participant(&service, &stmts, &action_env, tid)
+                                .await
                         }
-                        MeerkatMessage::Abort {
-                            request_id,
-                            txn_id,
-                            reply_to,
-                        } => {
-                            manager.abort_participant(&txn_id).await;
-                            if let Some(net) = manager.network.as_mut() {
-                                net.handle_command(NetworkCommand::SendMessage {
-                                    addr: Address::new(&reply_to),
-                                    msg: MeerkatMessage::AbortResponse { request_id },
-                                })
-                                .await;
-                            }
+                        None => {
+                            manager
+                                .execute_action_with_env(&service, &stmts, &action_env)
+                                .await
                         }
-                        _ => {}
+                    };
+                    let response = MeerkatMessage::ActionResponse {
+                        request_id,
+                        success: result.is_ok(),
+                        error: result.err().map(|e| e.to_string()),
+                    };
+                    if let Some(net) = manager.network.as_mut() {
+                        net.handle_command(NetworkCommand::SendMessage {
+                            addr: Address::new(&reply_to),
+                            msg: response,
+                        })
+                        .await;
+                    }
+                }
+                MeerkatMessage::Commit {
+                    request_id,
+                    txn_id,
+                    reply_to,
+                } => {
+                    let result = manager.commit_participant(&txn_id).await;
+                    let response = MeerkatMessage::CommitResponse {
+                        request_id,
+                        success: result.is_ok(),
+                        error: result.err().map(|e| e.to_string()),
+                    };
+                    if let Some(net) = manager.network.as_mut() {
+                        net.handle_command(NetworkCommand::SendMessage {
+                            addr: Address::new(&reply_to),
+                            msg: response,
+                        })
+                        .await;
+                    }
+                }
+                MeerkatMessage::Abort {
+                    request_id,
+                    txn_id,
+                    reply_to,
+                } => {
+                    manager.abort_participant(&txn_id).await;
+                    if let Some(net) = manager.network.as_mut() {
+                        net.handle_command(NetworkCommand::SendMessage {
+                            addr: Address::new(&reply_to),
+                            msg: MeerkatMessage::AbortResponse { request_id },
+                        })
+                        .await;
                     }
                 }
                 _ => {}
@@ -296,7 +287,7 @@ async fn run_client(
             .await
             .map_err(|e| format!("Network error: {}", e))?;
         let listen_ip = if local { "127.0.0.1" } else { "0.0.0.0" };
-        let listen_addr = Address::new(&format!("/ip4/{}/tcp/0", listen_ip));
+        let listen_addr = Address::new(format!("/ip4/{}/tcp/0", listen_ip));
         let reply = n
             .handle_command(NetworkCommand::Listen { addr: listen_addr })
             .await;
@@ -352,10 +343,9 @@ async fn run_client(
                         .parent()
                         .unwrap_or(std::path::Path::new("."));
                     let import_path = base_dir.join(path);
-                    let import_stmts = meerkat_lib::runtime::parser::parser::parse_file(
-                        import_path.to_str().unwrap(),
-                    )
-                    .map_err(|e| format!("Import parse error: {}", e))?;
+                    let import_stmts =
+                        meerkat_lib::runtime::parser::parse_file(import_path.to_str().unwrap())
+                            .map_err(|e| format!("Import parse error: {}", e))?;
                     for import_stmt in &import_stmts {
                         if let Stmt::Service { name, decls } = import_stmt {
                             manager

--- a/meerkat/src/repl.rs
+++ b/meerkat/src/repl.rs
@@ -2,8 +2,8 @@ use std::io::{self, BufRead, IsTerminal, Write};
 
 use meerkat_lib::runtime::ast::{Expr, Stmt, Value};
 use meerkat_lib::runtime::interpreter::{eval, execute, EvalContext, ExecuteEffect};
-use meerkat_lib::runtime::parser::parser::{parse_file, parse_repl};
 use meerkat_lib::runtime::parser::ReplParseResult;
+use meerkat_lib::runtime::parser::{parse_file, parse_repl};
 use meerkat_lib::runtime::Manager;
 
 const PROMPT: &str = "meerkat> ";
@@ -17,11 +17,7 @@ struct Watch {
 }
 
 /// Re-evaluate all watches and print any that have changed.
-async fn check_watches(
-    watches: &mut Vec<Watch>,
-    manager: &mut Manager,
-    repl_env: &[(String, Value)],
-) {
+async fn check_watches(watches: &mut [Watch], manager: &mut Manager, repl_env: &[(String, Value)]) {
     for w in watches.iter_mut() {
         let result = eval(
             &w.expr,
@@ -35,7 +31,7 @@ async fn check_watches(
         .await;
         match result {
             Ok(new_val) => {
-                let changed = w.last.as_ref().map_or(true, |old| old != &new_val);
+                let changed = w.last.as_ref() != Some(&new_val);
                 if changed {
                     match &w.last {
                         None => println!("[watch] {} = {}", w.label, new_val),
@@ -71,7 +67,7 @@ pub async fn run_repl(
         } else {
             "0.0.0.0"
         };
-        let listen_addr = meerkat_lib::net::Address::new(&format!("/ip4/{}/tcp/0", listen_ip));
+        let listen_addr = meerkat_lib::net::Address::new(format!("/ip4/{}/tcp/0", listen_ip));
         n.handle_command(meerkat_lib::net::NetworkCommand::Listen { addr: listen_addr })
             .await;
         manager.network = Some(n);


### PR DESCRIPTION
Addresses Issue #72. A repo-wide update is applied to satisfy `Clippy` using the given command:

```
cargo clippy --locked --workspace --all-targets --all-features -- -D warnings
```

All CI hooks and tests passing.

# Summary

- Resolve existing `Clippy` warnings for entire repo
- Elevate `parser` helpers to top-level
- `&Vec<T>` becomes more flexible `&[T]` everywhere
- Implement `Default` traits for `VarLock` and `MockNetwork`
- Avoid eager format string allocations inside `expect()` calls
- Simplify `Option`, `if-lets`, double-ended iterators
- Uncomment `Clippy` check step to upgrade CI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of number token parsing by validating via an intermediate integer type before casting.

* **Refactor**
  * Simplified parser module exports so parsing helpers are available directly from the parser module.
  * Streamlined network event handling and transaction/event draining flow.
  * Updated analysis and manager APIs to prefer slice-based inputs over vector references.

* **Tests**
  * Simplified integration test event matching while preserving existing assertions.

* **Chores**
  * Enforced Rust Clippy in CI, treating lint warnings as errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->