### PR TITLE
fixing an off-by-one error found by coderabbitai

### DIFF
--- a/meerkat-lib/src/runtime/parser/lex.rs
+++ b/meerkat-lib/src/runtime/parser/lex.rs
@@ -20,7 +20,7 @@ fn from_num<'b>(lex: &mut Lexer<'b, Token<'b>>) -> Result<i32, String> {
         Ok(val) => val,
         Err(e) => return Err(format!("Parsing failed with Error {:?}", e)),
     };
-    if out > ((i32::MIN as i64).abs()) {
+    if out > i32::MAX as i64 {
         // All numbers are positive because - is lexed separately
         return Err(format!("Number {} is out of bounds", out));
     }


### PR DESCRIPTION
See discussion in https://github.com/meerkat-lang/meerkat/pull/74 (coderabbitai's review with an actionable comment outside diff range)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected numeric bounds validation during integer parsing to properly reject out-of-range number literals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->