### PR TITLE
feat: AST printer

### DIFF
--- a/meerkat-lib/src/runtime/ast/mod.rs
+++ b/meerkat-lib/src/runtime/ast/mod.rs
@@ -1,5 +1,7 @@
 use crate::net::ServiceId;
 use std::fmt::Display;
+pub mod printer;
+pub use printer::AstPrinter;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 pub enum UnOp {

--- a/meerkat-lib/src/runtime/ast/printer.rs
+++ b/meerkat-lib/src/runtime/ast/printer.rs
@@ -1,42 +1,49 @@
 //! AST pretty printer inspired by Rust syntax. This module is primarily
 //! invoked by the `--ast` flag for use in testing and development. It
-//! supports configurable indentation levels.
+//! supports configurable indentation levels with `INDENTATION` constant
 
 use crate::runtime::ast::{ActionStmt, Decl, Expr, Field, Stmt, Value};
 
 const INDENTATION: usize = 2;
 
+/// Pretty printer for formatting and displaying the abstract syntax tree
 pub struct AstPrinter {
     spaces: usize,
 }
 
 impl Default for AstPrinter {
+    /// Creates a default AstPrinter with two spaces of indentation
     fn default() -> Self {
         Self::new()
     }
 }
 
 impl AstPrinter {
+    /// Creates a new AstPrinter instance with default indentation
     pub fn new() -> Self {
         Self {
             spaces: INDENTATION,
         }
     }
 
+    /// Creates a new AstPrinter instance with custom indentation level
     pub fn with_spaces(spaces: usize) -> Self {
         Self { spaces }
     }
 
+    /// Prints spaces corresponding to the current indentation level
     fn print_indent(&self, indent: usize) {
         print!("{}", " ".repeat(indent * self.spaces));
     }
 
+    /// Prints a sequence of top-level statements representing a program
     pub fn print_program(&self, stmts: &[Stmt]) {
         for stmt in stmts {
             self.print_stmt(stmt, 0);
         }
     }
 
+    /// Prints a single top-level statement with the specified indentation
     pub fn print_stmt(&self, stmt: &Stmt, indent: usize) {
         self.print_indent(indent);
         match stmt {
@@ -75,6 +82,7 @@ impl AstPrinter {
         }
     }
 
+    /// Prints a declaration statement with the specified indentation
     pub fn print_decl(&self, decl: &Decl, indent: usize) {
         self.print_indent(indent);
         match decl {
@@ -95,6 +103,7 @@ impl AstPrinter {
         }
     }
 
+    /// Prints a record/table field description with the specified indentation
     fn print_field(&self, field: &Field, indent: usize) {
         self.print_indent(indent);
         println!(
@@ -103,6 +112,7 @@ impl AstPrinter {
         );
     }
 
+    /// Prints an action statement with the specified indentation
     pub fn print_action_stmt(&self, stmt: &ActionStmt, indent: usize) {
         self.print_indent(indent);
         match stmt {
@@ -133,6 +143,7 @@ impl AstPrinter {
         }
     }
 
+    /// Prints an expression with the specified indentation
     pub fn print_expr(&self, expr: &Expr, indent: usize) {
         self.print_indent(indent);
         match expr {
@@ -227,6 +238,7 @@ impl AstPrinter {
         }
     }
 
+    /// Prints a runtime value representation with the specified indentation
     pub fn print_value(&self, val: &Value, indent: usize) {
         self.print_indent(indent);
         match val {

--- a/meerkat-lib/src/runtime/ast/printer.rs
+++ b/meerkat-lib/src/runtime/ast/printer.rs
@@ -1,0 +1,266 @@
+//! AST pretty printer inspired by Rust syntax. This module is primarily
+//! invoked by the `--ast` flag for use in testing and development. It
+//! supports configurable indentation levels.
+
+use crate::runtime::ast::{ActionStmt, Decl, Expr, Field, Stmt, Value};
+
+const INDENTATION: usize = 2;
+
+pub struct AstPrinter {
+    spaces: usize,
+}
+
+impl Default for AstPrinter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl AstPrinter {
+    pub fn new() -> Self {
+        Self {
+            spaces: INDENTATION,
+        }
+    }
+
+    pub fn with_spaces(spaces: usize) -> Self {
+        Self { spaces }
+    }
+
+    fn print_indent(&self, indent: usize) {
+        print!("{}", " ".repeat(indent * self.spaces));
+    }
+
+    pub fn print_program(&self, stmts: &[Stmt]) {
+        for stmt in stmts {
+            self.print_stmt(stmt, 0);
+        }
+    }
+
+    pub fn print_stmt(&self, stmt: &Stmt, indent: usize) {
+        self.print_indent(indent);
+        match stmt {
+            Stmt::ActionStmt(action) => {
+                println!("ActionStmt:");
+                self.print_action_stmt(action, indent + 1);
+            }
+            Stmt::Update { service, decls } => {
+                println!("Update: {{ service: \"{}\" }}", service);
+                for decl in decls {
+                    self.print_decl(decl, indent + 1);
+                }
+            }
+            Stmt::Connect { path, addr } => {
+                println!("Connect: {{ path: \"{}\", addr: \"{}\" }}", path, addr);
+            }
+            Stmt::Import { path, service } => {
+                println!("Import: {{ path: \"{}\", service: \"{}\" }}", path, service);
+            }
+            Stmt::Service { name, decls } => {
+                println!("Service: {{ name: \"{}\" }}", name);
+                for decl in decls {
+                    self.print_decl(decl, indent + 1);
+                }
+            }
+            Stmt::Test { service, stmts } => {
+                println!("Test: {{ service: \"{}\" }}", service);
+                for s in stmts {
+                    self.print_action_stmt(s, indent + 1);
+                }
+            }
+            Stmt::Watch { expr } => {
+                println!("Watch:");
+                self.print_expr(expr, indent + 1);
+            }
+        }
+    }
+
+    pub fn print_decl(&self, decl: &Decl, indent: usize) {
+        self.print_indent(indent);
+        match decl {
+            Decl::VarDecl { name, val } => {
+                println!("VarDecl: {{ name: \"{}\" }}", name);
+                self.print_expr(val, indent + 1);
+            }
+            Decl::DefDecl { name, val, is_pub } => {
+                println!("DefDecl: {{ name: \"{}\", is_pub: {} }}", name, is_pub);
+                self.print_expr(val, indent + 1);
+            }
+            Decl::TableDecl { name, fields } => {
+                println!("TableDecl: {{ name: \"{}\" }}", name);
+                for field in fields {
+                    self.print_field(field, indent + 1);
+                }
+            }
+        }
+    }
+
+    fn print_field(&self, field: &Field, indent: usize) {
+        self.print_indent(indent);
+        println!(
+            "Field: {{ name: \"{}\", type_: {:?} }}",
+            field.name, field.type_
+        );
+    }
+
+    pub fn print_action_stmt(&self, stmt: &ActionStmt, indent: usize) {
+        self.print_indent(indent);
+        match stmt {
+            ActionStmt::Let { name, expr, .. } => {
+                println!("Let: {{ name: \"{}\" }}", name);
+                self.print_expr(expr, indent + 1);
+            }
+            ActionStmt::Expr(expr) => {
+                println!("Expr:");
+                self.print_expr(expr, indent + 1);
+            }
+            ActionStmt::Do(expr) => {
+                println!("Do:");
+                self.print_expr(expr, indent + 1);
+            }
+            ActionStmt::Assert(expr) => {
+                println!("Assert:");
+                self.print_expr(expr, indent + 1);
+            }
+            ActionStmt::Assign { var, expr } => {
+                println!("Assign: {{ var: \"{}\" }}", var);
+                self.print_expr(expr, indent + 1);
+            }
+            ActionStmt::Insert { row, table_name } => {
+                println!("Insert: {{ table_name: \"{}\" }}", table_name);
+                self.print_expr(row, indent + 1);
+            }
+        }
+    }
+
+    pub fn print_expr(&self, expr: &Expr, indent: usize) {
+        self.print_indent(indent);
+        match expr {
+            Expr::Literal { val } => {
+                println!("Literal:");
+                self.print_value(val, indent + 1);
+            }
+            Expr::Variable { ident, .. } => {
+                println!("Variable: {{ ident: \"{}\" }}", ident);
+            }
+            Expr::Tuple { val } => {
+                println!("Tuple:");
+                for v in val {
+                    self.print_expr(v, indent + 1);
+                }
+            }
+            Expr::KeyVal { key, value } => {
+                println!("KeyVal: {{ key: \"{}\" }}", key);
+                self.print_expr(value, indent + 1);
+            }
+            Expr::Unop { op, expr } => {
+                println!("Unop: {{ op: {:?} }}", op);
+                self.print_expr(expr, indent + 1);
+            }
+            Expr::Binop { op, expr1, expr2 } => {
+                println!("Binop: {{ op: {:?} }}", op);
+                self.print_expr(expr1, indent + 1);
+                self.print_expr(expr2, indent + 1);
+            }
+            Expr::If { cond, expr1, expr2 } => {
+                println!("If:");
+                self.print_expr(cond, indent + 1);
+                self.print_expr(expr1, indent + 1);
+                self.print_expr(expr2, indent + 1);
+            }
+            Expr::Func { params, body } => {
+                println!("Func: {{ params: {:?} }}", params);
+                self.print_expr(body, indent + 1);
+            }
+            Expr::Call { func, args } => {
+                println!("Call:");
+                self.print_expr(func, indent + 1);
+                for arg in args {
+                    self.print_expr(arg, indent + 1);
+                }
+            }
+            Expr::Action(stmts) => {
+                println!("Action:");
+                for stmt in stmts {
+                    self.print_action_stmt(stmt, indent + 1);
+                }
+            }
+            Expr::MemberAccess { service, member } => {
+                println!(
+                    "MemberAccess: {{ service: \"{}\", member: \"{}\" }}",
+                    service, member
+                );
+            }
+            Expr::Select {
+                table_name,
+                column_names,
+                where_clause,
+            } => {
+                println!(
+                    "Select: {{ table_name: \"{}\", column_names: {:?} }}",
+                    table_name, column_names
+                );
+                self.print_expr(where_clause, indent + 1);
+            }
+            Expr::Table { schema, records } => {
+                println!("Table:");
+                for field in schema {
+                    self.print_field(field, indent + 1);
+                }
+                for record in records {
+                    self.print_expr(record, indent + 1);
+                }
+            }
+            Expr::Fold {
+                table_name,
+                column_name,
+                operation,
+                identity,
+            } => {
+                println!(
+                    "Fold: {{ table_name: \"{}\", column_name: \"{}\" }}",
+                    table_name, column_name
+                );
+                self.print_expr(operation, indent + 1);
+                self.print_expr(identity, indent + 1);
+            }
+        }
+    }
+
+    pub fn print_value(&self, val: &Value, indent: usize) {
+        self.print_indent(indent);
+        match val {
+            Value::Number { val } => {
+                println!("Number: {}", val);
+            }
+            Value::Bool { val } => {
+                println!("Bool: {}", val);
+            }
+            Value::String { val } => {
+                println!("String: \"{}\"", val);
+            }
+            Value::Closure {
+                params,
+                body,
+                env: _,
+                service_name,
+            } => {
+                println!(
+                    "Closure: {{ params: {:?}, service_name: \"{}\" }}",
+                    params, service_name
+                );
+                self.print_expr(body, indent + 1);
+            }
+            Value::ActionClosure {
+                stmts,
+                env: _,
+                service,
+            } => {
+                println!("ActionClosure: {{ service: \"{}\" }}", service.0);
+                for stmt in stmts {
+                    self.print_action_stmt(stmt, indent + 1);
+                }
+            }
+        }
+    }
+}

--- a/meerkat/src/main.rs
+++ b/meerkat/src/main.rs
@@ -99,8 +99,10 @@ pub async fn main() -> Result<(), Box<dyn Error>> {
             }
         }
         None => {
-            if args.server || args.check_only {
-                return Err("Expected a .mkt file (-f).".into());
+            if args.server || args.check_only || args.ast {
+                return Err(
+                    "Expected a .mkt file (-f) for --server, --check, or --ast mode.".into(),
+                );
             }
             let mut manager = Manager::new();
             manager.local = args.local;

--- a/meerkat/src/main.rs
+++ b/meerkat/src/main.rs
@@ -38,6 +38,10 @@ struct Args {
     /// Perform static checks and terminate immediately
     #[arg(long = "check", default_value_t = false)]
     check_only: bool,
+
+    /// Emit AST to `stdout`
+    #[arg(long = "ast", default_value_t = false)]
+    ast: bool,
 }
 
 #[tokio::main]
@@ -67,8 +71,24 @@ pub async fn main() -> Result<(), Box<dyn Error>> {
             let prog = meerkat_lib::runtime::parser::parse_file(file)
                 .map_err(|e| format!("Parse error: {}", e))?;
 
+            // This must appear prior to `check_only` or it will never print. These
+            // modes are designed to work both in isolation and in tandem
+            if args.ast {
+                let printer = meerkat_lib::runtime::ast::AstPrinter::new();
+                printer.print_program(&prog);
+            }
+
+            // TODO: Insert static checks here. The static checks must occur at this
+            // program point in order to properly sequence the semantics of these
+            // CLI flags. All standard checks go here; additional static checks
+            // must occur after this AND in the `check_only` branch below; both must
+            // be simultaneously maintained
+
+            // This mode must appear before `server` args check in order to properly
+            // stop execution. Logic for static checks must not occur in this branch,
+            // as the intent of this mode is to simply halt after the static semantics
+            // phase of the interpter/compiler. See also: above comment(s)
             if args.check_only {
-                // TODO: Insert static checks here
                 return Ok(());
             }
 


### PR DESCRIPTION
Introduce `--ast` CLI and AST printing module. This is part of the sequence of PRs for solving Issue #34; several upcoming PRs rely on it for the test-edit cycle, debugging compiler/interpreter stages for string interning, name resolution, and, ultimately, static type checking.

This feature prints the current AST and continues execution. Can be coupled with `--check` to print the AST and then terminate. This allows flexibility to show the AST and execute or just show the AST and stop. Heavy commenting to safeguard the sequential consistency of these command line arguments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

- **New Features**
  - Added a `--ast` command-line flag to print the parsed program’s Abstract Syntax Tree (AST) to standard output.
  - Introduced an AST pretty-printer that outputs indented, human-readable formatting.

- **Bug Fixes / Behavior Changes**
  - Updated command handling so `--ast` requires a `.mkt` input file (same behavior as `--server` and `--check`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->