### PR TITLE
chore: disable test `multiple_messages` until Issue 73 resolution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,8 +60,9 @@ jobs:
       - name: Check WASM build
         run: cargo check --locked -p meerkat-lib --target wasm32-unknown-unknown --all-features
 
+      # TODO: Re-enable `multiple_message` test after Issue 73 is resolved
       - name: Run tests
-        run: cargo test --locked --workspace --all-features
+        run: cargo test --locked --workspace --all-features -- --skip multiple_message
 
       - name: Smoke test CLI
         run: cargo run --locked -p meerkat -- --help

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -59,9 +59,10 @@ repos:
         files: ^(Cargo\.toml|Cargo\.lock|meerkat-lib/Cargo\.toml|meerkat-lib/.*\.(rs|lalrpop))$
         pass_filenames: false
 
+      # TODO: Re-enable `multiple_message` test after Issue 73 resolved
       - id: cargo-test
         name: cargo test
-        entry: cargo test --locked --workspace --all-features
+        entry: cargo test --locked --workspace --all-features -- --skip multiple_message
         language: system
         files: ^(Cargo\.toml|Cargo\.lock|meerkat(|-lib)/Cargo\.toml|.*\.(rs|lalrpop))$
         pass_filenames: false


### PR DESCRIPTION
As instructed, this PR temporarily disables the test `multiple_messages` until we can make decisions on Issue #73 and related net code design. It will unblock fellow developers and open PRs who are experiencing red CI due to `multiple_messages`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI and pre-commit test configurations to temporarily skip a specific test pending resolution of a known issue.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->