### PR TITLE
feat: string interning

### DIFF
--- a/meerkat-lib/src/error.rs
+++ b/meerkat-lib/src/error.rs
@@ -1,7 +1,36 @@
+//! Error types for the Meerkat library
+
+use std::fmt;
 use std::result;
 
+/// Result type alias using our library-specific Error type
 pub type Result<T> = result::Result<T, Error>;
 
+/// Represents errors that can occur within the Meerkat library
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Error {
+    /// A generic error message
     Message(String),
+    /// Error indicating a zero-trust boundary limit was exceeded
+    LimitExceeded(String),
 }
+
+impl fmt::Display for Error {
+    /// Format the error for user display
+    ///
+    /// Args:
+    ///     `f` (`&mut fmt::Formatter<'_>`): The formatter target
+    ///
+    /// Returns:
+    ///     `fmt::Result`: The result of the formatting operation
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Error::Message(msg) => write!(f, "{}", msg),
+            Error::LimitExceeded(msg) => {
+                write!(f, "Limit exceeded: {}", msg)
+            }
+        }
+    }
+}
+
+impl std::error::Error for Error {}

--- a/meerkat-lib/src/net/ast.rs
+++ b/meerkat-lib/src/net/ast.rs
@@ -12,7 +12,7 @@ pub struct NetField {
     /// The name of the field
     pub name: String,
     /// The `NetDataType` of the field
-    pub type_: NetDataType,
+    pub ty: NetDataType,
 }
 
 /// Network representation of an action statement

--- a/meerkat-lib/src/net/ast.rs
+++ b/meerkat-lib/src/net/ast.rs
@@ -7,20 +7,17 @@ use crate::net::ServiceNetId;
 use serde::{Deserialize, Serialize};
 
 /// Network representation of a field definition
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct NetField {
     pub name: String,
     pub ty: NetDataType,
 }
 
 /// Network representation of an action statement
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum NetActionStmt {
     /// Bind a value to a local name using `let`
-    Let {
-        name: String,
-        expr: NetExpr,
-    },
+    Let { name: String, expr: NetExpr },
     /// A standalone expression statement
     Expr(NetExpr),
     /// A `do` statement to evaluate an expression for side effects
@@ -28,32 +25,20 @@ pub enum NetActionStmt {
     /// An `assert` statement to check invariants
     Assert(NetExpr),
     /// Re-assign a value to an existing variable
-    Assign {
-        name: String,
-        expr: NetExpr,
-    },
+    Assign { name: String, expr: NetExpr },
     /// Insert a record into a table
-    Insert {
-        row: NetExpr,
-        table_name: String,
-    },
+    Insert { row: NetExpr, table_name: String },
 }
 
 /// Network representation of a value
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum NetValue {
     /// A numeric integer value
-    Number {
-        val: i32,
-    },
+    Number { val: i32 },
     /// A boolean value
-    Bool {
-        val: bool,
-    },
+    Bool { val: bool },
     /// A `String` literal value
-    String {
-        val: String,
-    },
+    String { val: String },
     /// A standard closure value with environment
     Closure {
         params: Vec<String>,
@@ -70,30 +55,18 @@ pub enum NetValue {
 }
 
 /// Network representation of an expression
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum NetExpr {
     /// Literal constant value
-    Literal {
-        val: NetValue,
-    },
+    Literal { val: NetValue },
     /// Variable reference
-    Variable {
-        name: String,
-    },
+    Variable { name: String },
     /// Tuple construct containing elements
-    Tuple {
-        val: Vec<NetExpr>,
-    },
+    Tuple { val: Vec<NetExpr> },
     /// Key-value attribute binding
-    KeyVal {
-        name: String,
-        value: Box<NetExpr>,
-    },
+    KeyVal { name: String, value: Box<NetExpr> },
     /// Unary operator application
-    Unop {
-        op: NetUnOp,
-        expr: Box<NetExpr>,
-    },
+    Unop { op: NetUnOp, expr: Box<NetExpr> },
     /// Binary operator application
     Binop {
         op: NetBinOp,
@@ -147,7 +120,7 @@ pub enum NetExpr {
 ///
 /// This enum defines the serialized unary operators mapped from the
 /// runtime counterparts for transmission over the network
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 pub enum NetUnOp {
     /// Negation operator
     Neg,
@@ -159,7 +132,7 @@ pub enum NetUnOp {
 ///
 /// This enum defines the serialized binary operators mapped from the
 /// runtime counterparts for transmission over the network
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 pub enum NetBinOp {
     /// Addition operator
     Add,
@@ -185,7 +158,7 @@ pub enum NetBinOp {
 ///
 /// This enum defines the serialized data types mapped from the
 /// runtime counterparts for transmission over the network
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum NetDataType {
     /// String data type representation
     String,

--- a/meerkat-lib/src/net/ast.rs
+++ b/meerkat-lib/src/net/ast.rs
@@ -1,0 +1,191 @@
+//! Network representation for `AST` elements
+//!
+//! This module defines the serialized equivalents of the runtime `AST`
+//! types, substituting `Symbol` identifiers with raw `String` names
+
+use crate::net::ServiceNetId;
+use crate::runtime::ast::{BinOp, DataType, UnOp};
+use serde::{Deserialize, Serialize};
+
+/// Network representation of a field definition
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct NetField {
+    /// The name of the field
+    pub name: String,
+    /// The `DataType` of the field
+    pub type_: DataType,
+}
+
+/// Network representation of an action statement
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum NetActionStmt {
+    /// Bind a value to a local name using `let`
+    Let {
+        /// The name to bind
+        name: String,
+        /// The `NetExpr` to bind
+        expr: NetExpr,
+    },
+    /// A standalone expression statement
+    Expr(NetExpr),
+    /// A `do` statement to evaluate an expression for side effects
+    Do(NetExpr),
+    /// An `assert` statement to check invariants
+    Assert(NetExpr),
+    /// Re-assign a value to an existing variable
+    Assign {
+        /// The variable name
+        name: String,
+        /// The `NetExpr` to evaluate
+        expr: NetExpr,
+    },
+    /// Insert a record into a table
+    Insert {
+        /// The `NetExpr` representing the row
+        row: NetExpr,
+        /// The destination table name
+        table_name: String,
+    },
+}
+
+/// Network representation of a value
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum NetValue {
+    /// A numeric integer value
+    Number {
+        /// The integer value
+        val: i32,
+    },
+    /// A boolean value
+    Bool {
+        /// The boolean value
+        val: bool,
+    },
+    /// A `String` literal value
+    String {
+        /// The string content
+        val: String,
+    },
+    /// A standard closure value with environment
+    Closure {
+        /// Parameter names
+        params: Vec<String>,
+        /// The closure body expression
+        body: Box<NetExpr>,
+        /// The captured environment bindings
+        env: Vec<(String, NetValue)>,
+        /// The service scope name
+        service_name: String,
+    },
+    /// An action closure value with environment and network ID
+    ActionClosure {
+        /// Action statements
+        stmts: Vec<NetActionStmt>,
+        /// The captured environment bindings
+        env: Vec<(String, NetValue)>,
+        /// The net-addressable service identifier `ServiceNetId`
+        service_net_id: ServiceNetId,
+    },
+}
+
+/// Network representation of an expression
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum NetExpr {
+    /// Literal constant value
+    Literal {
+        /// The constant `NetValue`
+        val: NetValue,
+    },
+    /// Variable reference
+    Variable {
+        /// The variable name
+        name: String,
+    },
+    /// Tuple construct containing elements
+    Tuple {
+        /// Inner elements
+        val: Vec<NetExpr>,
+    },
+    /// Key-value attribute binding
+    KeyVal {
+        /// The key name
+        name: String,
+        /// The value expression
+        value: Box<NetExpr>,
+    },
+    /// Unary operator application
+    Unop {
+        /// The `UnOp` operator
+        op: UnOp,
+        /// The operand expression
+        expr: Box<NetExpr>,
+    },
+    /// Binary operator application
+    Binop {
+        /// The `BinOp` operator
+        op: BinOp,
+        /// The first operand
+        expr1: Box<NetExpr>,
+        /// The second operand
+        expr2: Box<NetExpr>,
+    },
+    /// Conditional branching expression
+    If {
+        /// The condition expression
+        cond: Box<NetExpr>,
+        /// The true branch
+        expr1: Box<NetExpr>,
+        /// The false branch
+        expr2: Box<NetExpr>,
+    },
+    /// Anonymous function construct
+    Func {
+        /// Parameter names
+        params: Vec<String>,
+        /// The function body
+        body: Box<NetExpr>,
+    },
+    /// Function call expression
+    Call {
+        /// The function being called
+        func: Box<NetExpr>,
+        /// Arguments passed to the call
+        args: Vec<NetExpr>,
+    },
+    /// Embedded action statement block
+    Action(Vec<NetActionStmt>),
+    /// Accessing a remote service member
+    MemberAccess {
+        /// The remote service name
+        service_name: String,
+        /// The member name
+        member_name: String,
+    },
+    /// Data selection query
+    Select {
+        /// Source table name
+        table_name: String,
+        /// Target column names
+        column_names: Vec<String>,
+        /// Query filter condition
+        where_clause: Box<NetExpr>,
+    },
+    /// Inline table structure
+    Table {
+        /// Table schema fields
+        schema: Vec<NetField>,
+        /// Record entries
+        records: Vec<NetExpr>,
+    },
+    /// Fold aggregation construct
+    Fold {
+        /// Source table name
+        table_name: String,
+        /// Target column name
+        column_name: String,
+        /// Aggregator operation
+        operation: Box<NetExpr>,
+        /// Base accumulator identity
+        identity: Box<NetExpr>,
+    },
+}

--- a/meerkat-lib/src/net/ast.rs
+++ b/meerkat-lib/src/net/ast.rs
@@ -9,9 +9,7 @@ use serde::{Deserialize, Serialize};
 /// Network representation of a field definition
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct NetField {
-    /// The name of the field
     pub name: String,
-    /// The `NetDataType` of the field
     pub ty: NetDataType,
 }
 
@@ -20,9 +18,7 @@ pub struct NetField {
 pub enum NetActionStmt {
     /// Bind a value to a local name using `let`
     Let {
-        /// The name to bind
         name: String,
-        /// The `NetExpr` to bind
         expr: NetExpr,
     },
     /// A standalone expression statement
@@ -33,16 +29,12 @@ pub enum NetActionStmt {
     Assert(NetExpr),
     /// Re-assign a value to an existing variable
     Assign {
-        /// The variable name
         name: String,
-        /// The `NetExpr` to evaluate
         expr: NetExpr,
     },
     /// Insert a record into a table
     Insert {
-        /// The `NetExpr` representing the row
         row: NetExpr,
-        /// The destination table name
         table_name: String,
     },
 }
@@ -52,37 +44,27 @@ pub enum NetActionStmt {
 pub enum NetValue {
     /// A numeric integer value
     Number {
-        /// The integer value
         val: i32,
     },
     /// A boolean value
     Bool {
-        /// The boolean value
         val: bool,
     },
     /// A `String` literal value
     String {
-        /// The string content
         val: String,
     },
     /// A standard closure value with environment
     Closure {
-        /// Parameter names
         params: Vec<String>,
-        /// The closure body expression
         body: Box<NetExpr>,
-        /// The captured environment bindings
         env: Vec<(String, NetValue)>,
-        /// The service scope name
         service_name: String,
     },
     /// An action closure value with environment and network ID
     ActionClosure {
-        /// Action statements
         stmts: Vec<NetActionStmt>,
-        /// The captured environment bindings
         env: Vec<(String, NetValue)>,
-        /// The net-addressable service identifier `ServiceNetId`
         service_net_id: ServiceNetId,
     },
 }
@@ -92,99 +74,71 @@ pub enum NetValue {
 pub enum NetExpr {
     /// Literal constant value
     Literal {
-        /// The constant `NetValue`
         val: NetValue,
     },
     /// Variable reference
     Variable {
-        /// The variable name
         name: String,
     },
     /// Tuple construct containing elements
     Tuple {
-        /// Inner elements
         val: Vec<NetExpr>,
     },
     /// Key-value attribute binding
     KeyVal {
-        /// The key name
         name: String,
-        /// The value expression
         value: Box<NetExpr>,
     },
     /// Unary operator application
     Unop {
-        /// The `NetUnOp` operator
         op: NetUnOp,
-        /// The operand expression
         expr: Box<NetExpr>,
     },
     /// Binary operator application
     Binop {
-        /// The `NetBinOp` operator
         op: NetBinOp,
-        /// The first operand
         expr1: Box<NetExpr>,
-        /// The second operand
         expr2: Box<NetExpr>,
     },
     /// Conditional branching expression
     If {
-        /// The condition expression
         cond: Box<NetExpr>,
-        /// The true branch
         expr1: Box<NetExpr>,
-        /// The false branch
         expr2: Box<NetExpr>,
     },
     /// Anonymous function construct
     Func {
-        /// Parameter names
         params: Vec<String>,
-        /// The function body
         body: Box<NetExpr>,
     },
     /// Function call expression
     Call {
-        /// The function being called
         func: Box<NetExpr>,
-        /// Arguments passed to the call
         args: Vec<NetExpr>,
     },
     /// Embedded action statement block
     Action(Vec<NetActionStmt>),
     /// Accessing a remote service member
     MemberAccess {
-        /// The remote service name
         service_name: String,
-        /// The member name
         member_name: String,
     },
     /// Data selection query
     Select {
-        /// Source table name
         table_name: String,
-        /// Target column names
         column_names: Vec<String>,
-        /// Query filter condition
         where_clause: Box<NetExpr>,
     },
     /// Inline table structure
     Table {
-        /// Table schema fields
         schema: Vec<NetField>,
-        /// Record entries
         records: Vec<NetExpr>,
     },
     /// Fold aggregation construct
     Fold {
-        /// Source table name
         table_name: String,
-        /// Target column name
         column_name: String,
-        /// Aggregator operation
         operation: Box<NetExpr>,
-        /// Base accumulator identity
         identity: Box<NetExpr>,
     },
 }

--- a/meerkat-lib/src/net/ast.rs
+++ b/meerkat-lib/src/net/ast.rs
@@ -4,7 +4,6 @@
 //! types, substituting `Symbol` identifiers with raw `String` names
 
 use crate::net::ServiceNetId;
-use crate::runtime::ast::{BinOp, DataType, UnOp};
 use serde::{Deserialize, Serialize};
 
 /// Network representation of a field definition
@@ -12,8 +11,8 @@ use serde::{Deserialize, Serialize};
 pub struct NetField {
     /// The name of the field
     pub name: String,
-    /// The `DataType` of the field
-    pub type_: DataType,
+    /// The `NetDataType` of the field
+    pub type_: NetDataType,
 }
 
 /// Network representation of an action statement
@@ -115,15 +114,15 @@ pub enum NetExpr {
     },
     /// Unary operator application
     Unop {
-        /// The `UnOp` operator
-        op: UnOp,
+        /// The `NetUnOp` operator
+        op: NetUnOp,
         /// The operand expression
         expr: Box<NetExpr>,
     },
     /// Binary operator application
     Binop {
-        /// The `BinOp` operator
-        op: BinOp,
+        /// The `NetBinOp` operator
+        op: NetBinOp,
         /// The first operand
         expr1: Box<NetExpr>,
         /// The second operand
@@ -188,4 +187,56 @@ pub enum NetExpr {
         /// Base accumulator identity
         identity: Box<NetExpr>,
     },
+}
+
+/// Network representation of a unary operator
+///
+/// This enum defines the serialized unary operators mapped from the
+/// runtime counterparts for transmission over the network
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum NetUnOp {
+    /// Negation operator
+    Neg,
+    /// Logical negation operator
+    Not,
+}
+
+/// Network representation of a binary operator
+///
+/// This enum defines the serialized binary operators mapped from the
+/// runtime counterparts for transmission over the network
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum NetBinOp {
+    /// Addition operator
+    Add,
+    /// Subtraction operator
+    Sub,
+    /// Multiplication operator
+    Mul,
+    /// Division operator
+    Div,
+    /// Equality comparison operator
+    Eq,
+    /// Less-than comparison operator
+    Lt,
+    /// Greater-than comparison operator
+    Gt,
+    /// Logical conjunction operator
+    And,
+    /// Logical disjunction operator
+    Or,
+}
+
+/// Network representation of a data type
+///
+/// This enum defines the serialized data types mapped from the
+/// runtime counterparts for transmission over the network
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum NetDataType {
+    /// String data type representation
+    String,
+    /// Number data type representation
+    Number,
+    /// Boolean data type representation
+    Bool,
 }

--- a/meerkat-lib/src/net/codec.rs
+++ b/meerkat-lib/src/net/codec.rs
@@ -1,0 +1,442 @@
+//! Network codec for `AST` elements
+//!
+//! Provides encoding and decoding functions to map between the native
+//! `AST` types and the serialized network representation variants
+
+use crate::net::ast::{NetActionStmt, NetExpr, NetField, NetValue};
+use crate::runtime::ast::{ActionStmt, Expr, Field, Value};
+use crate::runtime::interner::Interner;
+
+/// Encode a runtime `Value` into a network representation
+///
+/// Args:
+///     val (`&Value`): The runtime `Value` to encode
+///     interner (`&Interner`): The `Interner` for symbol lookup
+///
+/// Returns:
+///     `NetValue`: The encoded `NetValue` network representation
+pub fn encode_value(val: &Value, interner: &Interner) -> NetValue {
+    match val {
+        Value::Number { val } => NetValue::Number { val: *val },
+        Value::Bool { val } => NetValue::Bool { val: *val },
+        Value::String { val } => NetValue::String { val: val.clone() },
+        Value::Closure {
+            params,
+            body,
+            env,
+            service_name,
+        } => {
+            let encoded_params = params
+                .iter()
+                .map(|p| interner.get(*p).to_string())
+                .collect();
+            let encoded_body = Box::new(encode_expr(body, interner));
+            let encoded_env = env
+                .iter()
+                .map(|(k, v)| (interner.get(*k).to_string(), encode_value(v, interner)))
+                .collect();
+            let encoded_service = interner.get(*service_name).to_string();
+            NetValue::Closure {
+                params: encoded_params,
+                body: encoded_body,
+                env: encoded_env,
+                service_name: encoded_service,
+            }
+        }
+        Value::ActionClosure {
+            stmts,
+            env,
+            service_net_id,
+        } => {
+            let encoded_stmts = stmts
+                .iter()
+                .map(|s| encode_action_stmt(s, interner))
+                .collect();
+            let encoded_env = env
+                .iter()
+                .map(|(k, v)| (interner.get(*k).to_string(), encode_value(v, interner)))
+                .collect();
+            NetValue::ActionClosure {
+                stmts: encoded_stmts,
+                env: encoded_env,
+                service_net_id: service_net_id.clone(),
+            }
+        }
+    }
+}
+
+/// Decode a network `NetValue` representation into a runtime `Value`
+///
+/// Args:
+///     val (`NetValue`): The network `NetValue` to decode
+///     interner (`&mut Interner`): The `Interner` for symbol creation
+///
+/// Returns:
+///     `Value`: The decoded runtime `Value`
+pub fn decode_value(val: NetValue, interner: &mut Interner) -> Value {
+    match val {
+        NetValue::Number { val } => Value::Number { val },
+        NetValue::Bool { val } => Value::Bool { val },
+        NetValue::String { val } => Value::String { val },
+        NetValue::Closure {
+            params,
+            body,
+            env,
+            service_name,
+        } => {
+            let decoded_params = params.into_iter().map(|p| interner.insert(&p)).collect();
+            let decoded_body = Box::new(decode_expr(*body, interner));
+            let decoded_env = env
+                .into_iter()
+                .map(|(k, v)| (interner.insert(&k), decode_value(v, interner)))
+                .collect();
+            let decoded_service = interner.insert(&service_name);
+            Value::Closure {
+                params: decoded_params,
+                body: decoded_body,
+                env: decoded_env,
+                service_name: decoded_service,
+            }
+        }
+        NetValue::ActionClosure {
+            stmts,
+            env,
+            service_net_id,
+        } => {
+            let decoded_stmts = stmts
+                .into_iter()
+                .map(|s| decode_action_stmt(s, interner))
+                .collect();
+            let decoded_env = env
+                .into_iter()
+                .map(|(k, v)| (interner.insert(&k), decode_value(v, interner)))
+                .collect();
+            Value::ActionClosure {
+                stmts: decoded_stmts,
+                env: decoded_env,
+                service_net_id,
+            }
+        }
+    }
+}
+
+/// Encode a runtime `Expr` into a network representation
+///
+/// Args:
+///     expr (`&Expr`): The runtime `Expr` to encode
+///     interner (`&Interner`): The `Interner` for symbol lookup
+///
+/// Returns:
+///     `NetExpr`: The encoded `NetExpr` network representation
+pub fn encode_expr(expr: &Expr, interner: &Interner) -> NetExpr {
+    match expr {
+        Expr::Literal { val } => NetExpr::Literal {
+            val: encode_value(val, interner),
+        },
+        Expr::Variable { name } => NetExpr::Variable {
+            name: interner.get(*name).to_string(),
+        },
+        Expr::Tuple { val } => NetExpr::Tuple {
+            val: val.iter().map(|e| encode_expr(e, interner)).collect(),
+        },
+        Expr::KeyVal { name, value } => NetExpr::KeyVal {
+            name: interner.get(*name).to_string(),
+            value: Box::new(encode_expr(value, interner)),
+        },
+        Expr::Unop { op, expr } => NetExpr::Unop {
+            op: *op,
+            expr: Box::new(encode_expr(expr, interner)),
+        },
+        Expr::Binop { op, expr1, expr2 } => NetExpr::Binop {
+            op: *op,
+            expr1: Box::new(encode_expr(expr1, interner)),
+            expr2: Box::new(encode_expr(expr2, interner)),
+        },
+        Expr::If { cond, expr1, expr2 } => NetExpr::If {
+            cond: Box::new(encode_expr(cond, interner)),
+            expr1: Box::new(encode_expr(expr1, interner)),
+            expr2: Box::new(encode_expr(expr2, interner)),
+        },
+        Expr::Func { params, body } => NetExpr::Func {
+            params: params
+                .iter()
+                .map(|p| interner.get(*p).to_string())
+                .collect(),
+            body: Box::new(encode_expr(body, interner)),
+        },
+        Expr::Call { func, args } => NetExpr::Call {
+            func: Box::new(encode_expr(func, interner)),
+            args: args.iter().map(|e| encode_expr(e, interner)).collect(),
+        },
+        Expr::Action(stmts) => NetExpr::Action(
+            stmts
+                .iter()
+                .map(|s| encode_action_stmt(s, interner))
+                .collect(),
+        ),
+        Expr::MemberAccess {
+            service_name,
+            member_name,
+        } => NetExpr::MemberAccess {
+            service_name: interner.get(*service_name).to_string(),
+            member_name: interner.get(*member_name).to_string(),
+        },
+        Expr::Select {
+            table_name,
+            column_names,
+            where_clause,
+        } => NetExpr::Select {
+            table_name: interner.get(*table_name).to_string(),
+            column_names: column_names
+                .iter()
+                .map(|c| interner.get(*c).to_string())
+                .collect(),
+            where_clause: Box::new(encode_expr(where_clause, interner)),
+        },
+        Expr::Table { schema, records } => NetExpr::Table {
+            schema: schema.iter().map(|f| encode_field(f, interner)).collect(),
+            records: records.iter().map(|r| encode_expr(r, interner)).collect(),
+        },
+        Expr::Fold {
+            table_name,
+            column_name,
+            operation,
+            identity,
+        } => NetExpr::Fold {
+            table_name: interner.get(*table_name).to_string(),
+            column_name: interner.get(*column_name).to_string(),
+            operation: Box::new(encode_expr(operation, interner)),
+            identity: Box::new(encode_expr(identity, interner)),
+        },
+    }
+}
+
+/// Decode a network `NetExpr` representation into a runtime `Expr`
+///
+/// Args:
+///     expr (`NetExpr`): The network `NetExpr` to decode
+///     interner (`&mut Interner`): The `Interner` for symbol creation
+///
+/// Returns:
+///     `Expr`: The decoded runtime `Expr`
+pub fn decode_expr(expr: NetExpr, interner: &mut Interner) -> Expr {
+    match expr {
+        NetExpr::Literal { val } => Expr::Literal {
+            val: decode_value(val, interner),
+        },
+        NetExpr::Variable { name } => Expr::Variable {
+            name: interner.insert(&name),
+        },
+        NetExpr::Tuple { val } => Expr::Tuple {
+            val: val.into_iter().map(|e| decode_expr(e, interner)).collect(),
+        },
+        NetExpr::KeyVal { name, value } => Expr::KeyVal {
+            name: interner.insert(&name),
+            value: Box::new(decode_expr(*value, interner)),
+        },
+        NetExpr::Unop { op, expr } => Expr::Unop {
+            op,
+            expr: Box::new(decode_expr(*expr, interner)),
+        },
+        NetExpr::Binop { op, expr1, expr2 } => Expr::Binop {
+            op,
+            expr1: Box::new(decode_expr(*expr1, interner)),
+            expr2: Box::new(decode_expr(*expr2, interner)),
+        },
+        NetExpr::If { cond, expr1, expr2 } => Expr::If {
+            cond: Box::new(decode_expr(*cond, interner)),
+            expr1: Box::new(decode_expr(*expr1, interner)),
+            expr2: Box::new(decode_expr(*expr2, interner)),
+        },
+        NetExpr::Func { params, body } => Expr::Func {
+            params: params.into_iter().map(|p| interner.insert(&p)).collect(),
+            body: Box::new(decode_expr(*body, interner)),
+        },
+        NetExpr::Call { func, args } => Expr::Call {
+            func: Box::new(decode_expr(*func, interner)),
+            args: args.into_iter().map(|e| decode_expr(e, interner)).collect(),
+        },
+        NetExpr::Action(stmts) => Expr::Action(
+            stmts
+                .into_iter()
+                .map(|s| decode_action_stmt(s, interner))
+                .collect(),
+        ),
+        NetExpr::MemberAccess {
+            service_name,
+            member_name,
+        } => Expr::MemberAccess {
+            service_name: interner.insert(&service_name),
+            member_name: interner.insert(&member_name),
+        },
+        NetExpr::Select {
+            table_name,
+            column_names,
+            where_clause,
+        } => Expr::Select {
+            table_name: interner.insert(&table_name),
+            column_names: column_names
+                .into_iter()
+                .map(|c| interner.insert(&c))
+                .collect(),
+            where_clause: Box::new(decode_expr(*where_clause, interner)),
+        },
+        NetExpr::Table { schema, records } => Expr::Table {
+            schema: schema
+                .into_iter()
+                .map(|f| decode_field(f, interner))
+                .collect(),
+            records: records
+                .into_iter()
+                .map(|r| decode_expr(r, interner))
+                .collect(),
+        },
+        NetExpr::Fold {
+            table_name,
+            column_name,
+            operation,
+            identity,
+        } => Expr::Fold {
+            table_name: interner.insert(&table_name),
+            column_name: interner.insert(&column_name),
+            operation: Box::new(decode_expr(*operation, interner)),
+            identity: Box::new(decode_expr(*identity, interner)),
+        },
+    }
+}
+
+/// Encode a runtime `ActionStmt` into a network representation
+///
+/// Args:
+///     stmt (`&ActionStmt`): The runtime `ActionStmt` to encode
+///     interner (`&Interner`): The `Interner` for symbol lookup
+///
+/// Returns:
+///     `NetActionStmt`: The encoded `NetActionStmt` network representation
+pub fn encode_action_stmt(stmt: &ActionStmt, interner: &Interner) -> NetActionStmt {
+    match stmt {
+        ActionStmt::Let { name, expr } => NetActionStmt::Let {
+            name: interner.get(*name).to_string(),
+            expr: encode_expr(expr, interner),
+        },
+        ActionStmt::Expr(expr) => NetActionStmt::Expr(encode_expr(expr, interner)),
+        ActionStmt::Do(expr) => NetActionStmt::Do(encode_expr(expr, interner)),
+        ActionStmt::Assert(expr) => NetActionStmt::Assert(encode_expr(expr, interner)),
+        ActionStmt::Assign { name, expr } => NetActionStmt::Assign {
+            name: interner.get(*name).to_string(),
+            expr: encode_expr(expr, interner),
+        },
+        ActionStmt::Insert { row, table_name } => NetActionStmt::Insert {
+            row: encode_expr(row, interner),
+            table_name: interner.get(*table_name).to_string(),
+        },
+    }
+}
+
+/// Decode a network `NetActionStmt` into a runtime `ActionStmt`
+///
+/// Args:
+///     stmt (`NetActionStmt`): The network `NetActionStmt` to decode
+///     interner (`&mut Interner`): The `Interner` for symbol creation
+///
+/// Returns:
+///     `ActionStmt`: The decoded runtime `ActionStmt`
+pub fn decode_action_stmt(stmt: NetActionStmt, interner: &mut Interner) -> ActionStmt {
+    match stmt {
+        NetActionStmt::Let { name, expr } => ActionStmt::Let {
+            name: interner.insert(&name),
+            expr: decode_expr(expr, interner),
+        },
+        NetActionStmt::Expr(expr) => ActionStmt::Expr(decode_expr(expr, interner)),
+        NetActionStmt::Do(expr) => ActionStmt::Do(decode_expr(expr, interner)),
+        NetActionStmt::Assert(expr) => ActionStmt::Assert(decode_expr(expr, interner)),
+        NetActionStmt::Assign { name, expr } => ActionStmt::Assign {
+            name: interner.insert(&name),
+            expr: decode_expr(expr, interner),
+        },
+        NetActionStmt::Insert { row, table_name } => ActionStmt::Insert {
+            row: decode_expr(row, interner),
+            table_name: interner.insert(&table_name),
+        },
+    }
+}
+
+/// Encode a runtime `Field` into a network representation
+///
+/// Args:
+///     field (`&Field`): The runtime `Field` to encode
+///     interner (`&Interner`): The `Interner` for symbol lookup
+///
+/// Returns:
+///     `NetField`: The encoded `NetField` network representation
+pub fn encode_field(field: &Field, interner: &Interner) -> NetField {
+    NetField {
+        name: interner.get(field.name).to_string(),
+        type_: field.type_.clone(),
+    }
+}
+
+/// Decode a network `NetField` representation into a runtime `Field`
+///
+/// Args:
+///     field (`NetField`): The network `NetField` to decode
+///     interner (`&mut Interner`): The `Interner` for symbol creation
+///
+/// Returns:
+///     `Field`: The decoded runtime `Field`
+pub fn decode_field(field: NetField, interner: &mut Interner) -> Field {
+    Field {
+        name: interner.insert(&field.name),
+        type_: field.type_,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::net::ServiceNetId;
+
+    /// Verify round-trip encoding, serialization, deserialization, and decoding of `AST` types
+    #[test]
+    fn test_value_codec_roundtrip() {
+        let mut interner_orig = Interner::new();
+        let service_net_id = ServiceNetId::new("test_service");
+
+        let var_x = interner_orig.insert("x");
+        let tbl_t = interner_orig.insert("t");
+
+        let stmt1 = ActionStmt::Let {
+            name: var_x,
+            expr: Expr::Literal {
+                val: Value::Number { val: 42 },
+            },
+        };
+        let stmt2 = ActionStmt::Insert {
+            row: Expr::Variable { name: var_x },
+            table_name: tbl_t,
+        };
+
+        let env_var = interner_orig.insert("y");
+        let env = vec![(env_var, Value::Bool { val: true })];
+
+        let original_value = Value::ActionClosure {
+            stmts: vec![stmt1, stmt2],
+            env,
+            service_net_id,
+        };
+
+        let orig_str = format!("{}", original_value);
+
+        let encoded = encode_value(&original_value, &interner_orig);
+
+        let json_str = serde_json::to_string(&encoded).unwrap();
+        let decoded_net_val: NetValue = serde_json::from_str(&json_str).unwrap();
+
+        let mut interner_new = Interner::new();
+        let decoded_value = decode_value(decoded_net_val, &mut interner_new);
+
+        let new_str = format!("{}", decoded_value);
+
+        assert_eq!(orig_str, new_str);
+    }
+}

--- a/meerkat-lib/src/net/codec.rs
+++ b/meerkat-lib/src/net/codec.rs
@@ -539,4 +539,336 @@ mod tests {
 
         assert_eq!(orig_str, new_str);
     }
+
+    /// Verify round-trip encoding and decoding for
+    /// Value::String and Value::Closure
+    #[test]
+    fn test_value_codec_exhaustive() {
+        let mut interner_orig = Interner::new();
+        let param_name = interner_orig.insert("x");
+        let body = Expr::Literal {
+            val: Value::String {
+                val: "hello".to_string(),
+            },
+        };
+        let env_key = interner_orig.insert("y");
+        let env_val = Value::Number { val: 123 };
+        let service = interner_orig.insert("my_service");
+
+        let original_value = Value::Closure {
+            params: vec![param_name],
+            body: Box::new(body),
+            env: vec![(env_key, env_val)],
+            service_name: service,
+        };
+
+        let encoded = encode_value(&original_value, &interner_orig);
+        let mut interner_new = Interner::new();
+        let decoded = decode_value(encoded, &mut interner_new);
+
+        assert_eq!(format!("{}", original_value), format!("{}", decoded));
+    }
+
+    /// Verify round-trip encoding and decoding for Tuple,
+    /// KeyVal, Unop, Binop, and If expressions
+    #[test]
+    fn test_expr_codec_exhaustive_1() {
+        let run_expr_test = |expr: &Expr, interner_orig: &Interner| {
+            let encoded = encode_expr(expr, interner_orig);
+            let mut interner_new = Interner::new();
+            let decoded = decode_expr(encoded, &mut interner_new);
+            assert_eq!(format!("{}", expr), format!("{}", decoded));
+        };
+
+        // 1. Tuple
+        let interner = Interner::new();
+        let tuple_expr = Expr::Tuple {
+            val: vec![
+                Expr::Literal {
+                    val: Value::Number { val: 1 },
+                },
+                Expr::Literal {
+                    val: Value::Number { val: 2 },
+                },
+            ],
+        };
+        run_expr_test(&tuple_expr, &interner);
+
+        // 2. KeyVal
+        let mut interner = Interner::new();
+        let name_kv = interner.insert("kv_name");
+        let key_val_expr = Expr::KeyVal {
+            name: name_kv,
+            value: Box::new(Expr::Literal {
+                val: Value::Number { val: 3 },
+            }),
+        };
+        run_expr_test(&key_val_expr, &interner);
+
+        // 3. Unop (Neg, Not)
+        for op in &[UnOp::Neg, UnOp::Not] {
+            let interner = Interner::new();
+            let unop_expr = Expr::Unop {
+                op: *op,
+                expr: Box::new(Expr::Literal {
+                    val: Value::Bool { val: true },
+                }),
+            };
+            run_expr_test(&unop_expr, &interner);
+        }
+
+        // 4. Binop
+        let binops = &[
+            BinOp::Add,
+            BinOp::Sub,
+            BinOp::Mul,
+            BinOp::Div,
+            BinOp::Eq,
+            BinOp::Lt,
+            BinOp::Gt,
+            BinOp::And,
+            BinOp::Or,
+        ];
+        for op in binops {
+            let interner = Interner::new();
+            let binop_expr = Expr::Binop {
+                op: *op,
+                expr1: Box::new(Expr::Literal {
+                    val: Value::Number { val: 5 },
+                }),
+                expr2: Box::new(Expr::Literal {
+                    val: Value::Number { val: 6 },
+                }),
+            };
+            run_expr_test(&binop_expr, &interner);
+        }
+
+        // 5. If
+        let interner = Interner::new();
+        let if_expr = Expr::If {
+            cond: Box::new(Expr::Literal {
+                val: Value::Bool { val: true },
+            }),
+            expr1: Box::new(Expr::Literal {
+                val: Value::Number { val: 7 },
+            }),
+            expr2: Box::new(Expr::Literal {
+                val: Value::Number { val: 8 },
+            }),
+        };
+        run_expr_test(&if_expr, &interner);
+    }
+
+    /// Verify round-trip encoding and decoding for Func,
+    /// Call, Action, and MemberAccess expressions
+    #[test]
+    fn test_expr_codec_exhaustive_2() {
+        let run_expr_test = |expr: &Expr, interner_orig: &Interner| {
+            let encoded = encode_expr(expr, interner_orig);
+            let mut interner_new = Interner::new();
+            let decoded = decode_expr(encoded, &mut interner_new);
+            assert_eq!(format!("{}", expr), format!("{}", decoded));
+        };
+
+        // 1. Func
+        let mut interner = Interner::new();
+        let param_name = interner.insert("p");
+        let func_expr = Expr::Func {
+            params: vec![param_name],
+            body: Box::new(Expr::Literal {
+                val: Value::Number { val: 9 },
+            }),
+        };
+        run_expr_test(&func_expr, &interner);
+
+        // 2. Call
+        let mut interner = Interner::new();
+        let param_name = interner.insert("p");
+        let func_expr = Expr::Func {
+            params: vec![param_name],
+            body: Box::new(Expr::Literal {
+                val: Value::Number { val: 9 },
+            }),
+        };
+        let call_expr = Expr::Call {
+            func: Box::new(func_expr),
+            args: vec![Expr::Literal {
+                val: Value::Number { val: 10 },
+            }],
+        };
+        run_expr_test(&call_expr, &interner);
+
+        // 3. MemberAccess
+        let mut interner = Interner::new();
+        let service_name = interner.insert("srv");
+        let member_name = interner.insert("mem");
+        let member_expr = Expr::MemberAccess {
+            service_name,
+            member_name,
+        };
+        run_expr_test(&member_expr, &interner);
+
+        // 4. Action
+        let interner = Interner::new();
+        let action_expr = Expr::Action(vec![ActionStmt::Do(Expr::Literal {
+            val: Value::Number { val: 11 },
+        })]);
+        run_expr_test(&action_expr, &interner);
+    }
+
+    /// Verify round-trip encoding and decoding for Select,
+    /// Table, and Fold expressions
+    #[test]
+    fn test_expr_codec_exhaustive_3() {
+        let run_expr_test = |expr: &Expr, interner_orig: &Interner| {
+            let encoded = encode_expr(expr, interner_orig);
+            let mut interner_new = Interner::new();
+            let decoded = decode_expr(encoded, &mut interner_new);
+            assert_eq!(format!("{}", expr), format!("{}", decoded));
+        };
+
+        // 1. Select
+        let mut interner = Interner::new();
+        let table_name = interner.insert("tbl");
+        let col1 = interner.insert("col1");
+        let col2 = interner.insert("col2");
+        let select_expr = Expr::Select {
+            table_name,
+            column_names: vec![col1, col2],
+            where_clause: Box::new(Expr::Literal {
+                val: Value::Bool { val: true },
+            }),
+        };
+        run_expr_test(&select_expr, &interner);
+
+        // 2. Table
+        let mut interner = Interner::new();
+        let col1 = interner.insert("col1");
+        let col2 = interner.insert("col2");
+        let f1 = Field {
+            name: col1,
+            ty: DataType::String,
+        };
+        let f2 = Field {
+            name: col2,
+            ty: DataType::Number,
+        };
+        let f3 = Field {
+            name: col2,
+            ty: DataType::Bool,
+        };
+        let table_expr = Expr::Table {
+            schema: vec![f1, f2, f3],
+            records: vec![Expr::Literal {
+                val: Value::String {
+                    val: "abc".to_string(),
+                },
+            }],
+        };
+        run_expr_test(&table_expr, &interner);
+
+        // 3. Fold
+        let mut interner = Interner::new();
+        let table_name = interner.insert("tbl");
+        let col1 = interner.insert("col1");
+        let fold_expr = Expr::Fold {
+            table_name,
+            column_name: col1,
+            operation: Box::new(Expr::Literal {
+                val: Value::Number { val: 42 },
+            }),
+            identity: Box::new(Expr::Literal {
+                val: Value::Number { val: 0 },
+            }),
+        };
+        run_expr_test(&fold_expr, &interner);
+    }
+
+    /// Verify round-trip encoding and decoding for Expr,
+    /// Do, Assert, and Assign ActionStmts
+    #[test]
+    fn test_action_stmt_codec_exhaustive() {
+        let run_stmt_test = |stmt: &ActionStmt, interner_orig: &Interner| {
+            let encoded = encode_action_stmt(stmt, interner_orig);
+            let mut interner_new = Interner::new();
+            let decoded = decode_action_stmt(encoded, &mut interner_new);
+            assert_eq!(format!("{}", stmt), format!("{}", decoded));
+        };
+
+        // 1. Expr
+        let interner = Interner::new();
+        let stmt_expr = ActionStmt::Expr(Expr::Literal {
+            val: Value::Number { val: 100 },
+        });
+        run_stmt_test(&stmt_expr, &interner);
+
+        // 2. Do
+        let interner = Interner::new();
+        let stmt_do = ActionStmt::Do(Expr::Literal {
+            val: Value::Number { val: 200 },
+        });
+        run_stmt_test(&stmt_do, &interner);
+
+        // 3. Assert
+        let interner = Interner::new();
+        let stmt_assert = ActionStmt::Assert(Expr::Literal {
+            val: Value::Bool { val: true },
+        });
+        run_stmt_test(&stmt_assert, &interner);
+
+        // 4. Assign
+        let mut interner = Interner::new();
+        let name_var = interner.insert("v");
+        let stmt_assign = ActionStmt::Assign {
+            name: name_var,
+            expr: Expr::Literal {
+                val: Value::Number { val: 300 },
+            },
+        };
+        run_stmt_test(&stmt_assign, &interner);
+    }
+
+    /// Verify that deserializing a structurally corrupted JSON
+    /// string is rejected safely
+    #[test]
+    fn test_codec_corrupt_payload_rejection() {
+        let malformed_json = "{ \"val\": { \"Closure\": { \"params\": [";
+        let res: Result<NetValue, _> = serde_json::from_str(malformed_json);
+        assert!(res.is_err() == true);
+    }
+
+    /// Verify that type mismatches in JSON are rejected safely
+    /// at the boundary
+    #[test]
+    fn test_codec_type_mismatch_rejection() {
+        let mismatched_json = "{ \"Bool\": { \"val\": \"not_a_bool\" } }";
+        let res: Result<NetValue, _> = serde_json::from_str(mismatched_json);
+        assert!(res.is_err() == true);
+    }
+
+    /// Verify that deeply nested AST structures do not crash the
+    /// encoder or decoder
+    #[test]
+    fn test_codec_deeply_nested_structure() {
+        let mut expr = Expr::Literal {
+            val: Value::Number { val: 0 },
+        };
+        let mut interner = Interner::new();
+        for _ in 0..20 {
+            expr = Expr::Binop {
+                op: BinOp::Add,
+                expr1: Box::new(expr),
+                expr2: Box::new(Expr::Literal {
+                    val: Value::Number { val: 1 },
+                }),
+            };
+        }
+
+        let encoded = encode_expr(&expr, &interner);
+        let json_str = serde_json::to_string(&encoded).unwrap();
+        let decoded_net: NetExpr = serde_json::from_str(&json_str).unwrap();
+        let decoded = decode_expr(decoded_net, &mut interner);
+
+        assert_eq!(format!("{}", expr), format!("{}", decoded));
+    }
 }

--- a/meerkat-lib/src/net/codec.rs
+++ b/meerkat-lib/src/net/codec.rs
@@ -372,7 +372,7 @@ pub fn decode_action_stmt(stmt: NetActionStmt, interner: &mut Interner) -> Actio
 pub fn encode_field(field: &Field, interner: &Interner) -> NetField {
     NetField {
         name: interner.get(field.name).to_string(),
-        type_: encode_datatype(&field.type_),
+        ty: encode_datatype(&field.ty),
     }
 }
 
@@ -387,7 +387,7 @@ pub fn encode_field(field: &Field, interner: &Interner) -> NetField {
 pub fn decode_field(field: NetField, interner: &mut Interner) -> Field {
     Field {
         name: interner.insert(&field.name),
-        type_: decode_datatype(field.type_),
+        ty: decode_datatype(field.ty),
     }
 }
 

--- a/meerkat-lib/src/net/codec.rs
+++ b/meerkat-lib/src/net/codec.rs
@@ -998,7 +998,7 @@ mod tests {
     fn test_codec_corrupt_payload_rejection() {
         let malformed_json = "{ \"val\": { \"Closure\": { \"params\": [";
         let res: std::result::Result<NetValue, _> = serde_json::from_str(malformed_json);
-        assert!(res.is_err() == true);
+        assert!(res.is_err());
     }
 
     /// Verify that type mismatches in JSON are rejected safely
@@ -1007,7 +1007,7 @@ mod tests {
     fn test_codec_type_mismatch_rejection() {
         let mismatched_json = "{ \"Bool\": { \"val\": \"not_a_bool\" } }";
         let res: std::result::Result<NetValue, _> = serde_json::from_str(mismatched_json);
-        assert!(res.is_err() == true);
+        assert!(res.is_err());
     }
 
     /// Verify that deeply nested AST structures do not crash the
@@ -1044,7 +1044,7 @@ mod tests {
         let net_val = NetValue::String { val: long_str };
         let mut interner = Interner::new();
         let res = decode_value(net_val, &mut interner);
-        assert!(res.is_err() == true);
+        assert!(res.is_err());
         assert!(matches!(res.unwrap_err(), Error::LimitExceeded(_)));
     }
 
@@ -1063,7 +1063,7 @@ mod tests {
         };
         let mut interner = Interner::new();
         let res = decode_value(net_val, &mut interner);
-        assert!(res.is_err() == true);
+        assert!(res.is_err());
         assert!(matches!(res.unwrap_err(), Error::LimitExceeded(_)));
     }
 
@@ -1075,7 +1075,7 @@ mod tests {
         let val = Value::String { val: long_str };
         let interner = Interner::new();
         let res = encode_value(&val, &interner);
-        assert!(res.is_err() == true);
+        assert!(res.is_err());
         assert!(matches!(res.unwrap_err(), Error::LimitExceeded(_)));
     }
 }

--- a/meerkat-lib/src/net/codec.rs
+++ b/meerkat-lib/src/net/codec.rs
@@ -3,9 +3,31 @@
 //! Provides encoding and decoding functions to map between the native
 //! `AST` types and the serialized network representation variants
 
+use crate::error::{Error, Result};
 use crate::net::ast::{NetActionStmt, NetBinOp, NetDataType, NetExpr, NetField, NetUnOp, NetValue};
 use crate::runtime::ast::{ActionStmt, BinOp, DataType, Expr, Field, UnOp, Value};
 use crate::runtime::interner::Interner;
+use crate::runtime::limits::{MAX_IDENTIFIER_LENGTH, MAX_STRING_LITERAL_LENGTH};
+
+fn validate_identifier(s: &str) -> Result<()> {
+    if s.len() > MAX_IDENTIFIER_LENGTH {
+        return Err(Error::LimitExceeded(format!(
+            "identifier exceeds maximum length of {} characters",
+            MAX_IDENTIFIER_LENGTH
+        )));
+    }
+    Ok(())
+}
+
+fn validate_string_literal(s: &str) -> Result<()> {
+    if s.len() > MAX_STRING_LITERAL_LENGTH {
+        return Err(Error::LimitExceeded(format!(
+            "string literal exceeds maximum length of {} characters",
+            MAX_STRING_LITERAL_LENGTH
+        )));
+    }
+    Ok(())
+}
 
 /// Encode a runtime `Value` into a network representation
 ///
@@ -14,53 +36,63 @@ use crate::runtime::interner::Interner;
 ///     interner (`&Interner`): The `Interner` for symbol lookup
 ///
 /// Returns:
-///     `NetValue`: The encoded `NetValue` network representation
-pub fn encode_value(val: &Value, interner: &Interner) -> NetValue {
+///     `Result<NetValue>`: The encoded `NetValue` network representation
+pub fn encode_value(val: &Value, interner: &Interner) -> Result<NetValue> {
     match val {
-        Value::Number { val } => NetValue::Number { val: *val },
-        Value::Bool { val } => NetValue::Bool { val: *val },
-        Value::String { val } => NetValue::String { val: val.clone() },
+        Value::Number { val } => Ok(NetValue::Number { val: *val }),
+        Value::Bool { val } => Ok(NetValue::Bool { val: *val }),
+        Value::String { val } => {
+            validate_string_literal(val)?;
+            Ok(NetValue::String { val: val.clone() })
+        }
         Value::Closure {
             params,
             body,
             env,
             service_name,
         } => {
-            let encoded_params = params
-                .iter()
-                .map(|p| interner.get(*p).to_string())
-                .collect();
-            let encoded_body = Box::new(encode_expr(body, interner));
-            let encoded_env = env
-                .iter()
-                .map(|(k, v)| (interner.get(*k).to_string(), encode_value(v, interner)))
-                .collect();
-            let encoded_service = interner.get(*service_name).to_string();
-            NetValue::Closure {
+            let mut encoded_params = Vec::new();
+            for p in params {
+                let p_str = interner.get(*p);
+                validate_identifier(p_str)?;
+                encoded_params.push(p_str.to_string());
+            }
+            let encoded_body = Box::new(encode_expr(body, interner)?);
+            let mut encoded_env = Vec::new();
+            for (k, v) in env {
+                let k_str = interner.get(*k);
+                validate_identifier(k_str)?;
+                encoded_env.push((k_str.to_string(), encode_value(v, interner)?));
+            }
+            let service_str = interner.get(*service_name);
+            validate_identifier(service_str)?;
+            Ok(NetValue::Closure {
                 params: encoded_params,
                 body: encoded_body,
                 env: encoded_env,
-                service_name: encoded_service,
-            }
+                service_name: service_str.to_string(),
+            })
         }
         Value::ActionClosure {
             stmts,
             env,
             service_net_id,
         } => {
-            let encoded_stmts = stmts
-                .iter()
-                .map(|s| encode_action_stmt(s, interner))
-                .collect();
-            let encoded_env = env
-                .iter()
-                .map(|(k, v)| (interner.get(*k).to_string(), encode_value(v, interner)))
-                .collect();
-            NetValue::ActionClosure {
+            let mut encoded_stmts = Vec::new();
+            for s in stmts {
+                encoded_stmts.push(encode_action_stmt(s, interner)?);
+            }
+            let mut encoded_env = Vec::new();
+            for (k, v) in env {
+                let k_str = interner.get(*k);
+                validate_identifier(k_str)?;
+                encoded_env.push((k_str.to_string(), encode_value(v, interner)?));
+            }
+            Ok(NetValue::ActionClosure {
                 stmts: encoded_stmts,
                 env: encoded_env,
                 service_net_id: service_net_id.clone(),
-            }
+            })
         }
     }
 }
@@ -72,50 +104,59 @@ pub fn encode_value(val: &Value, interner: &Interner) -> NetValue {
 ///     interner (`&mut Interner`): The `Interner` for symbol creation
 ///
 /// Returns:
-///     `Value`: The decoded runtime `Value`
-pub fn decode_value(val: NetValue, interner: &mut Interner) -> Value {
+///     `Result<Value>`: The decoded runtime `Value`
+pub fn decode_value(val: NetValue, interner: &mut Interner) -> Result<Value> {
     match val {
-        NetValue::Number { val } => Value::Number { val },
-        NetValue::Bool { val } => Value::Bool { val },
-        NetValue::String { val } => Value::String { val },
+        NetValue::Number { val } => Ok(Value::Number { val }),
+        NetValue::Bool { val } => Ok(Value::Bool { val }),
+        NetValue::String { val } => {
+            validate_string_literal(&val)?;
+            Ok(Value::String { val })
+        }
         NetValue::Closure {
             params,
             body,
             env,
             service_name,
         } => {
+            for p in &params {
+                validate_identifier(p)?;
+            }
             let decoded_params = params.into_iter().map(|p| interner.insert(&p)).collect();
-            let decoded_body = Box::new(decode_expr(*body, interner));
-            let decoded_env = env
-                .into_iter()
-                .map(|(k, v)| (interner.insert(&k), decode_value(v, interner)))
-                .collect();
+            let decoded_body = Box::new(decode_expr(*body, interner)?);
+            let mut decoded_env = Vec::new();
+            for (k, v) in env {
+                validate_identifier(&k)?;
+                decoded_env.push((interner.insert(&k), decode_value(v, interner)?));
+            }
+            validate_identifier(&service_name)?;
             let decoded_service = interner.insert(&service_name);
-            Value::Closure {
+            Ok(Value::Closure {
                 params: decoded_params,
                 body: decoded_body,
                 env: decoded_env,
                 service_name: decoded_service,
-            }
+            })
         }
         NetValue::ActionClosure {
             stmts,
             env,
             service_net_id,
         } => {
-            let decoded_stmts = stmts
-                .into_iter()
-                .map(|s| decode_action_stmt(s, interner))
-                .collect();
-            let decoded_env = env
-                .into_iter()
-                .map(|(k, v)| (interner.insert(&k), decode_value(v, interner)))
-                .collect();
-            Value::ActionClosure {
+            let mut decoded_stmts = Vec::new();
+            for s in stmts {
+                decoded_stmts.push(decode_action_stmt(s, interner)?);
+            }
+            let mut decoded_env = Vec::new();
+            for (k, v) in env {
+                validate_identifier(&k)?;
+                decoded_env.push((interner.insert(&k), decode_value(v, interner)?));
+            }
+            Ok(Value::ActionClosure {
                 stmts: decoded_stmts,
                 env: decoded_env,
                 service_net_id,
-            }
+            })
         }
     }
 }
@@ -127,87 +168,142 @@ pub fn decode_value(val: NetValue, interner: &mut Interner) -> Value {
 ///     interner (`&Interner`): The `Interner` for symbol lookup
 ///
 /// Returns:
-///     `NetExpr`: The encoded `NetExpr` network representation
-pub fn encode_expr(expr: &Expr, interner: &Interner) -> NetExpr {
+///     `Result<NetExpr>`: The encoded `NetExpr` network representation
+pub fn encode_expr(expr: &Expr, interner: &Interner) -> Result<NetExpr> {
     match expr {
-        Expr::Literal { val } => NetExpr::Literal {
-            val: encode_value(val, interner),
-        },
-        Expr::Variable { name } => NetExpr::Variable {
-            name: interner.get(*name).to_string(),
-        },
-        Expr::Tuple { val } => NetExpr::Tuple {
-            val: val.iter().map(|e| encode_expr(e, interner)).collect(),
-        },
-        Expr::KeyVal { name, value } => NetExpr::KeyVal {
-            name: interner.get(*name).to_string(),
-            value: Box::new(encode_expr(value, interner)),
-        },
-        Expr::Unop { op, expr } => NetExpr::Unop {
+        Expr::Literal { val } => Ok(NetExpr::Literal {
+            val: encode_value(val, interner)?,
+        }),
+        Expr::Variable { name } => {
+            let name_str = interner.get(*name);
+            validate_identifier(name_str)?;
+            Ok(NetExpr::Variable {
+                name: name_str.to_string(),
+            })
+        }
+        Expr::Tuple { val } => {
+            let mut encoded_val = Vec::new();
+            for e in val {
+                encoded_val.push(encode_expr(e, interner)?);
+            }
+            Ok(NetExpr::Tuple { val: encoded_val })
+        }
+        Expr::KeyVal { name, value } => {
+            let name_str = interner.get(*name);
+            validate_identifier(name_str)?;
+            Ok(NetExpr::KeyVal {
+                name: name_str.to_string(),
+                value: Box::new(encode_expr(value, interner)?),
+            })
+        }
+        Expr::Unop { op, expr } => Ok(NetExpr::Unop {
             op: encode_unop(*op),
-            expr: Box::new(encode_expr(expr, interner)),
-        },
-        Expr::Binop { op, expr1, expr2 } => NetExpr::Binop {
+            expr: Box::new(encode_expr(expr, interner)?),
+        }),
+        Expr::Binop { op, expr1, expr2 } => Ok(NetExpr::Binop {
             op: encode_binop(*op),
-            expr1: Box::new(encode_expr(expr1, interner)),
-            expr2: Box::new(encode_expr(expr2, interner)),
-        },
-        Expr::If { cond, expr1, expr2 } => NetExpr::If {
-            cond: Box::new(encode_expr(cond, interner)),
-            expr1: Box::new(encode_expr(expr1, interner)),
-            expr2: Box::new(encode_expr(expr2, interner)),
-        },
-        Expr::Func { params, body } => NetExpr::Func {
-            params: params
-                .iter()
-                .map(|p| interner.get(*p).to_string())
-                .collect(),
-            body: Box::new(encode_expr(body, interner)),
-        },
-        Expr::Call { func, args } => NetExpr::Call {
-            func: Box::new(encode_expr(func, interner)),
-            args: args.iter().map(|e| encode_expr(e, interner)).collect(),
-        },
-        Expr::Action(stmts) => NetExpr::Action(
-            stmts
-                .iter()
-                .map(|s| encode_action_stmt(s, interner))
-                .collect(),
-        ),
+            expr1: Box::new(encode_expr(expr1, interner)?),
+            expr2: Box::new(encode_expr(expr2, interner)?),
+        }),
+        Expr::If { cond, expr1, expr2 } => Ok(NetExpr::If {
+            cond: Box::new(encode_expr(cond, interner)?),
+            expr1: Box::new(encode_expr(expr1, interner)?),
+            expr2: Box::new(encode_expr(expr2, interner)?),
+        }),
+        Expr::Func { params, body } => {
+            let mut encoded_params = Vec::new();
+            for p in params {
+                let p_str = interner.get(*p);
+                validate_identifier(p_str)?;
+                encoded_params.push(p_str.to_string());
+            }
+            let encoded_body = Box::new(encode_expr(body, interner)?);
+            Ok(NetExpr::Func {
+                params: encoded_params,
+                body: encoded_body,
+            })
+        }
+        Expr::Call { func, args } => {
+            let encoded_func = Box::new(encode_expr(func, interner)?);
+            let mut encoded_args = Vec::new();
+            for e in args {
+                encoded_args.push(encode_expr(e, interner)?);
+            }
+            Ok(NetExpr::Call {
+                func: encoded_func,
+                args: encoded_args,
+            })
+        }
+        Expr::Action(stmts) => {
+            let mut encoded_stmts = Vec::new();
+            for s in stmts {
+                encoded_stmts.push(encode_action_stmt(s, interner)?);
+            }
+            Ok(NetExpr::Action(encoded_stmts))
+        }
         Expr::MemberAccess {
             service_name,
             member_name,
-        } => NetExpr::MemberAccess {
-            service_name: interner.get(*service_name).to_string(),
-            member_name: interner.get(*member_name).to_string(),
-        },
+        } => {
+            let service_str = interner.get(*service_name);
+            let member_str = interner.get(*member_name);
+            validate_identifier(service_str)?;
+            validate_identifier(member_str)?;
+            Ok(NetExpr::MemberAccess {
+                service_name: service_str.to_string(),
+                member_name: member_str.to_string(),
+            })
+        }
         Expr::Select {
             table_name,
             column_names,
             where_clause,
-        } => NetExpr::Select {
-            table_name: interner.get(*table_name).to_string(),
-            column_names: column_names
-                .iter()
-                .map(|c| interner.get(*c).to_string())
-                .collect(),
-            where_clause: Box::new(encode_expr(where_clause, interner)),
-        },
-        Expr::Table { schema, records } => NetExpr::Table {
-            schema: schema.iter().map(|f| encode_field(f, interner)).collect(),
-            records: records.iter().map(|r| encode_expr(r, interner)).collect(),
-        },
+        } => {
+            let table_str = interner.get(*table_name);
+            validate_identifier(table_str)?;
+            let mut encoded_cols = Vec::new();
+            for c in column_names {
+                let c_str = interner.get(*c);
+                validate_identifier(c_str)?;
+                encoded_cols.push(c_str.to_string());
+            }
+            Ok(NetExpr::Select {
+                table_name: table_str.to_string(),
+                column_names: encoded_cols,
+                where_clause: Box::new(encode_expr(where_clause, interner)?),
+            })
+        }
+        Expr::Table { schema, records } => {
+            let mut encoded_schema = Vec::new();
+            for f in schema {
+                encoded_schema.push(encode_field(f, interner)?);
+            }
+            let mut encoded_records = Vec::new();
+            for r in records {
+                encoded_records.push(encode_expr(r, interner)?);
+            }
+            Ok(NetExpr::Table {
+                schema: encoded_schema,
+                records: encoded_records,
+            })
+        }
         Expr::Fold {
             table_name,
             column_name,
             operation,
             identity,
-        } => NetExpr::Fold {
-            table_name: interner.get(*table_name).to_string(),
-            column_name: interner.get(*column_name).to_string(),
-            operation: Box::new(encode_expr(operation, interner)),
-            identity: Box::new(encode_expr(identity, interner)),
-        },
+        } => {
+            let table_str = interner.get(*table_name);
+            let column_str = interner.get(*column_name);
+            validate_identifier(table_str)?;
+            validate_identifier(column_str)?;
+            Ok(NetExpr::Fold {
+                table_name: table_str.to_string(),
+                column_name: column_str.to_string(),
+                operation: Box::new(encode_expr(operation, interner)?),
+                identity: Box::new(encode_expr(identity, interner)?),
+            })
+        }
     }
 }
 
@@ -218,90 +314,134 @@ pub fn encode_expr(expr: &Expr, interner: &Interner) -> NetExpr {
 ///     interner (`&mut Interner`): The `Interner` for symbol creation
 ///
 /// Returns:
-///     `Expr`: The decoded runtime `Expr`
-pub fn decode_expr(expr: NetExpr, interner: &mut Interner) -> Expr {
+///     `Result<Expr>`: The decoded runtime `Expr`
+pub fn decode_expr(expr: NetExpr, interner: &mut Interner) -> Result<Expr> {
     match expr {
-        NetExpr::Literal { val } => Expr::Literal {
-            val: decode_value(val, interner),
-        },
-        NetExpr::Variable { name } => Expr::Variable {
-            name: interner.insert(&name),
-        },
-        NetExpr::Tuple { val } => Expr::Tuple {
-            val: val.into_iter().map(|e| decode_expr(e, interner)).collect(),
-        },
-        NetExpr::KeyVal { name, value } => Expr::KeyVal {
-            name: interner.insert(&name),
-            value: Box::new(decode_expr(*value, interner)),
-        },
-        NetExpr::Unop { op, expr } => Expr::Unop {
+        NetExpr::Literal { val } => Ok(Expr::Literal {
+            val: decode_value(val, interner)?,
+        }),
+        NetExpr::Variable { name } => {
+            validate_identifier(&name)?;
+            Ok(Expr::Variable {
+                name: interner.insert(&name),
+            })
+        }
+        NetExpr::Tuple { val } => {
+            let mut decoded_val = Vec::new();
+            for e in val {
+                decoded_val.push(decode_expr(e, interner)?);
+            }
+            Ok(Expr::Tuple { val: decoded_val })
+        }
+        NetExpr::KeyVal { name, value } => {
+            validate_identifier(&name)?;
+            Ok(Expr::KeyVal {
+                name: interner.insert(&name),
+                value: Box::new(decode_expr(*value, interner)?),
+            })
+        }
+        NetExpr::Unop { op, expr } => Ok(Expr::Unop {
             op: decode_unop(op),
-            expr: Box::new(decode_expr(*expr, interner)),
-        },
-        NetExpr::Binop { op, expr1, expr2 } => Expr::Binop {
+            expr: Box::new(decode_expr(*expr, interner)?),
+        }),
+        NetExpr::Binop { op, expr1, expr2 } => Ok(Expr::Binop {
             op: decode_binop(op),
-            expr1: Box::new(decode_expr(*expr1, interner)),
-            expr2: Box::new(decode_expr(*expr2, interner)),
-        },
-        NetExpr::If { cond, expr1, expr2 } => Expr::If {
-            cond: Box::new(decode_expr(*cond, interner)),
-            expr1: Box::new(decode_expr(*expr1, interner)),
-            expr2: Box::new(decode_expr(*expr2, interner)),
-        },
-        NetExpr::Func { params, body } => Expr::Func {
-            params: params.into_iter().map(|p| interner.insert(&p)).collect(),
-            body: Box::new(decode_expr(*body, interner)),
-        },
-        NetExpr::Call { func, args } => Expr::Call {
-            func: Box::new(decode_expr(*func, interner)),
-            args: args.into_iter().map(|e| decode_expr(e, interner)).collect(),
-        },
-        NetExpr::Action(stmts) => Expr::Action(
-            stmts
-                .into_iter()
-                .map(|s| decode_action_stmt(s, interner))
-                .collect(),
-        ),
+            expr1: Box::new(decode_expr(*expr1, interner)?),
+            expr2: Box::new(decode_expr(*expr2, interner)?),
+        }),
+        NetExpr::If { cond, expr1, expr2 } => Ok(Expr::If {
+            cond: Box::new(decode_expr(*cond, interner)?),
+            expr1: Box::new(decode_expr(*expr1, interner)?),
+            expr2: Box::new(decode_expr(*expr2, interner)?),
+        }),
+        NetExpr::Func { params, body } => {
+            for p in &params {
+                validate_identifier(p)?;
+            }
+            let decoded_params = params.into_iter().map(|p| interner.insert(&p)).collect();
+            let decoded_body = Box::new(decode_expr(*body, interner)?);
+            Ok(Expr::Func {
+                params: decoded_params,
+                body: decoded_body,
+            })
+        }
+        NetExpr::Call { func, args } => {
+            let decoded_func = Box::new(decode_expr(*func, interner)?);
+            let mut decoded_args = Vec::new();
+            for e in args {
+                decoded_args.push(decode_expr(e, interner)?);
+            }
+            Ok(Expr::Call {
+                func: decoded_func,
+                args: decoded_args,
+            })
+        }
+        NetExpr::Action(stmts) => {
+            let mut decoded_stmts = Vec::new();
+            for s in stmts {
+                decoded_stmts.push(decode_action_stmt(s, interner)?);
+            }
+            Ok(Expr::Action(decoded_stmts))
+        }
         NetExpr::MemberAccess {
             service_name,
             member_name,
-        } => Expr::MemberAccess {
-            service_name: interner.insert(&service_name),
-            member_name: interner.insert(&member_name),
-        },
+        } => {
+            validate_identifier(&service_name)?;
+            validate_identifier(&member_name)?;
+            Ok(Expr::MemberAccess {
+                service_name: interner.insert(&service_name),
+                member_name: interner.insert(&member_name),
+            })
+        }
         NetExpr::Select {
             table_name,
             column_names,
             where_clause,
-        } => Expr::Select {
-            table_name: interner.insert(&table_name),
-            column_names: column_names
+        } => {
+            validate_identifier(&table_name)?;
+            for c in &column_names {
+                validate_identifier(c)?;
+            }
+            let decoded_cols = column_names
                 .into_iter()
                 .map(|c| interner.insert(&c))
-                .collect(),
-            where_clause: Box::new(decode_expr(*where_clause, interner)),
-        },
-        NetExpr::Table { schema, records } => Expr::Table {
-            schema: schema
-                .into_iter()
-                .map(|f| decode_field(f, interner))
-                .collect(),
-            records: records
-                .into_iter()
-                .map(|r| decode_expr(r, interner))
-                .collect(),
-        },
+                .collect();
+            Ok(Expr::Select {
+                table_name: interner.insert(&table_name),
+                column_names: decoded_cols,
+                where_clause: Box::new(decode_expr(*where_clause, interner)?),
+            })
+        }
+        NetExpr::Table { schema, records } => {
+            let mut decoded_schema = Vec::new();
+            for f in schema {
+                decoded_schema.push(decode_field(f, interner)?);
+            }
+            let mut decoded_records = Vec::new();
+            for r in records {
+                decoded_records.push(decode_expr(r, interner)?);
+            }
+            Ok(Expr::Table {
+                schema: decoded_schema,
+                records: decoded_records,
+            })
+        }
         NetExpr::Fold {
             table_name,
             column_name,
             operation,
             identity,
-        } => Expr::Fold {
-            table_name: interner.insert(&table_name),
-            column_name: interner.insert(&column_name),
-            operation: Box::new(decode_expr(*operation, interner)),
-            identity: Box::new(decode_expr(*identity, interner)),
-        },
+        } => {
+            validate_identifier(&table_name)?;
+            validate_identifier(&column_name)?;
+            Ok(Expr::Fold {
+                table_name: interner.insert(&table_name),
+                column_name: interner.insert(&column_name),
+                operation: Box::new(decode_expr(*operation, interner)?),
+                identity: Box::new(decode_expr(*identity, interner)?),
+            })
+        }
     }
 }
 
@@ -312,24 +452,36 @@ pub fn decode_expr(expr: NetExpr, interner: &mut Interner) -> Expr {
 ///     interner (`&Interner`): The `Interner` for symbol lookup
 ///
 /// Returns:
-///     `NetActionStmt`: The encoded `NetActionStmt` network representation
-pub fn encode_action_stmt(stmt: &ActionStmt, interner: &Interner) -> NetActionStmt {
+///     `Result<NetActionStmt>`: The encoded `NetActionStmt` network representation
+pub fn encode_action_stmt(stmt: &ActionStmt, interner: &Interner) -> Result<NetActionStmt> {
     match stmt {
-        ActionStmt::Let { name, expr } => NetActionStmt::Let {
-            name: interner.get(*name).to_string(),
-            expr: encode_expr(expr, interner),
-        },
-        ActionStmt::Expr(expr) => NetActionStmt::Expr(encode_expr(expr, interner)),
-        ActionStmt::Do(expr) => NetActionStmt::Do(encode_expr(expr, interner)),
-        ActionStmt::Assert(expr) => NetActionStmt::Assert(encode_expr(expr, interner)),
-        ActionStmt::Assign { name, expr } => NetActionStmt::Assign {
-            name: interner.get(*name).to_string(),
-            expr: encode_expr(expr, interner),
-        },
-        ActionStmt::Insert { row, table_name } => NetActionStmt::Insert {
-            row: encode_expr(row, interner),
-            table_name: interner.get(*table_name).to_string(),
-        },
+        ActionStmt::Let { name, expr } => {
+            let name_str = interner.get(*name);
+            validate_identifier(name_str)?;
+            Ok(NetActionStmt::Let {
+                name: name_str.to_string(),
+                expr: encode_expr(expr, interner)?,
+            })
+        }
+        ActionStmt::Expr(expr) => Ok(NetActionStmt::Expr(encode_expr(expr, interner)?)),
+        ActionStmt::Do(expr) => Ok(NetActionStmt::Do(encode_expr(expr, interner)?)),
+        ActionStmt::Assert(expr) => Ok(NetActionStmt::Assert(encode_expr(expr, interner)?)),
+        ActionStmt::Assign { name, expr } => {
+            let name_str = interner.get(*name);
+            validate_identifier(name_str)?;
+            Ok(NetActionStmt::Assign {
+                name: name_str.to_string(),
+                expr: encode_expr(expr, interner)?,
+            })
+        }
+        ActionStmt::Insert { row, table_name } => {
+            let table_str = interner.get(*table_name);
+            validate_identifier(table_str)?;
+            Ok(NetActionStmt::Insert {
+                row: encode_expr(row, interner)?,
+                table_name: table_str.to_string(),
+            })
+        }
     }
 }
 
@@ -340,24 +492,33 @@ pub fn encode_action_stmt(stmt: &ActionStmt, interner: &Interner) -> NetActionSt
 ///     interner (`&mut Interner`): The `Interner` for symbol creation
 ///
 /// Returns:
-///     `ActionStmt`: The decoded runtime `ActionStmt`
-pub fn decode_action_stmt(stmt: NetActionStmt, interner: &mut Interner) -> ActionStmt {
+///     `Result<ActionStmt>`: The decoded runtime `ActionStmt`
+pub fn decode_action_stmt(stmt: NetActionStmt, interner: &mut Interner) -> Result<ActionStmt> {
     match stmt {
-        NetActionStmt::Let { name, expr } => ActionStmt::Let {
-            name: interner.insert(&name),
-            expr: decode_expr(expr, interner),
-        },
-        NetActionStmt::Expr(expr) => ActionStmt::Expr(decode_expr(expr, interner)),
-        NetActionStmt::Do(expr) => ActionStmt::Do(decode_expr(expr, interner)),
-        NetActionStmt::Assert(expr) => ActionStmt::Assert(decode_expr(expr, interner)),
-        NetActionStmt::Assign { name, expr } => ActionStmt::Assign {
-            name: interner.insert(&name),
-            expr: decode_expr(expr, interner),
-        },
-        NetActionStmt::Insert { row, table_name } => ActionStmt::Insert {
-            row: decode_expr(row, interner),
-            table_name: interner.insert(&table_name),
-        },
+        NetActionStmt::Let { name, expr } => {
+            validate_identifier(&name)?;
+            Ok(ActionStmt::Let {
+                name: interner.insert(&name),
+                expr: decode_expr(expr, interner)?,
+            })
+        }
+        NetActionStmt::Expr(expr) => Ok(ActionStmt::Expr(decode_expr(expr, interner)?)),
+        NetActionStmt::Do(expr) => Ok(ActionStmt::Do(decode_expr(expr, interner)?)),
+        NetActionStmt::Assert(expr) => Ok(ActionStmt::Assert(decode_expr(expr, interner)?)),
+        NetActionStmt::Assign { name, expr } => {
+            validate_identifier(&name)?;
+            Ok(ActionStmt::Assign {
+                name: interner.insert(&name),
+                expr: decode_expr(expr, interner)?,
+            })
+        }
+        NetActionStmt::Insert { row, table_name } => {
+            validate_identifier(&table_name)?;
+            Ok(ActionStmt::Insert {
+                row: decode_expr(row, interner)?,
+                table_name: interner.insert(&table_name),
+            })
+        }
     }
 }
 
@@ -368,12 +529,14 @@ pub fn decode_action_stmt(stmt: NetActionStmt, interner: &mut Interner) -> Actio
 ///     interner (`&Interner`): The `Interner` for symbol lookup
 ///
 /// Returns:
-///     `NetField`: The encoded `NetField` network representation
-pub fn encode_field(field: &Field, interner: &Interner) -> NetField {
-    NetField {
-        name: interner.get(field.name).to_string(),
+///     `Result<NetField>`: The encoded `NetField` network representation
+pub fn encode_field(field: &Field, interner: &Interner) -> Result<NetField> {
+    let name_str = interner.get(field.name);
+    validate_identifier(name_str)?;
+    Ok(NetField {
+        name: name_str.to_string(),
         ty: encode_datatype(&field.ty),
-    }
+    })
 }
 
 /// Decode a network `NetField` representation into a runtime `Field`
@@ -383,12 +546,13 @@ pub fn encode_field(field: &Field, interner: &Interner) -> NetField {
 ///     interner (`&mut Interner`): The `Interner` for symbol creation
 ///
 /// Returns:
-///     `Field`: The decoded runtime `Field`
-pub fn decode_field(field: NetField, interner: &mut Interner) -> Field {
-    Field {
+///     `Result<Field>`: The decoded runtime `Field`
+pub fn decode_field(field: NetField, interner: &mut Interner) -> Result<Field> {
+    validate_identifier(&field.name)?;
+    Ok(Field {
         name: interner.insert(&field.name),
         ty: decode_datatype(field.ty),
-    }
+    })
 }
 
 /// Encode a runtime `UnOp` into its network equivalent
@@ -527,13 +691,13 @@ mod tests {
 
         let orig_str = format!("{}", original_value);
 
-        let encoded = encode_value(&original_value, &interner_orig);
+        let encoded = encode_value(&original_value, &interner_orig).unwrap();
 
         let json_str = serde_json::to_string(&encoded).unwrap();
         let decoded_net_val: NetValue = serde_json::from_str(&json_str).unwrap();
 
         let mut interner_new = Interner::new();
-        let decoded_value = decode_value(decoded_net_val, &mut interner_new);
+        let decoded_value = decode_value(decoded_net_val, &mut interner_new).unwrap();
 
         let new_str = format!("{}", decoded_value);
 
@@ -562,9 +726,9 @@ mod tests {
             service_name: service,
         };
 
-        let encoded = encode_value(&original_value, &interner_orig);
+        let encoded = encode_value(&original_value, &interner_orig).unwrap();
         let mut interner_new = Interner::new();
-        let decoded = decode_value(encoded, &mut interner_new);
+        let decoded = decode_value(encoded, &mut interner_new).unwrap();
 
         assert_eq!(format!("{}", original_value), format!("{}", decoded));
     }
@@ -574,9 +738,9 @@ mod tests {
     #[test]
     fn test_expr_codec_exhaustive_1() {
         let run_expr_test = |expr: &Expr, interner_orig: &Interner| {
-            let encoded = encode_expr(expr, interner_orig);
+            let encoded = encode_expr(expr, interner_orig).unwrap();
             let mut interner_new = Interner::new();
-            let decoded = decode_expr(encoded, &mut interner_new);
+            let decoded = decode_expr(encoded, &mut interner_new).unwrap();
             assert_eq!(format!("{}", expr), format!("{}", decoded));
         };
 
@@ -664,9 +828,9 @@ mod tests {
     #[test]
     fn test_expr_codec_exhaustive_2() {
         let run_expr_test = |expr: &Expr, interner_orig: &Interner| {
-            let encoded = encode_expr(expr, interner_orig);
+            let encoded = encode_expr(expr, interner_orig).unwrap();
             let mut interner_new = Interner::new();
-            let decoded = decode_expr(encoded, &mut interner_new);
+            let decoded = decode_expr(encoded, &mut interner_new).unwrap();
             assert_eq!(format!("{}", expr), format!("{}", decoded));
         };
 
@@ -721,9 +885,9 @@ mod tests {
     #[test]
     fn test_expr_codec_exhaustive_3() {
         let run_expr_test = |expr: &Expr, interner_orig: &Interner| {
-            let encoded = encode_expr(expr, interner_orig);
+            let encoded = encode_expr(expr, interner_orig).unwrap();
             let mut interner_new = Interner::new();
-            let decoded = decode_expr(encoded, &mut interner_new);
+            let decoded = decode_expr(encoded, &mut interner_new).unwrap();
             assert_eq!(format!("{}", expr), format!("{}", decoded));
         };
 
@@ -789,9 +953,9 @@ mod tests {
     #[test]
     fn test_action_stmt_codec_exhaustive() {
         let run_stmt_test = |stmt: &ActionStmt, interner_orig: &Interner| {
-            let encoded = encode_action_stmt(stmt, interner_orig);
+            let encoded = encode_action_stmt(stmt, interner_orig).unwrap();
             let mut interner_new = Interner::new();
-            let decoded = decode_action_stmt(encoded, &mut interner_new);
+            let decoded = decode_action_stmt(encoded, &mut interner_new).unwrap();
             assert_eq!(format!("{}", stmt), format!("{}", decoded));
         };
 
@@ -833,7 +997,7 @@ mod tests {
     #[test]
     fn test_codec_corrupt_payload_rejection() {
         let malformed_json = "{ \"val\": { \"Closure\": { \"params\": [";
-        let res: Result<NetValue, _> = serde_json::from_str(malformed_json);
+        let res: std::result::Result<NetValue, _> = serde_json::from_str(malformed_json);
         assert!(res.is_err() == true);
     }
 
@@ -842,7 +1006,7 @@ mod tests {
     #[test]
     fn test_codec_type_mismatch_rejection() {
         let mismatched_json = "{ \"Bool\": { \"val\": \"not_a_bool\" } }";
-        let res: Result<NetValue, _> = serde_json::from_str(mismatched_json);
+        let res: std::result::Result<NetValue, _> = serde_json::from_str(mismatched_json);
         assert!(res.is_err() == true);
     }
 
@@ -864,11 +1028,54 @@ mod tests {
             };
         }
 
-        let encoded = encode_expr(&expr, &interner);
+        let encoded = encode_expr(&expr, &interner).unwrap();
         let json_str = serde_json::to_string(&encoded).unwrap();
         let decoded_net: NetExpr = serde_json::from_str(&json_str).unwrap();
-        let decoded = decode_expr(decoded_net, &mut interner);
+        let decoded = decode_expr(decoded_net, &mut interner).unwrap();
 
         assert_eq!(format!("{}", expr), format!("{}", decoded));
+    }
+
+    /// Verify that decoding a value with an oversized string
+    /// literal fails
+    #[test]
+    fn test_codec_decode_oversized_string_literal() {
+        let long_str = "a".repeat(MAX_STRING_LITERAL_LENGTH + 1);
+        let net_val = NetValue::String { val: long_str };
+        let mut interner = Interner::new();
+        let res = decode_value(net_val, &mut interner);
+        assert!(res.is_err() == true);
+        assert!(matches!(res.unwrap_err(), Error::LimitExceeded(_)));
+    }
+
+    /// Verify that decoding a value with an oversized identifier
+    /// fails
+    #[test]
+    fn test_codec_decode_oversized_identifier() {
+        let long_ident = "a".repeat(MAX_IDENTIFIER_LENGTH + 1);
+        let net_val = NetValue::Closure {
+            params: vec![long_ident],
+            body: Box::new(NetExpr::Literal {
+                val: NetValue::Number { val: 0 },
+            }),
+            env: vec![],
+            service_name: "test".to_string(),
+        };
+        let mut interner = Interner::new();
+        let res = decode_value(net_val, &mut interner);
+        assert!(res.is_err() == true);
+        assert!(matches!(res.unwrap_err(), Error::LimitExceeded(_)));
+    }
+
+    /// Verify that encoding a value with an oversized string
+    /// literal fails
+    #[test]
+    fn test_codec_encode_oversized_string_literal() {
+        let long_str = "a".repeat(MAX_STRING_LITERAL_LENGTH + 1);
+        let val = Value::String { val: long_str };
+        let interner = Interner::new();
+        let res = encode_value(&val, &interner);
+        assert!(res.is_err() == true);
+        assert!(matches!(res.unwrap_err(), Error::LimitExceeded(_)));
     }
 }

--- a/meerkat-lib/src/net/codec.rs
+++ b/meerkat-lib/src/net/codec.rs
@@ -3,8 +3,8 @@
 //! Provides encoding and decoding functions to map between the native
 //! `AST` types and the serialized network representation variants
 
-use crate::net::ast::{NetActionStmt, NetExpr, NetField, NetValue};
-use crate::runtime::ast::{ActionStmt, Expr, Field, Value};
+use crate::net::ast::{NetActionStmt, NetBinOp, NetDataType, NetExpr, NetField, NetUnOp, NetValue};
+use crate::runtime::ast::{ActionStmt, BinOp, DataType, Expr, Field, UnOp, Value};
 use crate::runtime::interner::Interner;
 
 /// Encode a runtime `Value` into a network representation
@@ -144,11 +144,11 @@ pub fn encode_expr(expr: &Expr, interner: &Interner) -> NetExpr {
             value: Box::new(encode_expr(value, interner)),
         },
         Expr::Unop { op, expr } => NetExpr::Unop {
-            op: *op,
+            op: encode_unop(*op),
             expr: Box::new(encode_expr(expr, interner)),
         },
         Expr::Binop { op, expr1, expr2 } => NetExpr::Binop {
-            op: *op,
+            op: encode_binop(*op),
             expr1: Box::new(encode_expr(expr1, interner)),
             expr2: Box::new(encode_expr(expr2, interner)),
         },
@@ -235,11 +235,11 @@ pub fn decode_expr(expr: NetExpr, interner: &mut Interner) -> Expr {
             value: Box::new(decode_expr(*value, interner)),
         },
         NetExpr::Unop { op, expr } => Expr::Unop {
-            op,
+            op: decode_unop(op),
             expr: Box::new(decode_expr(*expr, interner)),
         },
         NetExpr::Binop { op, expr1, expr2 } => Expr::Binop {
-            op,
+            op: decode_binop(op),
             expr1: Box::new(decode_expr(*expr1, interner)),
             expr2: Box::new(decode_expr(*expr2, interner)),
         },
@@ -372,7 +372,7 @@ pub fn decode_action_stmt(stmt: NetActionStmt, interner: &mut Interner) -> Actio
 pub fn encode_field(field: &Field, interner: &Interner) -> NetField {
     NetField {
         name: interner.get(field.name).to_string(),
-        type_: field.type_.clone(),
+        type_: encode_datatype(&field.type_),
     }
 }
 
@@ -387,7 +387,107 @@ pub fn encode_field(field: &Field, interner: &Interner) -> NetField {
 pub fn decode_field(field: NetField, interner: &mut Interner) -> Field {
     Field {
         name: interner.insert(&field.name),
-        type_: field.type_,
+        type_: decode_datatype(field.type_),
+    }
+}
+
+/// Encode a runtime `UnOp` into its network equivalent
+///
+/// Args:
+///     op (`UnOp`): The runtime operator to encode
+///
+/// Returns:
+///     `NetUnOp`: The encoded network operator representation
+pub fn encode_unop(op: UnOp) -> NetUnOp {
+    match op {
+        UnOp::Neg => NetUnOp::Neg,
+        UnOp::Not => NetUnOp::Not,
+    }
+}
+
+/// Decode a network `NetUnOp` into its runtime equivalent
+///
+/// Args:
+///     op (`NetUnOp`): The network operator to decode
+///
+/// Returns:
+///     `UnOp`: The decoded runtime operator representation
+pub fn decode_unop(op: NetUnOp) -> UnOp {
+    match op {
+        NetUnOp::Neg => UnOp::Neg,
+        NetUnOp::Not => UnOp::Not,
+    }
+}
+
+/// Encode a runtime `BinOp` into its network equivalent
+///
+/// Args:
+///     op (`BinOp`): The runtime operator to encode
+///
+/// Returns:
+///     `NetBinOp`: The encoded network operator representation
+pub fn encode_binop(op: BinOp) -> NetBinOp {
+    match op {
+        BinOp::Add => NetBinOp::Add,
+        BinOp::Sub => NetBinOp::Sub,
+        BinOp::Mul => NetBinOp::Mul,
+        BinOp::Div => NetBinOp::Div,
+        BinOp::Eq => NetBinOp::Eq,
+        BinOp::Lt => NetBinOp::Lt,
+        BinOp::Gt => NetBinOp::Gt,
+        BinOp::And => NetBinOp::And,
+        BinOp::Or => NetBinOp::Or,
+    }
+}
+
+/// Decode a network `NetBinOp` into its runtime equivalent
+///
+/// Args:
+///     op (`NetBinOp`): The network operator to decode
+///
+/// Returns:
+///     `BinOp`: The decoded runtime operator representation
+pub fn decode_binop(op: NetBinOp) -> BinOp {
+    match op {
+        NetBinOp::Add => BinOp::Add,
+        NetBinOp::Sub => BinOp::Sub,
+        NetBinOp::Mul => BinOp::Mul,
+        NetBinOp::Div => BinOp::Div,
+        NetBinOp::Eq => BinOp::Eq,
+        NetBinOp::Lt => BinOp::Lt,
+        NetBinOp::Gt => BinOp::Gt,
+        NetBinOp::And => BinOp::And,
+        NetBinOp::Or => BinOp::Or,
+    }
+}
+
+/// Encode a runtime `DataType` into its network equivalent
+///
+/// Args:
+///     t (`&DataType`): The runtime data type to encode
+///
+/// Returns:
+///     `NetDataType`: The encoded network data type representation
+pub fn encode_datatype(t: &DataType) -> NetDataType {
+    match t {
+        DataType::String => NetDataType::String,
+        DataType::Number => NetDataType::Number,
+        DataType::Bool => NetDataType::Bool,
+    }
+}
+
+/// Decode a network `NetDataType` into its runtime equivalent
+///
+/// Args:
+///     t (`NetDataType`): The network data type to decode
+///
+/// Returns:
+///     `DataType`: The decoded runtime data type representation
+pub fn decode_datatype(t: NetDataType) -> DataType {
+    match t {
+        NetDataType::String => DataType::String,
+        NetDataType::Number => DataType::Number,
+        NetDataType::Bool => DataType::Bool,
     }
 }
 

--- a/meerkat-lib/src/net/mod.rs
+++ b/meerkat-lib/src/net/mod.rs
@@ -1,4 +1,6 @@
 pub mod actor;
+pub mod ast;
+pub mod codec;
 pub mod messages;
 pub mod mock;
 pub mod network_layer;

--- a/meerkat-lib/src/net/types.rs
+++ b/meerkat-lib/src/net/types.rs
@@ -49,31 +49,19 @@ impl ServiceNetId {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum MeerkatMessage {
     /// Ping for testing
-    Ping {
-        content: String,
-    },
+    Ping { content: String },
 
     /// Pong response
-    Pong {
-        content: String,
-    },
+    Pong { content: String },
 
     /// Peer announcement with their canonical `Address`
-    Announce {
-        peer_addr: Address,
-    },
+    Announce { peer_addr: Address },
 
     /// Transaction message (for future use)
-    Transaction {
-        tx_id: u64,
-        payload: Vec<u8>,
-    },
+    Transaction { tx_id: u64, payload: Vec<u8> },
 
     /// Propagation message (for future use)
-    Propagation {
-        var_id: u64,
-        new_value: Vec<u8>,
-    },
+    Propagation { var_id: u64, new_value: Vec<u8> },
 
     /// Request to look up a member of a service on a remote node
     LookupRequest {
@@ -89,16 +77,10 @@ pub enum MeerkatMessage {
     },
 
     /// Response to a `LookupRequest` with the serialized value
-    LookupResponse {
-        request_id: u64,
-        value: NetValue,
-    },
+    LookupResponse { request_id: u64, value: NetValue },
 
     /// Response indicating lookup failed
-    LookupError {
-        request_id: u64,
-        error: String,
-    },
+    LookupError { request_id: u64, error: String },
 
     /// Execute an action on a remote service
     ActionRequest {
@@ -150,17 +132,13 @@ pub enum MeerkatMessage {
     },
 
     /// Acknowledgement that an `Abort` was processed on a participant
-    AbortResponse {
-        request_id: u64,
-    },
+    AbortResponse { request_id: u64 },
 
     /// Sent by an owner when it parks a transactional request on a
     /// wait queue (wait-die wait): tells the waiting originator the
     /// request is alive and still queued, so it keeps waiting
     /// instead of timing out
-    WaitParked {
-        request_id: u64,
-    },
+    WaitParked { request_id: u64 },
 }
 
 /// Errors that can occur when sending messages

--- a/meerkat-lib/src/net/types.rs
+++ b/meerkat-lib/src/net/types.rs
@@ -1,141 +1,206 @@
+use crate::net::ast::{NetActionStmt, NetValue};
+use crate::runtime::txn::TxnId;
 use serde::{Deserialize, Serialize};
 
 /// Unique identifier for sent messages (for error tracking)
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct MessageId(pub u64);
 
-/// Address - canonical internet-routable address
+/// Canonical internet-routable address represented by `Address`
+///
 /// Examples:
-/// - Server: "/ip4/203.0.113.10/tcp/9000/p2p/12D3..."
-/// - Client: "/ip4/203.0.113.10/tcp/9000/p2p/server-id/ws/p2p/client-id"
+/// - Server: `/ip4/203.0.113.10/tcp/9000/p2p/12D3...`
+/// - Client: `/ip4/203.0.113.10/tcp/9000/p2p/server-id/ws/p2p/client-id`
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct Address(pub String);
 
 impl Address {
+    /// Creates a new `Address` from the given string
     pub fn new(addr: impl Into<String>) -> Self {
         Address(addr.into())
     }
 }
 
-/// Globally unique identity of a *service* (as opposed to a node).
+/// Globally unique identity of a service (as opposed to a node)
 ///
-/// Per the Historiographer design, a service identity is its global,
-/// internet-routable network address including the service slug, e.g.
-/// "/ip4/203.0.113.10/tcp/9000/p2p/12D3.../my_service". This is used as part
-/// of the key for all transaction state that mentions a variable, so that the
-/// same variable name in two different services (possibly on different nodes)
-/// never collides.
+/// Per the `Historiographer` design, a service identity is its global,
+/// internet-routable network address including the service slug, e.g.,
+/// `/ip4/203.0.113.10/tcp/9000/p2p/12D3.../my_service`
+/// This is used as part of the key for all transaction state that
+/// mentions a variable, so that the same variable name in two
+/// different services (possibly on different nodes) never collides
 ///
-/// For local-only execution where the node has no network address yet, the
-/// identity falls back to the service name. On a single node names are
-/// unambiguous; the address-based identity takes over once networking is
-/// available (and is required for cross-node transactions).
+/// For local-only execution where the node has no network address yet,
+/// the identity falls back to the service name. On a single node
+/// names are unambiguous; the address-based identity takes over once
+/// networking is available (and is required for cross-node
+/// transactions)
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
-pub struct ServiceId(pub String);
+pub struct ServiceNetId(pub String);
 
-impl ServiceId {
+impl ServiceNetId {
+    /// Creates a new `ServiceNetId` from the given string
     pub fn new(id: impl Into<String>) -> Self {
-        ServiceId(id.into())
+        ServiceNetId(id.into())
     }
 }
 
-/// Message types in the Meerkat protocol
+/// Message types in the `Meerkat` protocol
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum MeerkatMessage {
     /// Ping for testing
-    Ping { content: String },
+    Ping {
+        /// The payload string for the ping
+        content: String,
+    },
 
     /// Pong response
-    Pong { content: String },
+    Pong {
+        /// The payload string for the pong
+        content: String,
+    },
 
-    /// Peer announcement with their canonical address
-    Announce { peer_addr: Address },
+    /// Peer announcement with their canonical `Address`
+    Announce {
+        /// The announced peer address
+        peer_addr: Address,
+    },
 
     /// Transaction message (for future use)
-    Transaction { tx_id: u64, payload: Vec<u8> },
+    Transaction {
+        /// The transaction identifier
+        tx_id: u64,
+        /// The raw transaction payload
+        payload: Vec<u8>,
+    },
 
     /// Propagation message (for future use)
-    Propagation { var_id: u64, new_value: Vec<u8> },
+    Propagation {
+        /// The variable identifier
+        var_id: u64,
+        /// The new value serialized
+        new_value: Vec<u8>,
+    },
 
     /// Request to look up a member of a service on a remote node
     LookupRequest {
+        /// The unique request identifier
         request_id: u64,
+        /// The target service name
         service: String,
+        /// The member to resolve
         member: String,
-        reply_to: String, // full multiaddr of the requester
-        /// When Some, the read joins this transaction: the owning node acquires
-        /// and holds a read lock under the shared id until commit/abort. When
-        /// None, it is a plain unlocked read.
-        txn_id: Option<crate::runtime::txn::TxnId>,
+        /// The full multiaddr of the requester
+        reply_to: String,
+        /// When `Some`, the read joins this transaction: the owning node
+        /// acquires and holds a read lock under the shared `txn_id`
+        /// until `commit`/`abort`
+        /// When `None`, it is a plain unlocked read
+        txn_id: Option<TxnId>,
     },
 
-    /// Response to a LookupRequest with the serialized value
+    /// Response to a `LookupRequest` with the serialized value
     LookupResponse {
+        /// The request identifier corresponding to the lookup request
         request_id: u64,
-        value: String, // JSON-serialized Value
+        /// The retrieved network representation of the value
+        value: NetValue,
     },
 
     /// Response indicating lookup failed
-    LookupError { request_id: u64, error: String },
+    LookupError {
+        /// The request identifier corresponding to the lookup request
+        request_id: u64,
+        /// The error message details
+        error: String,
+    },
 
     /// Execute an action on a remote service
     ActionRequest {
+        /// The unique request identifier
         request_id: u64,
+        /// The target service name
         service: String,
-        stmts: Vec<crate::ast::ActionStmt>,
-        env: Vec<(String, crate::ast::Value)>,
+        /// The sequence of statements to execute
+        stmts: Vec<NetActionStmt>,
+        /// The environment bindings mapping keys to network values
+        env: Vec<(String, NetValue)>,
+        /// The full multiaddr of the requester
         reply_to: String,
-        /// When Some, the action joins the originator's distributed transaction:
-        /// execute under this shared id and hold (do not commit) until a later
-        /// Commit/Abort. When None, execute standalone and commit immediately.
-        txn_id: Option<crate::runtime::txn::TxnId>,
+        /// When `Some`, the action joins the originator's distributed
+        /// transaction: execute under this shared `txn_id` and hold
+        /// (do not commit) until a later `Commit`/`Abort`
+        /// When `None`, execute standalone and commit immediately
+        txn_id: Option<TxnId>,
     },
 
-    /// Response to ActionRequest
+    /// Response to `ActionRequest`
     ActionResponse {
+        /// The request identifier corresponding to the action request
         request_id: u64,
+        /// Indicates if the action succeeded
         success: bool,
+        /// The error details if the action failed
         error: Option<String>,
     },
 
-    /// Tell a participant node to commit a distributed transaction: apply the
-    /// writes it buffered for `txn_id` and release the locks it holds.
+    /// Tell a participant node to commit a distributed transaction:
+    /// apply the writes it buffered for `txn_id` and release the
+    /// locks it holds
     Commit {
+        /// The request identifier for tracking
         request_id: u64,
-        txn_id: crate::runtime::txn::TxnId,
+        /// The transaction identifier to commit
+        txn_id: TxnId,
+        /// The full multiaddr of the sender
         reply_to: String,
     },
 
-    /// Acknowledgement that a Commit was applied (or failed) on a participant.
+    /// Acknowledgement that a `Commit` was applied (or failed) on a
+    /// participant
     CommitResponse {
+        /// The request identifier
         request_id: u64,
+        /// Indicates if the commit succeeded
         success: bool,
+        /// The error details if the commit failed
         error: Option<String>,
     },
 
-    /// Tell a participant node to abort a distributed transaction: discard the
-    /// writes it buffered for `txn_id` and release the locks it holds.
-    /// Acknowledged so the originator knows the participant's locks are freed
-    /// before it returns (and exits).
+    /// Tell a participant node to abort a distributed transaction:
+    /// discard the writes it buffered for `txn_id` and release the
+    /// locks it holds
+    /// Acknowledged so the originator knows the participant's locks
+    /// are freed before it returns (and exits)
     Abort {
+        /// The request identifier
         request_id: u64,
-        txn_id: crate::runtime::txn::TxnId,
+        /// The transaction identifier to abort
+        txn_id: TxnId,
+        /// The full multiaddr of the sender
         reply_to: String,
     },
 
-    /// Acknowledgement that an Abort was processed on a participant.
-    AbortResponse { request_id: u64 },
+    /// Acknowledgement that an `Abort` was processed on a participant
+    AbortResponse {
+        /// The request identifier corresponding to the abort request
+        request_id: u64,
+    },
 
-    /// Sent by an owner when it parks a transactional request on a wait queue
-    /// (wait-die wait): tells the waiting originator the request is alive and
-    /// still queued, so it keeps waiting instead of timing out.
-    WaitParked { request_id: u64 },
+    /// Sent by an owner when it parks a transactional request on a
+    /// wait queue (wait-die wait): tells the waiting originator the
+    /// request is alive and still queued, so it keeps waiting
+    /// instead of timing out
+    WaitParked {
+        /// The request identifier that was parked
+        request_id: u64,
+    },
 }
 
-/// Errors that can occur when sending
+/// Errors that can occur when sending messages
 #[derive(Debug, Clone)]
 pub enum SendError {
-    /// Could not resolve/reach the address
+    /// Could not resolve/reach the `Address`
     UnreachableAddress(Address),
 
     /// Connection dropped before send completed
@@ -145,15 +210,17 @@ pub enum SendError {
     ProtocolError(String),
 }
 
-/// Describes what kind of node we are.
-/// Determines how translate_address behaves.
+/// Describes what kind of node we are
+///
+/// Determines how `translate_address` behaves
 pub enum NodeType {
     /// Server node - can dial IP directly, no translation needed
     Server,
-    /// Browser client - can only reach the network via WebSocket to relay server
+    /// Browser client - can only reach the network via WebSocket
+    /// to relay server
     BrowserClient {
-        /// WebSocket address of our relay server e.g.
-        /// "/ip4/server1-ip/tcp/9001/ws/p2p/server1-id"
+        /// WebSocket address of our relay server, e.g.,
+        /// `/ip4/server1-ip/tcp/9001/ws/p2p/server1-id`
         relay_server: Address,
     },
 }

--- a/meerkat-lib/src/net/types.rs
+++ b/meerkat-lib/src/net/types.rs
@@ -50,47 +50,36 @@ impl ServiceNetId {
 pub enum MeerkatMessage {
     /// Ping for testing
     Ping {
-        /// The payload string for the ping
         content: String,
     },
 
     /// Pong response
     Pong {
-        /// The payload string for the pong
         content: String,
     },
 
     /// Peer announcement with their canonical `Address`
     Announce {
-        /// The announced peer address
         peer_addr: Address,
     },
 
     /// Transaction message (for future use)
     Transaction {
-        /// The transaction identifier
         tx_id: u64,
-        /// The raw transaction payload
         payload: Vec<u8>,
     },
 
     /// Propagation message (for future use)
     Propagation {
-        /// The variable identifier
         var_id: u64,
-        /// The new value serialized
         new_value: Vec<u8>,
     },
 
     /// Request to look up a member of a service on a remote node
     LookupRequest {
-        /// The unique request identifier
         request_id: u64,
-        /// The target service name
         service: String,
-        /// The member to resolve
         member: String,
-        /// The full multiaddr of the requester
         reply_to: String,
         /// When `Some`, the read joins this transaction: the owning node
         /// acquires and holds a read lock under the shared `txn_id`
@@ -101,31 +90,22 @@ pub enum MeerkatMessage {
 
     /// Response to a `LookupRequest` with the serialized value
     LookupResponse {
-        /// The request identifier corresponding to the lookup request
         request_id: u64,
-        /// The retrieved network representation of the value
         value: NetValue,
     },
 
     /// Response indicating lookup failed
     LookupError {
-        /// The request identifier corresponding to the lookup request
         request_id: u64,
-        /// The error message details
         error: String,
     },
 
     /// Execute an action on a remote service
     ActionRequest {
-        /// The unique request identifier
         request_id: u64,
-        /// The target service name
         service: String,
-        /// The sequence of statements to execute
         stmts: Vec<NetActionStmt>,
-        /// The environment bindings mapping keys to network values
         env: Vec<(String, NetValue)>,
-        /// The full multiaddr of the requester
         reply_to: String,
         /// When `Some`, the action joins the originator's distributed
         /// transaction: execute under this shared `txn_id` and hold
@@ -136,11 +116,8 @@ pub enum MeerkatMessage {
 
     /// Response to `ActionRequest`
     ActionResponse {
-        /// The request identifier corresponding to the action request
         request_id: u64,
-        /// Indicates if the action succeeded
         success: bool,
-        /// The error details if the action failed
         error: Option<String>,
     },
 
@@ -148,22 +125,16 @@ pub enum MeerkatMessage {
     /// apply the writes it buffered for `txn_id` and release the
     /// locks it holds
     Commit {
-        /// The request identifier for tracking
         request_id: u64,
-        /// The transaction identifier to commit
         txn_id: TxnId,
-        /// The full multiaddr of the sender
         reply_to: String,
     },
 
     /// Acknowledgement that a `Commit` was applied (or failed) on a
     /// participant
     CommitResponse {
-        /// The request identifier
         request_id: u64,
-        /// Indicates if the commit succeeded
         success: bool,
-        /// The error details if the commit failed
         error: Option<String>,
     },
 
@@ -173,17 +144,13 @@ pub enum MeerkatMessage {
     /// Acknowledged so the originator knows the participant's locks
     /// are freed before it returns (and exits)
     Abort {
-        /// The request identifier
         request_id: u64,
-        /// The transaction identifier to abort
         txn_id: TxnId,
-        /// The full multiaddr of the sender
         reply_to: String,
     },
 
     /// Acknowledgement that an `Abort` was processed on a participant
     AbortResponse {
-        /// The request identifier corresponding to the abort request
         request_id: u64,
     },
 
@@ -192,7 +159,6 @@ pub enum MeerkatMessage {
     /// request is alive and still queued, so it keeps waiting
     /// instead of timing out
     WaitParked {
-        /// The request identifier that was parked
         request_id: u64,
     },
 }

--- a/meerkat-lib/src/runtime/ast/mod.rs
+++ b/meerkat-lib/src/runtime/ast/mod.rs
@@ -185,7 +185,7 @@ pub enum Decl {
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Field {
     pub name: Symbol,
-    pub type_: DataType,
+    pub ty: DataType,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]

--- a/meerkat-lib/src/runtime/ast/mod.rs
+++ b/meerkat-lib/src/runtime/ast/mod.rs
@@ -1,4 +1,5 @@
-use crate::net::ServiceId;
+use crate::net::ServiceNetId;
+use crate::runtime::interner::Symbol;
 use std::fmt::Display;
 pub mod printer;
 pub use printer::AstPrinter;
@@ -24,21 +25,21 @@ pub enum BinOp {
     Or,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum ActionStmt {
-    Let { name: String, expr: Expr },
+    Let { name: Symbol, expr: Expr },
     Expr(Expr),
     Do(Expr),
     Assert(Expr),
-    Assign { var: String, expr: Expr },
-    Insert { row: Expr, table_name: String },
+    Assign { name: Symbol, expr: Expr },
+    Insert { row: Expr, table_name: Symbol },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum Stmt {
     ActionStmt(ActionStmt),
     Update {
-        service: String,
+        service_name: Symbol,
         decls: Vec<Decl>,
     },
     Connect {
@@ -47,14 +48,14 @@ pub enum Stmt {
     },
     Import {
         path: String,
-        service: String,
+        service_name: Symbol,
     },
     Service {
-        name: String,
+        name: Symbol,
         decls: Vec<Decl>,
     },
     Test {
-        service: String,
+        service_name: Symbol,
         stmts: Vec<ActionStmt>,
     },
     Watch {
@@ -62,7 +63,7 @@ pub enum Stmt {
     },
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum Value {
     Number {
         val: i32,
@@ -74,36 +75,38 @@ pub enum Value {
         val: String,
     },
     Closure {
-        params: Vec<String>,
+        params: Vec<Symbol>,
         body: Box<Expr>,
-        env: Vec<(String, Value)>,
-        service_name: String,
+        env: Vec<(Symbol, Value)>,
+        service_name: Symbol,
     },
     ActionClosure {
         stmts: Vec<ActionStmt>,
-        env: Vec<(String, Value)>,
-        /// Identity of the service this action belongs to. Carries the owning
-        /// node's address, so the action can be executed even if its service is
-        /// not imported into the scope where the closure is later used.
-        service: ServiceId,
+        env: Vec<(Symbol, Value)>,
+        /// Identity of the service this action belongs to
+        ///
+        /// Carries the owning node's address, so the action can be
+        /// executed even if its service is not imported into the scope
+        /// where the closure is later used
+        service_net_id: ServiceNetId,
     },
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum Expr {
     /// Basic Lambda Core expressions
     Literal {
         val: Value,
     },
     Variable {
-        ident: String,
+        name: Symbol,
     },
     Tuple {
         val: Vec<Expr>,
     },
     KeyVal {
-        // TODO: replace with a Record type (different from Tuple) that is a list of key value pairs
-        key: String,
+        // TODO: replace with a `Record` type (different from `Tuple`) that is a list of key value pairs
+        name: Symbol,
         value: Box<Expr>,
     },
     Unop {
@@ -123,7 +126,7 @@ pub enum Expr {
     },
 
     Func {
-        params: Vec<String>,
+        params: Vec<Symbol>,
         body: Box<Expr>,
     },
     Call {
@@ -135,27 +138,28 @@ pub enum Expr {
     Action(Vec<ActionStmt>),
 
     MemberAccess {
-        service: String,
-        member: String,
+        service_name: Symbol,
+        member_name: Symbol,
     },
     Select {
-        table_name: String,
-        column_names: Vec<String>,
+        table_name: Symbol,
+        column_names: Vec<Symbol>,
         where_clause: Box<Expr>,
     },
 
     Table {
-        // TODO: remove this, we should just have Records and Tuples
+        // TODO: remove this, we should just have `Record`s and `Tuple`s
         schema: Vec<Field>,
         records: Vec<Expr>,
-        /*How do records differ from rows?
-         Records only consist of data contained within tables: {1, "A", 18}
-         Rows are what are written inside insert statements, insert {id: 1, name: "A", age: 18};
-        */
+        /* How do records differ from rows?
+         *
+         * - Records only consist of data contained within tables: `{1, "A", 18}`
+         * - Rows are what are written inside insert statements: `insert {id: 1, name: "A", age: 18}`
+         */
     },
     Fold {
-        table_name: String,
-        column_name: String,
+        table_name: Symbol,
+        column_name: Symbol,
         operation: Box<Expr>,
         identity: Box<Expr>,
     },
@@ -164,23 +168,23 @@ pub enum Expr {
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum Decl {
     VarDecl {
-        name: String,
+        name: Symbol,
         val: Expr,
     },
     DefDecl {
-        name: String,
+        name: Symbol,
         val: Expr,
         is_pub: bool,
     },
     TableDecl {
-        name: String,
+        name: Symbol,
         fields: Vec<Field>,
     },
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Field {
-    pub name: String,
+    pub name: Symbol,
     pub type_: DataType,
 }
 
@@ -216,7 +220,17 @@ impl Display for BinOp {
     }
 }
 
+/// Implement the `Display` trait for the `Value` type
+///
+/// This prints a human-readable representation of runtime values
 impl Display for Value {
+    /// Format the value for display
+    ///
+    /// Args:
+    ///     `f` (`&mut std::fmt::Formatter<'_>`): The formatter target
+    ///
+    /// Returns:
+    ///     `std::fmt::Result`: The result of the formatting operation
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Value::Number { val } => write!(f, "{}", val),
@@ -224,29 +238,56 @@ impl Display for Value {
             Value::String { val } => write!(f, "\"{}\"", val),
             Value::Closure {
                 params, body, env, ..
-            } => write!(f, "fn({})[{:?}]{{{}}}", params.join(","), env, body),
+            } => {
+                let params_str: Vec<String> = params.iter().map(|p| p.to_string()).collect();
+                let env_str: Vec<String> =
+                    env.iter().map(|(k, v)| format!("{}: {}", k, v)).collect();
+                write!(f, "fn({})[{:?}]{{{}}}", params_str.join(","), env_str, body)
+            }
             Value::ActionClosure {
                 stmts,
                 env,
-                service,
-            } => write!(f, "action[{:?}][{}]{{{:?}}}", env, service.0, stmts),
+                service_net_id,
+            } => {
+                let env_str: Vec<String> =
+                    env.iter().map(|(k, v)| format!("{}: {}", k, v)).collect();
+                write!(
+                    f,
+                    "action[{:?}][{}]{{{:?}}}",
+                    env_str, service_net_id.0, stmts
+                )
+            }
         }
     }
 }
 
+/// Implement the `Display` trait for the `Expr` type
+///
+/// This prints a human-readable representation of abstract syntax tree
+/// expressions
 impl Display for Expr {
+    /// Format the expression for display
+    ///
+    /// Args:
+    ///     `f` (`&mut std::fmt::Formatter<'_>`): The formatter target
+    ///
+    /// Returns:
+    ///     `std::fmt::Result`: The result of the formatting operation
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Expr::Literal { val } => write!(f, "{}", val),
             Expr::Tuple { .. } => write!(f, "vector"),
-            Expr::KeyVal { key, value } => write!(f, "keyval: {}, {}", key, value),
-            Expr::Variable { ident } => write!(f, "{}", ident),
+            Expr::KeyVal { name, value } => write!(f, "keyval: {}, {}", name, value),
+            Expr::Variable { name } => write!(f, "{}", name),
             Expr::Unop { op, expr } => write!(f, "{}{}", op, expr),
             Expr::Binop { op, expr1, expr2 } => write!(f, "{} {} {}", expr1, op, expr2),
             Expr::If { cond, expr1, expr2 } => {
                 write!(f, "if {} then {} else {}", cond, expr1, expr2)
             }
-            Expr::Func { params, body } => write!(f, "fn({})[{}]", params.join(","), body),
+            Expr::Func { params, body } => {
+                let params_str: Vec<String> = params.iter().map(|p| p.to_string()).collect();
+                write!(f, "fn({})[{}]", params_str.join(","), body)
+            }
             Expr::Call { func, args } => write!(
                 f,
                 "{}({})",
@@ -265,7 +306,10 @@ impl Display for Expr {
                     .collect::<Vec<_>>()
                     .join(", ")
             ),
-            Expr::MemberAccess { service, member } => write!(f, "{}.{}", service, member),
+            Expr::MemberAccess {
+                service_name,
+                member_name,
+            } => write!(f, "{}.{}", service_name, member_name),
             Expr::Select { where_clause, .. } => write!(f, "{}", where_clause),
             Expr::Table { records, .. } => {
                 write!(f, "[",)?;
@@ -296,14 +340,24 @@ impl Display for Expr {
     }
 }
 
+/// Implement the `Display` trait for the `ActionStmt` type
+///
+/// This prints a human-readable representation of action statements
 impl Display for ActionStmt {
+    /// Format the action statement for display
+    ///
+    /// Args:
+    ///     `f` (`&mut std::fmt::Formatter<'_>`): The formatter target
+    ///
+    /// Returns:
+    ///     `std::fmt::Result`: The result of the formatting operation
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             ActionStmt::Let { name, expr } => write!(f, "let {} = {}", name, expr),
             ActionStmt::Expr(expr) => write!(f, "{}", expr),
             ActionStmt::Do(expr) => write!(f, "do {}", expr),
             ActionStmt::Assert(expr) => write!(f, "assert {}", expr),
-            ActionStmt::Assign { var, expr } => write!(f, "{} = {}", var, expr),
+            ActionStmt::Assign { name, expr } => write!(f, "{} = {}", name, expr),
             ActionStmt::Insert { row, table_name } => {
                 write!(f, "insert into {} {}", table_name, row)
             }
@@ -311,7 +365,17 @@ impl Display for ActionStmt {
     }
 }
 
+/// Implement the `Display` trait for the `Decl` type
+///
+/// This prints a human-readable representation of declarations
 impl Display for Decl {
+    /// Format the declaration for display
+    ///
+    /// Args:
+    ///     `f` (`&mut std::fmt::Formatter<'_>`): The formatter target
+    ///
+    /// Returns:
+    ///     `std::fmt::Result`: The result of the formatting operation
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Decl::VarDecl { name, val } => {

--- a/meerkat-lib/src/runtime/ast/mod.rs
+++ b/meerkat-lib/src/runtime/ast/mod.rs
@@ -4,13 +4,13 @@ use std::fmt::Display;
 pub mod printer;
 pub use printer::AstPrinter;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum UnOp {
     Neg, // negate
     Not, // logical not
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum BinOp {
     Add,
     Sub,
@@ -188,7 +188,7 @@ pub struct Field {
     pub type_: DataType,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum DataType {
     String,
     Number,

--- a/meerkat-lib/src/runtime/ast/printer.rs
+++ b/meerkat-lib/src/runtime/ast/printer.rs
@@ -1,34 +1,43 @@
-//! AST pretty printer inspired by Rust syntax. This module is primarily
-//! invoked by the `--ast` flag for use in testing and development. It
-//! supports configurable indentation levels with `INDENTATION` constant
+//! `AST` pretty printer inspired by Rust syntax
+//!
+//! This module is primarily invoked by the `--ast` flag for use in
+//! testing and development. It supports configurable indentation
+//! levels with the `INDENTATION` constant
 
 use crate::runtime::ast::{ActionStmt, Decl, Expr, Field, Stmt, Value};
+use crate::runtime::interner::{Interner, Symbol};
 
 const INDENTATION: usize = 2;
 
 /// Pretty printer for formatting and displaying the abstract syntax tree
-pub struct AstPrinter {
+pub struct AstPrinter<'a> {
     spaces: usize,
+    interner: &'a Interner,
 }
 
-impl Default for AstPrinter {
-    /// Creates a default AstPrinter with two spaces of indentation
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl AstPrinter {
-    /// Creates a new AstPrinter instance with default indentation
-    pub fn new() -> Self {
+impl<'a> AstPrinter<'a> {
+    /// Creates a new `AstPrinter` instance with default indentation
+    pub fn new(interner: &'a Interner) -> Self {
         Self {
             spaces: INDENTATION,
+            interner,
         }
     }
 
-    /// Creates a new AstPrinter instance with custom indentation level
-    pub fn with_spaces(spaces: usize) -> Self {
-        Self { spaces }
+    /// Creates a new `AstPrinter` instance with custom indentation level
+    pub fn with_spaces(spaces: usize, interner: &'a Interner) -> Self {
+        Self { spaces, interner }
+    }
+
+    /// Helper function to format a `Symbol` with its ID and string representation
+    ///
+    /// Args:
+    ///     `sym` (`Symbol`): The symbol to format
+    ///
+    /// Returns:
+    ///     `String`: The formatted symbol string representation
+    pub fn format_symbol(&self, sym: Symbol) -> String {
+        format!("{} (\"{}\")", sym, self.interner.get(sym))
     }
 
     /// Prints spaces corresponding to the current indentation level
@@ -51,8 +60,15 @@ impl AstPrinter {
                 println!("ActionStmt:");
                 self.print_action_stmt(action, indent + 1);
             }
-            Stmt::Update { service, decls } => {
-                println!("Update: {{ service: \"{}\" }}", service);
+            Stmt::Update {
+                service_name,
+                decls,
+            } => {
+                let service_name = *service_name;
+                println!(
+                    "Update: {{ service_name: {} }}",
+                    self.format_symbol(service_name)
+                );
                 for decl in decls {
                     self.print_decl(decl, indent + 1);
                 }
@@ -60,17 +76,30 @@ impl AstPrinter {
             Stmt::Connect { path, addr } => {
                 println!("Connect: {{ path: \"{}\", addr: \"{}\" }}", path, addr);
             }
-            Stmt::Import { path, service } => {
-                println!("Import: {{ path: \"{}\", service: \"{}\" }}", path, service);
+            Stmt::Import { path, service_name } => {
+                let service_name = *service_name;
+                println!(
+                    "Import: {{ path: \"{}\", service_name: {} }}",
+                    path,
+                    self.format_symbol(service_name)
+                );
             }
             Stmt::Service { name, decls } => {
-                println!("Service: {{ name: \"{}\" }}", name);
+                let name = *name;
+                println!("Service: {{ name: {} }}", self.format_symbol(name));
                 for decl in decls {
                     self.print_decl(decl, indent + 1);
                 }
             }
-            Stmt::Test { service, stmts } => {
-                println!("Test: {{ service: \"{}\" }}", service);
+            Stmt::Test {
+                service_name,
+                stmts,
+            } => {
+                let service_name = *service_name;
+                println!(
+                    "Test: {{ service_name: {} }}",
+                    self.format_symbol(service_name)
+                );
                 for s in stmts {
                     self.print_action_stmt(s, indent + 1);
                 }
@@ -87,15 +116,23 @@ impl AstPrinter {
         self.print_indent(indent);
         match decl {
             Decl::VarDecl { name, val } => {
-                println!("VarDecl: {{ name: \"{}\" }}", name);
+                let name = *name;
+                println!("VarDecl: {{ name: {} }}", self.format_symbol(name));
                 self.print_expr(val, indent + 1);
             }
             Decl::DefDecl { name, val, is_pub } => {
-                println!("DefDecl: {{ name: \"{}\", is_pub: {} }}", name, is_pub);
+                let name = *name;
+                let is_pub = *is_pub;
+                println!(
+                    "DefDecl: {{ name: {}, is_pub: {} }}",
+                    self.format_symbol(name),
+                    is_pub
+                );
                 self.print_expr(val, indent + 1);
             }
             Decl::TableDecl { name, fields } => {
-                println!("TableDecl: {{ name: \"{}\" }}", name);
+                let name = *name;
+                println!("TableDecl: {{ name: {} }}", self.format_symbol(name));
                 for field in fields {
                     self.print_field(field, indent + 1);
                 }
@@ -107,8 +144,9 @@ impl AstPrinter {
     fn print_field(&self, field: &Field, indent: usize) {
         self.print_indent(indent);
         println!(
-            "Field: {{ name: \"{}\", type_: {:?} }}",
-            field.name, field.type_
+            "Field: {{ name: {}, type_: {:?} }}",
+            self.format_symbol(field.name),
+            field.type_
         );
     }
 
@@ -116,8 +154,9 @@ impl AstPrinter {
     pub fn print_action_stmt(&self, stmt: &ActionStmt, indent: usize) {
         self.print_indent(indent);
         match stmt {
-            ActionStmt::Let { name, expr, .. } => {
-                println!("Let: {{ name: \"{}\" }}", name);
+            ActionStmt::Let { name, expr } => {
+                let name = *name;
+                println!("Let: {{ name: {} }}", self.format_symbol(name));
                 self.print_expr(expr, indent + 1);
             }
             ActionStmt::Expr(expr) => {
@@ -132,12 +171,17 @@ impl AstPrinter {
                 println!("Assert:");
                 self.print_expr(expr, indent + 1);
             }
-            ActionStmt::Assign { var, expr } => {
-                println!("Assign: {{ var: \"{}\" }}", var);
+            ActionStmt::Assign { name, expr } => {
+                let name = *name;
+                println!("Assign: {{ name: {} }}", self.format_symbol(name));
                 self.print_expr(expr, indent + 1);
             }
             ActionStmt::Insert { row, table_name } => {
-                println!("Insert: {{ table_name: \"{}\" }}", table_name);
+                let table_name = *table_name;
+                println!(
+                    "Insert: {{ table_name: {} }}",
+                    self.format_symbol(table_name)
+                );
                 self.print_expr(row, indent + 1);
             }
         }
@@ -151,8 +195,9 @@ impl AstPrinter {
                 println!("Literal:");
                 self.print_value(val, indent + 1);
             }
-            Expr::Variable { ident, .. } => {
-                println!("Variable: {{ ident: \"{}\" }}", ident);
+            Expr::Variable { name } => {
+                let name = *name;
+                println!("Variable: {{ name: {} }}", self.format_symbol(name));
             }
             Expr::Tuple { val } => {
                 println!("Tuple:");
@@ -160,15 +205,18 @@ impl AstPrinter {
                     self.print_expr(v, indent + 1);
                 }
             }
-            Expr::KeyVal { key, value } => {
-                println!("KeyVal: {{ key: \"{}\" }}", key);
+            Expr::KeyVal { name, value } => {
+                let name = *name;
+                println!("KeyVal: {{ name: {} }}", self.format_symbol(name));
                 self.print_expr(value, indent + 1);
             }
             Expr::Unop { op, expr } => {
+                let op = *op;
                 println!("Unop: {{ op: {:?} }}", op);
                 self.print_expr(expr, indent + 1);
             }
             Expr::Binop { op, expr1, expr2 } => {
+                let op = *op;
                 println!("Binop: {{ op: {:?} }}", op);
                 self.print_expr(expr1, indent + 1);
                 self.print_expr(expr2, indent + 1);
@@ -180,7 +228,9 @@ impl AstPrinter {
                 self.print_expr(expr2, indent + 1);
             }
             Expr::Func { params, body } => {
-                println!("Func: {{ params: {:?} }}", params);
+                let params_str: Vec<String> =
+                    params.iter().map(|p| self.format_symbol(*p)).collect();
+                println!("Func: {{ params: {:?} }}", params_str);
                 self.print_expr(body, indent + 1);
             }
             Expr::Call { func, args } => {
@@ -196,10 +246,16 @@ impl AstPrinter {
                     self.print_action_stmt(stmt, indent + 1);
                 }
             }
-            Expr::MemberAccess { service, member } => {
+            Expr::MemberAccess {
+                service_name,
+                member_name,
+            } => {
+                let service_name = *service_name;
+                let member_name = *member_name;
                 println!(
-                    "MemberAccess: {{ service: \"{}\", member: \"{}\" }}",
-                    service, member
+                    "MemberAccess: {{ service_name: {}, member_name: {} }}",
+                    self.format_symbol(service_name),
+                    self.format_symbol(member_name)
                 );
             }
             Expr::Select {
@@ -207,9 +263,15 @@ impl AstPrinter {
                 column_names,
                 where_clause,
             } => {
+                let table_name = *table_name;
+                let cols_str: Vec<String> = column_names
+                    .iter()
+                    .map(|c| self.format_symbol(*c))
+                    .collect();
                 println!(
-                    "Select: {{ table_name: \"{}\", column_names: {:?} }}",
-                    table_name, column_names
+                    "Select: {{ table_name: {}, column_names: {:?} }}",
+                    self.format_symbol(table_name),
+                    cols_str
                 );
                 self.print_expr(where_clause, indent + 1);
             }
@@ -228,9 +290,12 @@ impl AstPrinter {
                 operation,
                 identity,
             } => {
+                let table_name = *table_name;
+                let column_name = *column_name;
                 println!(
-                    "Fold: {{ table_name: \"{}\", column_name: \"{}\" }}",
-                    table_name, column_name
+                    "Fold: {{ table_name: {}, column_name: {} }}",
+                    self.format_symbol(table_name),
+                    self.format_symbol(column_name)
                 );
                 self.print_expr(operation, indent + 1);
                 self.print_expr(identity, indent + 1);
@@ -243,9 +308,11 @@ impl AstPrinter {
         self.print_indent(indent);
         match val {
             Value::Number { val } => {
+                let val = *val;
                 println!("Number: {}", val);
             }
             Value::Bool { val } => {
+                let val = *val;
                 println!("Bool: {}", val);
             }
             Value::String { val } => {
@@ -254,21 +321,28 @@ impl AstPrinter {
             Value::Closure {
                 params,
                 body,
-                env: _,
                 service_name,
+                ..
             } => {
+                let service_name = *service_name;
+                let params_str: Vec<String> =
+                    params.iter().map(|p| self.format_symbol(*p)).collect();
                 println!(
-                    "Closure: {{ params: {:?}, service_name: \"{}\" }}",
-                    params, service_name
+                    "Closure: {{ params: {:?}, service_name: {} }}",
+                    params_str,
+                    self.format_symbol(service_name)
                 );
                 self.print_expr(body, indent + 1);
             }
             Value::ActionClosure {
                 stmts,
-                env: _,
-                service,
+                service_net_id,
+                ..
             } => {
-                println!("ActionClosure: {{ service: \"{}\" }}", service.0);
+                println!(
+                    "ActionClosure: {{ service_net_id: \"{}\" }}",
+                    service_net_id.0
+                );
                 for stmt in stmts {
                     self.print_action_stmt(stmt, indent + 1);
                 }

--- a/meerkat-lib/src/runtime/ast/printer.rs
+++ b/meerkat-lib/src/runtime/ast/printer.rs
@@ -144,9 +144,9 @@ impl<'a> AstPrinter<'a> {
     fn print_field(&self, field: &Field, indent: usize) {
         self.print_indent(indent);
         println!(
-            "Field: {{ name: {}, type_: {:?} }}",
+            "Field: {{ name: {}, ty: {:?} }}",
             self.format_symbol(field.name),
-            field.type_
+            field.ty
         );
     }
 

--- a/meerkat-lib/src/runtime/interner.rs
+++ b/meerkat-lib/src/runtime/interner.rs
@@ -1,0 +1,272 @@
+//! String interning module
+//!
+//! Provides the `Interner` and `Symbol` structures to enable forward
+//! and reverse lookup of strings
+//!
+//! This implementation intentionally copies strings to avoid viral
+//! lifetime annotations
+
+use serde::Deserialize;
+use serde::Serialize;
+use std::collections::HashMap;
+
+/// A numeric representation of an identifier or symbol
+///
+/// The inner field `id` is private to the module to prevent arbitrary
+/// construction of `Symbol` outside of the `interner` module, enforcing
+/// that symbols can only be created by `Interner` or sentinel constructors
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+pub struct Symbol {
+    id: u32,
+}
+
+/// Implement the `Debug` trait for the `Symbol` struct
+///
+/// This provides a structured representation of the symbol for debugging
+impl std::fmt::Debug for Symbol {
+    /// Format the symbol for debugging
+    ///
+    /// Args:
+    ///     `f` (`&mut std::fmt::Formatter<'_>`): The formatter target
+    ///
+    /// Returns:
+    ///     `std::fmt::Result`: The result of the formatting operation
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Symbol({})", self.id)
+    }
+}
+
+/// Implement the `Display` trait for the `Symbol` struct
+///
+/// This outputs the raw integer ID of the symbol for standard display formatting
+impl std::fmt::Display for Symbol {
+    /// Format the symbol for user display
+    ///
+    /// Args:
+    ///     `f` (`&mut std::fmt::Formatter<'_>`): The formatter target
+    ///
+    /// Returns:
+    ///     `std::fmt::Result`: The result of the formatting operation
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.id)
+    }
+}
+
+/// Implement the `Default` trait for the `Symbol` struct
+///
+/// This enables creating an empty sentinel symbol by default
+impl Default for Symbol {
+    /// Get the default sentinel `Symbol`
+    ///
+    /// Returns:
+    ///     `Self`: The default `Symbol` (representing the empty string)
+    fn default() -> Self {
+        Self::empty()
+    }
+}
+
+/// Associated functions for the `Symbol` struct
+///
+/// This contains sentinel constructors for constructing empty symbols
+impl Symbol {
+    /// Get the default empty symbol representing the empty string
+    ///
+    /// Returns:
+    ///     `Self`: The default empty `Symbol`
+    pub const fn empty() -> Self {
+        Symbol { id: 0 }
+    }
+}
+
+/// Implement the `Serialize` trait for the `Symbol` struct
+///
+/// This serializes the symbol as a single `u32` value to maintain
+/// compatibility with the network representation of symbols
+impl Serialize for Symbol {
+    /// Serialize the symbol into a raw `u32` value
+    ///
+    /// Args:
+    ///     `serializer` (`S`): The serializer target
+    ///
+    /// Returns:
+    ///     `Result<S::Ok, S::Error>`: The serialization result
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        self.id.serialize(serializer)
+    }
+}
+
+/// Implement the `Deserialize` trait for the `Symbol` struct
+///
+/// This deserializes the symbol from a single `u32` value to maintain
+/// compatibility with the network representation of symbols
+impl<'de> Deserialize<'de> for Symbol {
+    /// Deserialize the symbol from a raw `u32` value
+    ///
+    /// Args:
+    ///     `deserializer` (`D`): The deserializer source
+    ///
+    /// Returns:
+    ///     `Result<Self, D::Error>`: The deserialized symbol instance
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let id = u32::deserialize(deserializer)?;
+        Ok(Symbol { id })
+    }
+}
+
+/// A string interner that maps strings to unique `Symbol`s
+pub struct Interner {
+    index: HashMap<String, u32>,
+    strings: Vec<String>,
+    next_id: u32,
+}
+
+impl Default for Interner {
+    /// Initialize a new `Interner` instance with default settings
+    ///
+    /// Returns:
+    ///     `Self`: The default `Interner` instance
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Interner {
+    /// Initialize a new `Interner` instance
+    ///
+    /// Creates an `Interner` where `0` is reserved for the empty string
+    ///
+    /// Returns:
+    ///     `Self`: The initialized `Interner` instance
+    pub fn new() -> Self {
+        let index = HashMap::from([(String::new(), 0)]);
+        Self {
+            index,
+            strings: vec![String::new()],
+            next_id: 1,
+        }
+    }
+
+    /// Intern a string slice and return its unique `Symbol`
+    ///
+    /// If the string slice already exists in the `Interner`, this
+    /// method returns the existing `Symbol`. Otherwise, it inserts the
+    /// string, assigns a new identifier, and returns the new `Symbol`
+    ///
+    /// Args:
+    ///     `s` (`&str`): The string slice to intern
+    ///
+    /// Returns:
+    ///     `Symbol`: The unique symbol representing the string
+    pub fn insert(&mut self, s: &str) -> Symbol {
+        if let Some(&id) = self.index.get(s) {
+            return Symbol { id };
+        }
+
+        let id = self.next_id;
+        let _ = self.index.insert(s.to_string(), id);
+        self.strings.push(s.to_string());
+        self.next_id += 1;
+        Symbol { id }
+    }
+
+    /// Retrieve the string slice associated with a `Symbol`
+    ///
+    /// Looks up the string represented by the given `Symbol`. If the
+    /// `Symbol` is out of bounds or invalid, returns an empty string
+    /// slice
+    ///
+    /// Args:
+    ///     `id` (`Symbol`): The symbol to look up
+    ///
+    /// Returns:
+    ///     `&str`: The string slice associated with the `Symbol`
+    pub fn get(&self, id: Symbol) -> &str {
+        let idx = id.id as usize;
+        self.strings.get(idx).map(|s| s.as_str()).unwrap_or("")
+    }
+
+    /// Exposes validation check for a symbol
+    ///
+    /// Checks if a raw symbol `id` is valid within this `Interner`
+    ///
+    /// Args:
+    ///     `id` (`u32`): The raw ID to check
+    ///
+    /// Returns:
+    ///     `Option<Symbol>`: The validated symbol, or `None` if invalid
+    pub fn get_symbol(&self, id: u32) -> Option<Symbol> {
+        if id < self.next_id {
+            Some(Symbol { id })
+        } else {
+            None
+        }
+    }
+}
+
+/// Unit tests for the `Interner` and `Symbol` types
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Verify that a newly initialized `Interner` reserves index `0` for the empty string
+    #[test]
+    fn test_new_interner_has_empty_string_at_zero() {
+        let interner = Interner::new();
+        assert_eq!(interner.get(Symbol { id: 0 }), "");
+        assert_eq!(interner.next_id, 1);
+    }
+
+    /// Verify that basic string insertion yields a new `Symbol` and correct string retrieval
+    #[test]
+    fn test_basic_insert_and_get() {
+        let mut interner = Interner::new();
+        let sym = interner.insert("hello");
+
+        assert_eq!(sym, Symbol { id: 1 });
+        assert_eq!(interner.get(sym), "hello");
+    }
+
+    /// Verify that inserting duplicate strings returns the same identical `Symbol`
+    #[test]
+    fn test_deduplication() {
+        let mut interner = Interner::new();
+        let sym1 = interner.insert("rust");
+        let sym2 = interner.insert("rust");
+
+        assert_eq!(sym1, sym2, "Redundant strings must return the same Symbol");
+        assert_eq!(
+            interner.strings.len(),
+            2,
+            "Vector should only contain empty string and 'rust'"
+        );
+    }
+
+    /// Verify that retrieving an out-of-bounds `Symbol` yields the empty string sentinel
+    #[test]
+    fn test_out_of_bounds_safety() {
+        let interner = Interner::new();
+        // Index `99` does not exist, should return empty string
+        // sentinel
+        assert_eq!(interner.get(Symbol { id: 99 }), "");
+    }
+
+    /// Verify that inserting multiple unique strings yields unique `Symbol`s for each string
+    #[test]
+    fn test_multiple_unique_inserts() {
+        let mut interner = Interner::new();
+        let s1 = interner.insert("a");
+        let s2 = interner.insert("b");
+        let s3 = interner.insert("c");
+
+        assert_eq!(interner.get(s1), "a");
+        assert_eq!(interner.get(s2), "b");
+        assert_eq!(interner.get(s3), "c");
+        assert_ne!(s1, s2);
+    }
+}

--- a/meerkat-lib/src/runtime/interner.rs
+++ b/meerkat-lib/src/runtime/interner.rs
@@ -209,4 +209,52 @@ mod tests {
         assert_eq!(interner.get(s3), "c");
         assert_ne!(s1, s2);
     }
+
+    /// Verify that a Symbol's Debug formatting produces the expected string representation
+    #[test]
+    fn test_symbol_debug_format() {
+        let symbol = Symbol { id: 42 };
+        assert_eq!(format!("{:?}", symbol), "Symbol(42)");
+    }
+
+    /// Verify that Symbol's Default implementation creates the empty sentinel symbol
+    #[test]
+    fn test_symbol_default() {
+        assert_eq!(Symbol::default(), Symbol::empty());
+    }
+
+    /// Verify that Interner's Default implementation initializes correctly
+    #[test]
+    fn test_interner_default() {
+        let interner = Interner::default();
+        assert_eq!(interner.get(Symbol::empty()), "");
+    }
+
+    /// Verify that Symbol implements Display correctly
+    #[test]
+    fn test_symbol_display_format() {
+        let symbol = Symbol { id: 100 };
+        assert_eq!(format!("{}", symbol), "100");
+    }
+
+    /// Verify Symbol PartialEq, Eq, and Hash properties
+    #[test]
+    fn test_symbol_eq_and_hash() {
+        use std::collections::hash_map::DefaultHasher;
+        use std::hash::{Hash, Hasher};
+
+        let sym1 = Symbol { id: 10 };
+        let sym2 = Symbol { id: 10 };
+        let sym3 = Symbol { id: 20 };
+
+        assert!(sym1 == sym2);
+        assert!(sym1 != sym3);
+
+        let mut h1 = DefaultHasher::new();
+        sym1.hash(&mut h1);
+        let mut h2 = DefaultHasher::new();
+        sym2.hash(&mut h2);
+
+        assert_eq!(h1.finish(), h2.finish());
+    }
 }

--- a/meerkat-lib/src/runtime/interner.rs
+++ b/meerkat-lib/src/runtime/interner.rs
@@ -6,8 +6,6 @@
 //! This implementation intentionally copies strings to avoid viral
 //! lifetime annotations
 
-use serde::Deserialize;
-use serde::Serialize;
 use std::collections::HashMap;
 
 /// A numeric representation of an identifier or symbol
@@ -75,47 +73,6 @@ impl Symbol {
     ///     `Self`: The default empty `Symbol`
     pub const fn empty() -> Self {
         Symbol { id: 0 }
-    }
-}
-
-/// Implement the `Serialize` trait for the `Symbol` struct
-///
-/// This serializes the symbol as a single `u32` value to maintain
-/// compatibility with the network representation of symbols
-impl Serialize for Symbol {
-    /// Serialize the symbol into a raw `u32` value
-    ///
-    /// Args:
-    ///     `serializer` (`S`): The serializer target
-    ///
-    /// Returns:
-    ///     `Result<S::Ok, S::Error>`: The serialization result
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        self.id.serialize(serializer)
-    }
-}
-
-/// Implement the `Deserialize` trait for the `Symbol` struct
-///
-/// This deserializes the symbol from a single `u32` value to maintain
-/// compatibility with the network representation of symbols
-impl<'de> Deserialize<'de> for Symbol {
-    /// Deserialize the symbol from a raw `u32` value
-    ///
-    /// Args:
-    ///     `deserializer` (`D`): The deserializer source
-    ///
-    /// Returns:
-    ///     `Result<Self, D::Error>`: The deserialized symbol instance
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        let id = u32::deserialize(deserializer)?;
-        Ok(Symbol { id })
     }
 }
 
@@ -189,23 +146,6 @@ impl Interner {
     pub fn get(&self, id: Symbol) -> &str {
         let idx = id.id as usize;
         self.strings.get(idx).map(|s| s.as_str()).unwrap_or("")
-    }
-
-    /// Exposes validation check for a symbol
-    ///
-    /// Checks if a raw symbol `id` is valid within this `Interner`
-    ///
-    /// Args:
-    ///     `id` (`u32`): The raw ID to check
-    ///
-    /// Returns:
-    ///     `Option<Symbol>`: The validated symbol, or `None` if invalid
-    pub fn get_symbol(&self, id: u32) -> Option<Symbol> {
-        if id < self.next_id {
-            Some(Symbol { id })
-        } else {
-            None
-        }
     }
 }
 

--- a/meerkat-lib/src/runtime/interner.rs
+++ b/meerkat-lib/src/runtime/interner.rs
@@ -5,8 +5,17 @@
 //!
 //! This implementation intentionally copies strings to avoid viral
 //! lifetime annotations
+//!
+//! Callers must validate all inputs against the `limits.rs` file.
+//! Returning a `Result` from the interner would require pattern
+//! matching across the entire library, bloating the codebase
+//! massively. The `assert` provides a fail-fast panic to protect
+//! the interner's internal state. Input validation is the caller's
+//! responsibility exclusively at zero-trust boundary entry points
 
 use std::collections::HashMap;
+
+use crate::runtime::limits::MAX_IDENTIFIER_LENGTH;
 
 /// A numeric representation of an identifier or symbol
 ///
@@ -121,6 +130,10 @@ impl Interner {
     /// Returns:
     ///     `Symbol`: The unique symbol representing the string
     pub fn insert(&mut self, s: &str) -> Symbol {
+        assert!(
+            s.len() <= MAX_IDENTIFIER_LENGTH,
+            "it exceeded the maximum identifier limit"
+        );
         if let Some(&id) = self.index.get(s) {
             return Symbol { id };
         }
@@ -256,5 +269,15 @@ mod tests {
         sym2.hash(&mut h2);
 
         assert_eq!(h1.finish(), h2.finish());
+    }
+
+    /// Verify that inserting an identifier exceeding the length
+    /// limit panics
+    #[test]
+    #[should_panic(expected = "it exceeded the maximum identifier limit")]
+    fn test_interner_exceeds_identifier_limit_panics() {
+        let mut interner = Interner::new();
+        let long_ident = "a".repeat(MAX_IDENTIFIER_LENGTH + 1);
+        interner.insert(&long_ident);
     }
 }

--- a/meerkat-lib/src/runtime/interpreter/evaluator.rs
+++ b/meerkat-lib/src/runtime/interpreter/evaluator.rs
@@ -1,54 +1,68 @@
 use crate::ast::{BinOp, Expr, UnOp, Value};
-use crate::runtime::manager::Manager;
+use crate::runtime::interner::Symbol;
 use crate::runtime::txn::Transaction;
+use crate::runtime::Manager;
 use std::collections::HashSet;
 
 #[derive(Debug)]
 pub enum EvalError {
     TypeError(String),
-    NetworkError(String),
-    LookupError(String),
+    VarNotFound(String),
+    ServiceNotFound(String),
+    LocalDispatchFailed(String),
+    RemoteDispatchFailed(String),
     NotImplemented,
-    LockConflict(String),
-    /// A transaction lost a wait-die contest (an older transaction holds the
-    /// lock) and must abort and retry with a higher iteration.
     WaitDieAbort(String),
-    /// Wait-die wait: the requester is older than the current holder and should
-    /// wait for the lock to free. Carries the contended (service, var) so the
-    /// owner can park the request on that variable's wait queue.
-    WaitOn(String, String),
+    WaitOn(Symbol, Symbol),
 }
 
+/// Implement the `Display` trait for the `EvalError` type
+///
+/// This prints user-facing descriptions of evaluator errors
 impl std::fmt::Display for EvalError {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    /// Format the evaluation error for display
+    ///
+    /// Args:
+    ///     `f` (`&mut std::fmt::Formatter<'_>`): The formatter target
+    ///
+    /// Returns:
+    ///     `std::fmt::Result`: The result of the formatting operation
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             EvalError::TypeError(s) => write!(f, "Type error: {}", s),
-            EvalError::NetworkError(s) => write!(f, "Network error: {}", s),
-            EvalError::LookupError(s) => write!(f, "Lookup error: {}", s),
-            EvalError::NotImplemented => write!(f, "Not yet implemented"),
-            EvalError::LockConflict(s) => write!(f, "Lock conflict: {}", s),
+            EvalError::VarNotFound(s) => write!(f, "Variable not found: {}", s),
+            EvalError::ServiceNotFound(s) => write!(f, "Service not found: {}", s),
+            EvalError::LocalDispatchFailed(s) => write!(f, "Local dispatch failed: {}", s),
+            EvalError::RemoteDispatchFailed(s) => write!(f, "Remote dispatch failed: {}", s),
+            EvalError::NotImplemented => write!(f, "Not implemented"),
             EvalError::WaitDieAbort(s) => write!(f, "Wait-die abort: {}", s),
-            EvalError::WaitOn(service, var) => write!(f, "Wait-die wait on {}::{}", service, var),
+            EvalError::WaitOn(service, var) => {
+                write!(f, "Wait-die wait on Symbol({})::Symbol({})", service, var)
+            }
         }
     }
 }
 
 impl std::error::Error for EvalError {}
 
-/// Evaluation context: holds the stable execution state that doesn't
-/// change per call frame. Passed as &mut so manager can be updated.
-/// env is kept separate since it changes at each function call boundary.
+/// Evaluation context represented by `EvalContext`
+///
+/// Holds the stable execution state that does not change per call
+/// frame. Passed as `&mut` so the `manager` can be updated
+///
+/// The `env` parameter is kept separate since it changes at each
+/// function call boundary
 pub struct EvalContext<'a> {
     pub manager: &'a mut Manager,
-    pub service_name: &'a str,
-    /// Active transaction, if evaluation is happening inside one.
+    pub service_name: Symbol,
+    /// Active transaction if evaluation is happening inside one
     pub txn: Option<&'a mut Transaction>,
 }
 
 #[async_recursion::async_recursion]
 pub async fn eval(
     expr: &Expr,
-    env: &[(String, Value)],
+    env: &[(Symbol, Value)],
     ctx: &mut EvalContext<'_>,
 ) -> Result<Value, EvalError> {
     match expr {
@@ -69,14 +83,14 @@ pub async fn eval(
                 } => {
                     let mut new_env = closure_env.clone();
                     for (param, arg_val) in params.iter().zip(arg_vals) {
-                        new_env.push((param.clone(), arg_val));
+                        new_env.push((*param, arg_val));
                     }
                     eval(
                         &body,
                         &new_env,
                         &mut EvalContext {
                             manager: ctx.manager,
-                            service_name: &closure_svc,
+                            service_name: closure_svc,
                             txn: ctx.txn.as_deref_mut(),
                         },
                     )
@@ -88,14 +102,14 @@ pub async fn eval(
             }
         }
 
-        Expr::Variable { ident } => {
+        &Expr::Variable { name } => {
             for (var_name, var_val) in env.iter().rev() {
-                if var_name == ident {
+                if *var_name == name {
                     return Ok(var_val.clone());
                 }
             }
             ctx.manager
-                .lookup(ident, ctx.service_name, ctx.txn.as_deref_mut())
+                .lookup(name, ctx.service_name, ctx.txn.as_deref_mut())
                 .await
         }
 
@@ -159,20 +173,17 @@ pub async fn eval(
         }
 
         Expr::Func { params, body } => {
-            let var_binded: HashSet<String> = params.iter().cloned().collect();
+            let var_binded: HashSet<Symbol> = params.iter().cloned().collect();
             let free_vars = body.free_var(&HashSet::new(), &var_binded);
-            let captured_env: Vec<(String, Value)> = env
+            let captured_env: Vec<(Symbol, Value)> = env
                 .iter()
                 .filter(|(name, _)| {
                     free_vars.contains(name)
                         && !ctx
                             .manager
                             .services
-                            .get(ctx.service_name)
-                            .map(|s| {
-                                s.vars.contains_key(name.as_str())
-                                    || s.defs.contains_key(name.as_str())
-                            })
+                            .get(&ctx.service_name)
+                            .map(|s| s.vars.contains_key(name) || s.defs.contains_key(name))
                             .unwrap_or(false)
                 })
                 .cloned()
@@ -181,30 +192,29 @@ pub async fn eval(
                 params: params.clone(),
                 body: body.clone(),
                 env: captured_env,
-                service_name: ctx.service_name.to_string(),
+                service_name: ctx.service_name,
             })
         }
 
         Expr::Action(stmts) => {
-            // Use free_var on the Action expression itself to find free variables
-            // Service vars/defs are looked up fresh via the manager at execution time
+            // Use `free_var` on the `Action` expression itself to find
+            // free variables
+            // Service `vars` or `defs` are looked up fresh via the
+            // `manager` at execution time
             let action_expr = Expr::Action(stmts.clone());
             let free_vars = action_expr.free_var(
                 &std::collections::HashSet::new(),
                 &std::collections::HashSet::new(),
             );
-            let captured_env: Vec<(String, Value)> = env
+            let captured_env: Vec<(Symbol, Value)> = env
                 .iter()
                 .filter(|(name, _)| {
                     free_vars.contains(name)
                         && !ctx
                             .manager
                             .services
-                            .get(ctx.service_name)
-                            .map(|s| {
-                                s.vars.contains_key(name.as_str())
-                                    || s.defs.contains_key(name.as_str())
-                            })
+                            .get(&ctx.service_name)
+                            .map(|s| s.vars.contains_key(name) || s.defs.contains_key(name))
                             .unwrap_or(false)
                 })
                 .cloned()
@@ -212,35 +222,46 @@ pub async fn eval(
             Ok(Value::ActionClosure {
                 stmts: stmts.clone(),
                 env: captured_env,
-                // Stamp the action with its owning service's identity (which
-                // embeds this node's address), so it stays executable wherever
-                // the closure travels.
-                service: ctx.manager.id_for_service(ctx.service_name),
+                // Stamp the action with its owning service's identity
+                // (which embeds this node's address), so it stays
+                // executable wherever the `closure` travels
+                service_net_id: ctx.manager.service_net_id_for_name(ctx.service_name),
             })
         }
 
-        Expr::MemberAccess { service, member } => {
-            // Manager figures out whether service is local or remote
+        &Expr::MemberAccess {
+            service_name,
+            member_name,
+        } => {
+            // The `Manager` determines whether the service is local or
+            // remote
             ctx.manager
-                .lookup(member, service, ctx.txn.as_deref_mut())
+                .lookup(member_name, service_name, ctx.txn.as_deref_mut())
                 .await
         }
-        _ => Err(EvalError::NotImplemented),
+        Expr::Tuple { .. }
+        | Expr::KeyVal { .. }
+        | Expr::Select { .. }
+        | Expr::Table { .. }
+        | Expr::Fold { .. } => Err(EvalError::NotImplemented),
     }
 }
 
+/// Unit tests for the evaluator
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::ast::{ActionStmt, BinOp, Expr, Value};
+    use crate::runtime::interner::Interner;
     use crate::runtime::Manager;
 
+    /// Verify that evaluating a literal expression returns the expected runtime `Value`
     #[tokio::test]
     async fn test_literal() {
-        let mut manager = Manager::default();
+        let mut manager = Manager::new(Interner::new());
         let mut ctx = EvalContext {
             manager: &mut manager,
-            service_name: "",
+            service_name: Symbol::empty(),
             txn: None,
         };
         let expr = Expr::Literal {
@@ -250,12 +271,13 @@ mod tests {
         assert_eq!(result, Value::Number { val: 42 });
     }
 
+    /// Verify that evaluating a binary add operation returns the sum of the numbers
     #[tokio::test]
     async fn test_binop_add() {
-        let mut manager = Manager::default();
+        let mut manager = Manager::new(Interner::new());
         let mut ctx = EvalContext {
             manager: &mut manager,
-            service_name: "",
+            service_name: Symbol::empty(),
             txn: None,
         };
         let expr = Expr::Binop {
@@ -271,21 +293,21 @@ mod tests {
         assert_eq!(result, Value::Number { val: 5 });
     }
 
+    /// Verify that defining a function and calling it yields the expected computed `Value`
     #[tokio::test]
     async fn test_func_and_call() {
-        let mut manager = Manager::default();
+        let mut manager = Manager::new(Interner::new());
+        let x = manager.interner.insert("x");
         let mut ctx = EvalContext {
             manager: &mut manager,
-            service_name: "",
+            service_name: Symbol::empty(),
             txn: None,
         };
         let func_expr = Expr::Func {
-            params: vec!["x".to_string()],
+            params: vec![x],
             body: Box::new(Expr::Binop {
                 op: BinOp::Add,
-                expr1: Box::new(Expr::Variable {
-                    ident: "x".to_string(),
-                }),
+                expr1: Box::new(Expr::Variable { name: x }),
                 expr2: Box::new(Expr::Literal {
                     val: Value::Number { val: 10 },
                 }),
@@ -301,16 +323,18 @@ mod tests {
         assert_eq!(result, Value::Number { val: 15 });
     }
 
+    /// Verify that evaluating an action statement block produces an action `Value::ActionClosure`
     #[tokio::test]
     async fn test_action_creation() {
-        let mut manager = Manager::default();
+        let mut manager = Manager::new(Interner::new());
+        let var_name = manager.interner.insert("var_name");
         let mut ctx = EvalContext {
             manager: &mut manager,
-            service_name: "",
+            service_name: Symbol::empty(),
             txn: None,
         };
         let action_expr = Expr::Action(vec![ActionStmt::Assign {
-            var: "x".to_string(),
+            name: var_name,
             expr: Expr::Literal {
                 val: Value::Number { val: 5 },
             },
@@ -322,29 +346,30 @@ mod tests {
         }
     }
 
+    /// Verify that created `Value::Closure`s capture only their referenced free variables from the environment
     #[tokio::test]
     async fn test_closure_captures_only_free_vars() {
-        let mut manager = Manager::default();
+        let mut manager = Manager::new(Interner::new());
+        let v1 = manager.interner.insert("v1");
+        let v2 = manager.interner.insert("v2");
+        let v3 = manager.interner.insert("v3");
+        let v4 = manager.interner.insert("v4");
         let mut ctx = EvalContext {
             manager: &mut manager,
-            service_name: "",
+            service_name: Symbol::empty(),
             txn: None,
         };
         let env = vec![
-            ("a".to_string(), Value::Number { val: 1 }),
-            ("b".to_string(), Value::Number { val: 2 }),
-            ("c".to_string(), Value::Number { val: 3 }),
+            (v1, Value::Number { val: 1 }),
+            (v2, Value::Number { val: 2 }),
+            (v3, Value::Number { val: 3 }),
         ];
         let func_expr = Expr::Func {
-            params: vec!["x".to_string()],
+            params: vec![v4],
             body: Box::new(Expr::Binop {
                 op: BinOp::Add,
-                expr1: Box::new(Expr::Variable {
-                    ident: "x".to_string(),
-                }),
-                expr2: Box::new(Expr::Variable {
-                    ident: "a".to_string(),
-                }),
+                expr1: Box::new(Expr::Variable { name: v4 }),
+                expr2: Box::new(Expr::Variable { name: v1 }),
             }),
         };
         let result = eval(&func_expr, &env, &mut ctx).await.unwrap();
@@ -357,7 +382,7 @@ mod tests {
             } => {
                 assert_eq!(params.len(), 1);
                 assert_eq!(captured_env.len(), 1);
-                assert_eq!(captured_env[0].0, "a");
+                assert_eq!(captured_env[0].0, v1);
                 assert_eq!(captured_env[0].1, Value::Number { val: 1 });
             }
             _ => panic!("Expected Closure"),

--- a/meerkat-lib/src/runtime/interpreter/executor.rs
+++ b/meerkat-lib/src/runtime/interpreter/executor.rs
@@ -1,28 +1,29 @@
 use super::evaluator::{eval, EvalContext, EvalError};
 use crate::ast::{ActionStmt, Value};
+use crate::runtime::interner::Symbol;
 use crate::runtime::txn::Transaction;
 use crate::runtime::Manager;
 
-/// The effect produced by executing a single statement.
+/// The effect produced by executing a single statement using `ExecuteEffect`
 pub enum ExecuteEffect {
-    /// Statement completed with no binding or value.
+    /// Statement completed with no binding or value
     None,
-    /// A `let` binding: the name and value to add to env.
-    Binding(String, Value),
-    /// An expression statement was evaluated: the result value.
+    /// A `let` binding: the name and value to add to `env`
+    Binding(Symbol, Value),
+    /// An expression statement was evaluated: the result value
     ExprValue(Value),
 }
 
 #[async_recursion::async_recursion]
 pub async fn execute(
     stmt: &ActionStmt,
-    env: &[(String, Value)],
+    env: &[(Symbol, Value)],
     manager: &mut Manager,
-    service_name: &str,
+    service_name: Symbol,
     mut txn: Option<&mut Transaction>,
 ) -> Result<ExecuteEffect, EvalError> {
     match stmt {
-        ActionStmt::Assign { var, expr } => {
+        ActionStmt::Assign { name, expr } => {
             let value = eval(
                 expr,
                 env,
@@ -33,7 +34,7 @@ pub async fn execute(
                 },
             )
             .await?;
-            manager.assign(service_name, var, value, txn).await?;
+            manager.assign(service_name, *name, value, txn).await?;
             Ok(ExecuteEffect::None)
         }
         ActionStmt::Do(expr) => {
@@ -51,18 +52,20 @@ pub async fn execute(
                 Value::ActionClosure {
                     stmts,
                     env: closure_env,
-                    service: action_sid,
+                    service_net_id,
                 } => {
-                    // name_for_id tells us whether the action's service is local
-                    // (Some => its in-scope name) or remote (None). For remote we
-                    // ship to the owning node using the address embedded in the
-                    // ServiceId, so it runs even if not imported into this scope.
-                    match manager.name_for_id(&action_sid) {
+                    // `service_name_for_net_id` tells us whether the action's
+                    // service is local (`Some` => its in-scope name) or remote
+                    // (`None`)
+                    // For remote, we ship to the owning node using the address
+                    // embedded in the `ServiceNetId`, so it runs even if not
+                    // imported into this scope
+                    match manager.service_name_for_net_id(&service_net_id) {
                         Some(svc_name) => {
                             let mut exec_env = closure_env.clone();
                             for s in &stmts {
                                 if let ExecuteEffect::Binding(name, val) =
-                                    execute(s, &exec_env, manager, &svc_name, txn.as_deref_mut())
+                                    execute(s, &exec_env, manager, svc_name, txn.as_deref_mut())
                                         .await?
                                 {
                                     exec_env.push((name, val));
@@ -70,11 +73,16 @@ pub async fn execute(
                             }
                         }
                         None => {
-                            // Ship to its owning node under the shared transaction
-                            // (Option B); the remote node executes and holds until
-                            // our commit/abort.
+                            // Ship to its owning node under the shared
+                            // transaction; the remote node executes
+                            // and holds until our `commit` or `abort`
                             manager
-                                .remote_action(&action_sid, stmts, closure_env, txn.as_deref_mut())
+                                .remote_action(
+                                    &service_net_id,
+                                    stmts,
+                                    closure_env,
+                                    txn.as_deref_mut(),
+                                )
                                 .await?;
                         }
                     }
@@ -113,7 +121,7 @@ pub async fn execute(
                 },
             )
             .await?;
-            Ok(ExecuteEffect::Binding(name.clone(), val))
+            Ok(ExecuteEffect::Binding(*name, val))
         }
         ActionStmt::Expr(expr) => {
             let val = eval(

--- a/meerkat-lib/src/runtime/limits.rs
+++ b/meerkat-lib/src/runtime/limits.rs
@@ -1,0 +1,7 @@
+//! System limits for Meerkat
+
+/// Maximum allowed length of an identifier in characters
+pub const MAX_IDENTIFIER_LENGTH: usize = 64;
+
+/// Maximum allowed length of a string literal in characters
+pub const MAX_STRING_LITERAL_LENGTH: usize = 8192;

--- a/meerkat-lib/src/runtime/manager/mod.rs
+++ b/meerkat-lib/src/runtime/manager/mod.rs
@@ -359,8 +359,9 @@ impl Manager {
             }
         }
         Err(EvalError::VarNotFound(format!(
-            "Variable Symbol({}) not found in service Symbol({})",
-            var_name, service_name
+            "Variable '{}' not found in service '{}'",
+            self.interner.get(var_name),
+            self.interner.get(service_name)
         )))
     }
 
@@ -429,14 +430,15 @@ impl Manager {
                 var_state.value = value;
             } else {
                 return Err(EvalError::VarNotFound(format!(
-                    "Variable Symbol({}) not found in service Symbol({})",
-                    var_name, service_name
+                    "Variable '{}' not found in service '{}'",
+                    self.interner.get(var_name),
+                    self.interner.get(service_name)
                 )));
             }
         } else {
             return Err(EvalError::ServiceNotFound(format!(
-                "Service Symbol({}) not found",
-                service_name
+                "Service '{}' not found",
+                self.interner.get(service_name)
             )));
         }
 
@@ -497,7 +499,11 @@ impl Manager {
                         Err(e) => {
                             // Propagation is best-effort; durable retry of failed
                             // updates is tracked under issue #24 (async updates).
-                            log::warn!("propagation of def Symbol({}) failed: {}", def_name, e);
+                            log::warn!(
+                                "propagation of def '{}' failed: {}",
+                                self.interner.get(def_name),
+                                e
+                            );
                             continue;
                         }
                     };
@@ -624,7 +630,10 @@ impl Manager {
     ///     EvalError::ServiceNotFound: If the remote service is not registered
     fn remote_addr(&self, service: Symbol) -> Result<Address, EvalError> {
         let full_url = self.remote_services.get(&service).ok_or_else(|| {
-            EvalError::ServiceNotFound(format!("Remote service Symbol({}) not found", service))
+            EvalError::ServiceNotFound(format!(
+                "Remote service '{}' not found",
+                self.interner.get(service)
+            ))
         })?;
         let service_str = self.interner.get(service);
         let addr_str = full_url.0.trim_end_matches(&format!("/{}", service_str));
@@ -750,8 +759,9 @@ impl Manager {
                 msg,
                 request_id,
                 format!(
-                    "Timeout waiting for remote lookup of Symbol({}).Symbol({})",
-                    service, member
+                    "Timeout waiting for remote lookup of '{}.{}'",
+                    self.interner.get(service),
+                    self.interner.get(member)
                 ),
             )
             .await?;
@@ -988,19 +998,21 @@ impl Manager {
         txn_id: &TxnId,
     ) -> Result<(), EvalError> {
         let service = self.services.get_mut(&service_name).ok_or_else(|| {
-            EvalError::ServiceNotFound(format!("Service Symbol({}) not found", service_name))
+            EvalError::ServiceNotFound(format!(
+                "Service '{}' not found",
+                self.interner.get(service_name)
+            ))
         })?;
-        let var_state = service
-            .vars
-            .get_mut(&var)
-            .ok_or_else(|| EvalError::VarNotFound(format!("Variable Symbol({}) not found", var)))?;
+        let var_state = service.vars.get_mut(&var).ok_or_else(|| {
+            EvalError::VarNotFound(format!("Variable '{}' not found", self.interner.get(var)))
+        })?;
         if var_state.lock.try_write(txn_id) {
             Ok(())
         } else {
             match var_state.lock.wait_die(txn_id) {
                 crate::runtime::txn::WaitDie::Die => Err(EvalError::WaitDieAbort(format!(
-                    "transaction died contending for write lock on Symbol({})",
-                    var
+                    "transaction died contending for write lock on '{}'",
+                    self.interner.get(var)
                 ))),
                 crate::runtime::txn::WaitDie::Wait => Err(EvalError::WaitOn(service_name, var)),
             }
@@ -1032,19 +1044,21 @@ impl Manager {
         txn_id: &TxnId,
     ) -> Result<(), EvalError> {
         let service = self.services.get_mut(&service_name).ok_or_else(|| {
-            EvalError::ServiceNotFound(format!("Service Symbol({}) not found", service_name))
+            EvalError::ServiceNotFound(format!(
+                "Service '{}' not found",
+                self.interner.get(service_name)
+            ))
         })?;
-        let var_state = service
-            .vars
-            .get_mut(&var)
-            .ok_or_else(|| EvalError::VarNotFound(format!("Variable Symbol({}) not found", var)))?;
+        let var_state = service.vars.get_mut(&var).ok_or_else(|| {
+            EvalError::VarNotFound(format!("Variable '{}' not found", self.interner.get(var)))
+        })?;
         if var_state.lock.try_read(txn_id) {
             Ok(())
         } else {
             match var_state.lock.wait_die(txn_id) {
                 crate::runtime::txn::WaitDie::Die => Err(EvalError::WaitDieAbort(format!(
-                    "transaction died contending for read lock on Symbol({})",
-                    var
+                    "transaction died contending for read lock on '{}'",
+                    self.interner.get(var)
                 ))),
                 crate::runtime::txn::WaitDie::Wait => Err(EvalError::WaitOn(service_name, var)),
             }
@@ -1075,19 +1089,21 @@ impl Manager {
         txn_id: &TxnId,
     ) -> Result<(), EvalError> {
         let service = self.services.get_mut(&service_name).ok_or_else(|| {
-            EvalError::ServiceNotFound(format!("Service Symbol({}) not found", service_name))
+            EvalError::ServiceNotFound(format!(
+                "Service '{}' not found",
+                self.interner.get(service_name)
+            ))
         })?;
-        let var_state = service
-            .vars
-            .get_mut(&var)
-            .ok_or_else(|| EvalError::VarNotFound(format!("Variable Symbol({}) not found", var)))?;
+        let var_state = service.vars.get_mut(&var).ok_or_else(|| {
+            EvalError::VarNotFound(format!("Variable '{}' not found", self.interner.get(var)))
+        })?;
         if var_state.lock.upgrade_to_write(txn_id) {
             Ok(())
         } else {
             match var_state.lock.wait_die(txn_id) {
                 crate::runtime::txn::WaitDie::Die => Err(EvalError::WaitDieAbort(format!(
-                    "transaction died contending to upgrade lock on Symbol({})",
-                    var
+                    "transaction died contending to upgrade lock on '{}'",
+                    self.interner.get(var)
                 ))),
                 crate::runtime::txn::WaitDie::Wait => Err(EvalError::WaitOn(service_name, var)),
             }

--- a/meerkat-lib/src/runtime/manager/mod.rs
+++ b/meerkat-lib/src/runtime/manager/mod.rs
@@ -2,7 +2,11 @@ use super::ast::{ActionStmt, Decl, Expr, Value};
 use super::interpreter::{eval, execute, EvalContext, EvalError, ExecuteEffect};
 use super::semantic_analysis::var_analysis::{calc_dep_srv, DependAnalysis};
 use crate::net::network_layer::NetworkLayer;
-use crate::net::{Address, MeerkatMessage, NetworkActor, NetworkCommand, NetworkEvent, ServiceId};
+use crate::net::{
+    codec, Address, MeerkatMessage, NetworkActor, NetworkCommand, NetworkEvent, NetworkReply,
+    ServiceNetId,
+};
+use crate::runtime::interner::{Interner, Symbol};
 use crate::runtime::txn::{Transaction, TxnId, VarState};
 use std::collections::{HashMap, HashSet};
 use tokio::sync::oneshot;
@@ -10,11 +14,11 @@ use tokio::time::Duration;
 
 pub struct Service {
     /// Globally unique identity of this service (address-based when networked).
-    pub id: ServiceId,
-    pub name: String,
+    pub id: ServiceNetId,
+    pub name: Symbol,
     /// Per-variable state: value, lock, and latest write transaction in one place
-    pub vars: HashMap<String, VarState>,
-    pub defs: HashMap<String, Expr>, // original def expressions for re-evaluation
+    pub vars: HashMap<Symbol, VarState>,
+    pub defs: HashMap<Symbol, Expr>, // original def expressions for re-evaluation
     pub dep: DependAnalysis,         // dependency graph + topo order
 }
 
@@ -26,16 +30,16 @@ pub enum ParkedRequest {
     Action {
         request_id: u64,
         reply_to: String,
-        service: String,
+        service: Symbol,
         stmts: Vec<ActionStmt>,
-        env: Vec<(String, Value)>,
+        env: Vec<(Symbol, Value)>,
         tid: TxnId,
     },
     Lookup {
         request_id: u64,
         reply_to: String,
-        service: String,
-        member: String,
+        service: Symbol,
+        member: Symbol,
         tid: TxnId,
     },
 }
@@ -52,9 +56,9 @@ impl ParkedRequest {
 }
 
 pub struct Manager {
-    pub services: HashMap<String, Service>,
+    pub services: HashMap<Symbol, Service>,
     /// Maps service name to remote address (for distributed services)
-    pub remote_services: HashMap<String, Address>,
+    pub remote_services: HashMap<Symbol, Address>,
     /// Network actor for distributed communication
     pub network: Option<NetworkActor>,
     /// Pending reply channels keyed by request_id
@@ -69,7 +73,7 @@ pub struct Manager {
     /// Requests parked because the requesting transaction is older than a lock
     /// holder (wait-die wait), keyed by the contended (service, var). Drained
     /// oldest-first when that variable's lock frees on commit or abort.
-    pub wait_queue: HashMap<(ServiceId, String), Vec<ParkedRequest>>,
+    pub wait_queue: HashMap<(ServiceNetId, Symbol), Vec<ParkedRequest>>,
     /// This node's canonical, dialable address, set once after the network is
     /// listening. Service identities are derived from it, so they are stable for
     /// the life of the process (never empty-then-populated) and match the URL
@@ -77,10 +81,12 @@ pub struct Manager {
     local_address: Option<String>,
     /// Enable local loopback mode
     pub local: bool,
+    /// String interner
+    pub interner: Interner,
 }
 
 impl Manager {
-    pub fn new() -> Self {
+    pub fn new(interner: Interner) -> Self {
         Manager {
             services: HashMap::new(),
             remote_services: HashMap::new(),
@@ -91,13 +97,15 @@ impl Manager {
             wait_queue: HashMap::new(),
             local_address: None,
             local: false,
+            interner,
         }
     }
 
-    /// Park a request on the wait queue for the contended (service, var). It
-    /// receives no reply until that variable's lock frees and it is re-dispatched.
-    pub fn park_request(&mut self, service: &str, var: String, parked: ParkedRequest) {
-        let key = (self.id_for_service(service), var);
+    /// Park a request on the wait queue for the contended `(service, var)`
+    /// It receives no reply until that variable's lock frees and it is
+    /// re-dispatched
+    pub fn park_request(&mut self, service: Symbol, var: Symbol, parked: ParkedRequest) {
+        let key = (self.service_net_id_for_name(service), var);
         self.wait_queue.entry(key).or_default().push(parked);
     }
 
@@ -107,7 +115,7 @@ impl Manager {
     /// being starved by a stream of younger requests.
     pub fn take_ready_waiters(
         &mut self,
-        freed: &HashSet<(ServiceId, String)>,
+        freed: &HashSet<(ServiceNetId, Symbol)>,
     ) -> Vec<ParkedRequest> {
         let mut ready = Vec::new();
         for key in freed {
@@ -172,50 +180,56 @@ impl Manager {
         out
     }
 
-    /// Record this node's canonical address once the network is listening, so
-    /// service identities are stable and consistent with the advertised URL.
+    /// Record this node's canonical address once the network is listening,
+    /// so service identities are stable and consistent with the
+    /// advertised URL
     pub fn set_local_address(&mut self, addr: String) {
         self.local_address = Some(addr);
     }
 
-    /// Compute the global identity of a service owned by this node. When the
-    /// node has a network address, the identity is that address plus the service
-    /// slug; otherwise it falls back to the bare name for local-only execution.
-    fn service_identity(&self, name: &str) -> ServiceId {
+    /// Compute the global identity of a service owned by this node. When
+    /// the node has a network address, the identity is that address plus
+    /// the service slug; otherwise it falls back to the bare name for
+    /// local-only execution
+    fn compute_service_net_id(&self, service_name: Symbol) -> ServiceNetId {
+        let name_str = self.interner.get(service_name);
         match &self.local_address {
-            Some(addr) if !addr.is_empty() => ServiceId::new(format!("{}/{}", addr, name)),
-            // No network address: fall back to the bare name. On a single node
-            // names are unambiguous, and because local_address is fixed at
-            // startup this choice never changes mid-run.
-            _ => ServiceId::new(name),
+            Some(addr) if !addr.is_empty() => ServiceNetId::new(format!("{}/{}", addr, name_str)),
+            Some(_) | None => {
+                // No network address: fall back to the bare name. On a
+                // single node names are unambiguous, and because
+                // `local_address` is fixed at startup this choice never
+                // changes mid-run
+                ServiceNetId::new(name_str)
+            }
         }
     }
 
     pub async fn create_service(
         &mut self,
-        name: String,
+        name: Symbol,
         decls: Vec<Decl>,
     ) -> Result<(), EvalError> {
         let dep = calc_dep_srv(&decls);
 
-        let id = self.service_identity(&name);
-        // Register the service (with its real ServiceId) before evaluating any
-        // declarations, so action closures built during initialization are
-        // stamped with the correct ServiceId instead of id_for_service's
-        // bare-name fallback.
+        let id = self.compute_service_net_id(name);
+        // Register the service (with its real `ServiceNetId`) before
+        // evaluating any declarations, so action closures built during
+        // initialization are stamped with the correct `ServiceNetId`
+        // instead of `service_net_id_for_name`'s bare-name fallback
         self.services.insert(
-            name.clone(),
+            name,
             Service {
                 id,
-                name: name.clone(),
+                name,
                 vars: HashMap::new(),
                 defs: HashMap::new(),
                 dep,
             },
         );
 
-        let mut env: Vec<(String, Value)> = vec![];
-        let svc_name = name.clone();
+        let mut env: Vec<(Symbol, Value)> = vec![];
+        let svc_name = name;
 
         for decl in decls {
             match decl {
@@ -225,12 +239,12 @@ impl Manager {
                         &env,
                         &mut EvalContext {
                             manager: self,
-                            service_name: &svc_name,
+                            service_name: svc_name,
                             txn: None,
                         },
                     )
                     .await?;
-                    env.push((name.clone(), value.clone()));
+                    env.push((name, value.clone()));
                     if let Some(service) = self.services.get_mut(&svc_name) {
                         service.vars.insert(name, VarState::new(value));
                     }
@@ -241,14 +255,14 @@ impl Manager {
                         &env,
                         &mut EvalContext {
                             manager: self,
-                            service_name: &svc_name,
+                            service_name: svc_name,
                             txn: None,
                         },
                     )
                     .await?;
-                    env.push((name.clone(), value.clone()));
+                    env.push((name, value.clone()));
                     if let Some(service) = self.services.get_mut(&svc_name) {
-                        service.vars.insert(name.clone(), VarState::new(value));
+                        service.vars.insert(name, VarState::new(value));
                         service.defs.insert(name, val); // store original expr
                     }
                 }
@@ -261,30 +275,46 @@ impl Manager {
         Ok(())
     }
 
+    /// Lookup a variable or def's value within a service
+    ///
+    /// Evaluates stored def expressions to ensure freshness and acquires
+    /// appropriate read locks when executed inside a transaction.
+    ///
+    /// Args:
+    ///     var_name (Symbol): The symbol of the variable or definition to look up
+    ///     service_name (Symbol): The symbol of the service containing the variable
+    ///     txn (Option<&mut Transaction>): An optional active transaction context
+    ///
+    /// Returns:
+    ///     Result<Value, EvalError>: The retrieved runtime value, or an error
+    ///
+    /// Raises:
+    ///     EvalError::VarNotFound: If the variable does not exist in the service
+    ///     EvalError::ServiceNotFound: If the service is not found
     pub async fn lookup(
         &mut self,
-        ident: &str,
-        service_name: &str,
+        var_name: Symbol,
+        service_name: Symbol,
         mut txn: Option<&mut Transaction>,
     ) -> Result<Value, EvalError> {
         // Check if service is remote
-        if self.remote_services.contains_key(service_name) {
-            return self.remote_lookup(service_name, ident, txn).await;
+        if self.remote_services.contains_key(&service_name) {
+            return self.remote_lookup(service_name, var_name, txn).await;
         }
 
         // If it's a def, re-evaluate from stored expression for freshness.
         // The transaction flows through so the def's underlying vars are locked.
         let def_expr = self
             .services
-            .get(service_name)
-            .and_then(|s| s.defs.get(ident))
+            .get(&service_name)
+            .and_then(|s| s.defs.get(&var_name))
             .cloned();
 
         if let Some(expr) = def_expr {
             // Evaluate the def with an empty env so its dependencies resolve
             // through lookup (acquiring read locks and populating the cache)
             // rather than being pre-seeded from current service var values.
-            let env: Vec<(String, Value)> = Vec::new();
+            let env: Vec<(Symbol, Value)> = Vec::new();
             return eval(
                 &expr,
                 &env,
@@ -301,7 +331,7 @@ impl Manager {
         // present, otherwise acquire a read lock lazily and cache the value.
         // Transaction state is keyed by (service id, variable) so the same name
         // in different services never collides.
-        let key = (self.id_for_service(service_name), ident.to_string());
+        let key = (self.service_net_id_for_name(service_name), var_name);
         let mut need_read_lock: Option<TxnId> = None;
         if let Some(t) = txn.as_deref() {
             if let Some(cached) = t.read_cache.get(&key) {
@@ -312,15 +342,15 @@ impl Manager {
             }
         }
         if let Some(txn_id) = need_read_lock {
-            self.acquire_read_lock(service_name, ident, &txn_id)?;
+            self.acquire_read_lock(service_name, var_name, &txn_id)?;
             if let Some(t) = txn.as_deref_mut() {
                 t.locked.insert(key.clone());
             }
         }
 
         // Return stored var value (and cache it for the transaction)
-        if let Some(service) = self.services.get(service_name) {
-            if let Some(var_state) = service.vars.get(ident) {
+        if let Some(service) = self.services.get(&service_name) {
+            if let Some(var_state) = service.vars.get(&var_name) {
                 let value = var_state.value.clone();
                 if let Some(t) = txn {
                     t.read_cache.insert(key, value.clone());
@@ -328,16 +358,34 @@ impl Manager {
                 return Ok(value);
             }
         }
-        Err(EvalError::LookupError(format!(
-            "Variable '{}' not found in service '{}'",
-            ident, service_name
+        Err(EvalError::VarNotFound(format!(
+            "Variable Symbol({}) not found in service Symbol({})",
+            var_name, service_name
         )))
     }
 
+    /// Assign a value to a service variable
+    ///
+    /// In a transaction, this acquires a write lock (or upgrades an existing read lock)
+    /// and buffers the write. Non-transactional writes are applied immediately and propagated.
+    ///
+    /// Args:
+    ///     service_name (Symbol): The symbol of the service containing the variable
+    ///     var_name (Symbol): The symbol of the variable to assign
+    ///     value (Value): The value to assign to the variable
+    ///     txn (Option<&mut Transaction>): An optional active transaction context
+    ///
+    /// Returns:
+    ///     Result<(), EvalError>: Ok on success, or a lock/validation error
+    ///
+    /// Raises:
+    ///     EvalError::VarNotFound: If the variable does not exist in the service
+    ///     EvalError::ServiceNotFound: If the service is not found
+    ///     EvalError::WaitDieAbort: If the transaction aborts due to lock contention
     pub async fn assign(
         &mut self,
-        service_name: &str,
-        var: &str,
+        service_name: Symbol,
+        var_name: Symbol,
         value: Value,
         txn: Option<&mut Transaction>,
     ) -> Result<(), EvalError> {
@@ -346,7 +394,7 @@ impl Manager {
         // write. The buffered value is applied to the service only at commit, so
         // a transaction that fails partway leaves no partial writes behind.
         if txn.is_some() {
-            let key = (self.id_for_service(service_name), var.to_string());
+            let key = (self.service_net_id_for_name(service_name), var_name);
             enum LockAction {
                 Acquire,
                 Upgrade,
@@ -361,8 +409,10 @@ impl Manager {
                 (t.id.clone(), kind)
             };
             match kind {
-                LockAction::Upgrade => self.upgrade_to_write_lock(service_name, var, &txn_id)?,
-                LockAction::Acquire => self.acquire_write_lock(service_name, var, &txn_id)?,
+                LockAction::Upgrade => {
+                    self.upgrade_to_write_lock(service_name, var_name, &txn_id)?
+                }
+                LockAction::Acquire => self.acquire_write_lock(service_name, var_name, &txn_id)?,
             }
             if let Some(t) = txn {
                 t.locked.insert(key.clone());
@@ -374,46 +424,46 @@ impl Manager {
         }
 
         // Non-transactional path: apply the write immediately and propagate.
-        if let Some(service) = self.services.get_mut(service_name) {
-            if let Some(var_state) = service.vars.get_mut(var) {
+        if let Some(service) = self.services.get_mut(&service_name) {
+            if let Some(var_state) = service.vars.get_mut(&var_name) {
                 var_state.value = value;
             } else {
-                return Err(EvalError::LookupError(format!(
-                    "Variable '{}' not found in service '{}'",
-                    var, service_name
+                return Err(EvalError::VarNotFound(format!(
+                    "Variable Symbol({}) not found in service Symbol({})",
+                    var_name, service_name
                 )));
             }
         } else {
-            return Err(EvalError::LookupError(format!(
-                "Service '{}' not found",
+            return Err(EvalError::ServiceNotFound(format!(
+                "Service Symbol({}) not found",
                 service_name
             )));
         }
 
         // propagate: re-evaluate defs that depend on this var in topo order
-        self.propagate(service_name, var).await;
+        self.propagate(service_name, var_name).await;
         Ok(())
     }
 
-    async fn propagate(&mut self, service_name: &str, changed_var: &str) {
+    async fn propagate(&mut self, service_name: Symbol, changed_var: Symbol) {
         // collect defs that need re-evaluation in topo order
-        let topo_order: Vec<String> = self
+        let topo_order: Vec<Symbol> = self
             .services
-            .get(service_name)
+            .get(&service_name)
             .map(|s| s.dep.topo_order.clone())
             .unwrap_or_default();
 
         for def_name in topo_order {
             let needs_update = self
                 .services
-                .get(service_name)
+                .get(&service_name)
                 .and_then(|s| s.dep.dep_vars.get(&def_name))
-                .map(|dep_vars| dep_vars.contains(changed_var))
+                .map(|dep_vars| dep_vars.contains(&changed_var))
                 .unwrap_or(false);
 
             let is_def = self
                 .services
-                .get(service_name)
+                .get(&service_name)
                 .map(|s| s.defs.contains_key(&def_name))
                 .unwrap_or(false);
 
@@ -421,20 +471,15 @@ impl Manager {
                 // build env from current var values
                 let expr = self
                     .services
-                    .get(service_name)
+                    .get(&service_name)
                     .and_then(|s| s.defs.get(&def_name))
                     .cloned();
 
                 if let Some(expr) = expr {
-                    let env: Vec<(String, Value)> = self
+                    let env: Vec<(Symbol, Value)> = self
                         .services
-                        .get(service_name)
-                        .map(|s| {
-                            s.vars
-                                .iter()
-                                .map(|(k, v)| (k.clone(), v.value.clone()))
-                                .collect()
-                        })
+                        .get(&service_name)
+                        .map(|s| s.vars.iter().map(|(k, v)| (*k, v.value.clone())).collect())
                         .unwrap_or_default();
 
                     let value = match eval(
@@ -452,12 +497,12 @@ impl Manager {
                         Err(e) => {
                             // Propagation is best-effort; durable retry of failed
                             // updates is tracked under issue #24 (async updates).
-                            log::warn!("propagation of def '{}' failed: {}", def_name, e);
+                            log::warn!("propagation of def Symbol({}) failed: {}", def_name, e);
                             continue;
                         }
                     };
 
-                    if let Some(service) = self.services.get_mut(service_name) {
+                    if let Some(service) = self.services.get_mut(&service_name) {
                         if let Some(var_state) = service.vars.get_mut(&def_name) {
                             var_state.value = value;
                         }
@@ -480,23 +525,31 @@ impl Manager {
                         MeerkatMessage::ActionResponse { request_id, .. } => Some(*request_id),
                         MeerkatMessage::CommitResponse { request_id, .. } => Some(*request_id),
                         MeerkatMessage::AbortResponse { request_id, .. } => Some(*request_id),
-                        MeerkatMessage::WaitParked { request_id } => Some(*request_id),
-                        _ => None,
+                        MeerkatMessage::WaitParked { request_id, .. } => Some(*request_id),
+                        MeerkatMessage::Ping { .. }
+                        | MeerkatMessage::Pong { .. }
+                        | MeerkatMessage::Announce { .. }
+                        | MeerkatMessage::Transaction { .. }
+                        | MeerkatMessage::Propagation { .. }
+                        | MeerkatMessage::LookupRequest { .. }
+                        | MeerkatMessage::ActionRequest { .. }
+                        | MeerkatMessage::Commit { .. }
+                        | MeerkatMessage::Abort { .. } => None,
                     };
-                    if let Some(id) = rid {
-                        if let Some(tx) = self.pending_replies.remove(&id) {
+                    if let Some(request_id) = rid {
+                        if let Some(tx) = self.pending_replies.remove(&request_id) {
                             let _ = tx.send(msg);
                         }
                     }
                 }
-                Some(_) => {}
+                Some(NetworkEvent::SendFailed { .. }) => {}
+                Some(NetworkEvent::PeerConnected { .. }) => {}
+                Some(NetworkEvent::PeerDisconnected { .. }) => {}
                 None => break,
             }
         }
     }
 
-    /// Send a message and await a reply using tokio::select! for timeout.
-    /// Encapsulates the duplicated send + register channel + await pattern
     /// shared by remote_lookup and remote_action.
     async fn send_and_await_reply(
         &mut self,
@@ -506,10 +559,9 @@ impl Manager {
         timeout_msg: String,
     ) -> Result<MeerkatMessage, EvalError> {
         // Send the message
-        let net = self
-            .network
-            .as_mut()
-            .ok_or_else(|| EvalError::NetworkError("No network layer available".to_string()))?;
+        let net = self.network.as_mut().ok_or_else(|| {
+            EvalError::LocalDispatchFailed("No network layer available".to_string())
+        })?;
         net.handle_command(NetworkCommand::SendMessage { addr, msg })
             .await;
 
@@ -543,7 +595,7 @@ impl Manager {
                         }
                         Ok(msg) => return Ok(msg),
                         Err(_) => {
-                            return Err(EvalError::NetworkError(
+                            return Err(EvalError::LocalDispatchFailed(
                                 "Reply channel closed".to_string(),
                             ))
                         }
@@ -551,19 +603,31 @@ impl Manager {
                 }
                 _ = &mut timeout => {
                     self.pending_replies.remove(&request_id);
-                    return Err(EvalError::NetworkError(timeout_msg));
+                    return Err(EvalError::LocalDispatchFailed(timeout_msg));
                 }
                 _ = tokio::time::sleep(Duration::from_millis(10)) => {}
             }
         }
     }
 
-    /// Get the network address for a remote service (strips the slug)
-    fn remote_addr(&self, service: &str) -> Result<Address, EvalError> {
-        let full_url = self.remote_services.get(service).ok_or_else(|| {
-            EvalError::LookupError(format!("Remote service '{}' not found", service))
+    /// Retrieve the network address associated with a remote service symbol
+    ///
+    /// Strips the trailing service slug from the registered service URL.
+    ///
+    /// Args:
+    ///     service (Symbol): The remote service symbol to look up
+    ///
+    /// Returns:
+    ///     Result<Address, EvalError>: The target remote network address
+    ///
+    /// Raises:
+    ///     EvalError::ServiceNotFound: If the remote service is not registered
+    fn remote_addr(&self, service: Symbol) -> Result<Address, EvalError> {
+        let full_url = self.remote_services.get(&service).ok_or_else(|| {
+            EvalError::ServiceNotFound(format!("Remote service Symbol({}) not found", service))
         })?;
-        let addr_str = full_url.0.trim_end_matches(&format!("/{}", service));
+        let service_str = self.interner.get(service);
+        let addr_str = full_url.0.trim_end_matches(&format!("/{}", service_str));
         Ok(Address::new(addr_str))
     }
 
@@ -581,7 +645,7 @@ impl Manager {
         let reply = net.handle_command(NetworkCommand::GetLocalAddresses).await;
         let node_ip = self.get_node_ip();
         match reply {
-            crate::net::NetworkReply::LocalAddresses { addrs } => {
+            NetworkReply::LocalAddresses { addrs } => {
                 if let Some(addr) = addrs.first() {
                     let addr_str = addr
                         .0
@@ -592,13 +656,12 @@ impl Manager {
                     String::new()
                 }
             }
-            _ => String::new(),
+            NetworkReply::MessageSent { .. }
+            | NetworkReply::ListenSuccess { .. }
+            | NetworkReply::Failure(_) => String::new(),
         }
     }
 
-    /// Generate a probabilistically-unique node id with no extra dependency.
-    /// RandomState is OS-seeded on native targets; combining it with the current
-    /// time gives a value that is distinct across nodes with high probability.
     fn random_node_id() -> u64 {
         use std::collections::hash_map::RandomState;
         use std::hash::{BuildHasher, Hasher};
@@ -627,10 +690,25 @@ impl Manager {
             .unwrap_or_else(|_| "127.0.0.1".to_string())
     }
 
+    /// Perform a remote variable lookup over the network
+    ///
+    /// Sends a lookup query to the node owning the remote service and registers
+    /// the local node as a transaction participant.
+    ///
+    /// Args:
+    ///     service (Symbol): The remote service symbol
+    ///     member (Symbol): The member/variable symbol within the service
+    ///     txn (Option<&mut Transaction>): The active transaction context
+    ///
+    /// Returns:
+    ///     Result<Value, EvalError>: The retrieved value, or a network/timeout error
+    ///
+    /// Raises:
+    ///     EvalError::LocalDispatchFailed: If a timeout or dispatch error occurs
     pub async fn remote_lookup(
         &mut self,
-        service: &str,
-        member: &str,
+        service: Symbol,
+        member: Symbol,
         txn: Option<&mut Transaction>,
     ) -> Result<Value, EvalError> {
         use std::sync::atomic::{AtomicU64, Ordering};
@@ -660,8 +738,8 @@ impl Manager {
 
         let msg = MeerkatMessage::LookupRequest {
             request_id,
-            service: service.to_string(),
-            member: member.to_string(),
+            service: self.interner.get(service).to_string(),
+            member: self.interner.get(member).to_string(),
             reply_to,
             txn_id: shared_tid,
         };
@@ -672,7 +750,7 @@ impl Manager {
                 msg,
                 request_id,
                 format!(
-                    "Timeout waiting for remote lookup of {}.{}",
+                    "Timeout waiting for remote lookup of Symbol({}).Symbol({})",
                     service, member
                 ),
             )
@@ -680,12 +758,23 @@ impl Manager {
 
         match reply {
             MeerkatMessage::LookupResponse { value, .. } => {
-                let val: Value = serde_json::from_str(&value)
-                    .map_err(|e| EvalError::NetworkError(e.to_string()))?;
+                let val = codec::decode_value(value, &mut self.interner);
                 Ok(val)
             }
-            MeerkatMessage::LookupError { error, .. } => Err(EvalError::LookupError(error)),
-            _ => Err(EvalError::NetworkError(
+            MeerkatMessage::LookupError { error, .. } => Err(EvalError::LocalDispatchFailed(error)),
+            MeerkatMessage::Ping { .. }
+            | MeerkatMessage::Pong { .. }
+            | MeerkatMessage::Announce { .. }
+            | MeerkatMessage::Transaction { .. }
+            | MeerkatMessage::Propagation { .. }
+            | MeerkatMessage::LookupRequest { .. }
+            | MeerkatMessage::ActionRequest { .. }
+            | MeerkatMessage::ActionResponse { .. }
+            | MeerkatMessage::Commit { .. }
+            | MeerkatMessage::CommitResponse { .. }
+            | MeerkatMessage::Abort { .. }
+            | MeerkatMessage::AbortResponse { .. }
+            | MeerkatMessage::WaitParked { .. } => Err(EvalError::LocalDispatchFailed(
                 "Unexpected reply to lookup request".to_string(),
             )),
         }
@@ -697,8 +786,8 @@ impl Manager {
     /// node already prepared for the same transaction.
     pub async fn remote_read_participant(
         &mut self,
-        service: &str,
-        member: &str,
+        service: Symbol,
+        member: Symbol,
         tid: TxnId,
     ) -> Result<Value, EvalError> {
         let mut txn = self
@@ -727,18 +816,19 @@ impl Manager {
 
     pub async fn remote_action(
         &mut self,
-        service_id: &ServiceId,
+        service_net_id: &ServiceNetId,
         stmts: Vec<ActionStmt>,
-        env: Vec<(String, Value)>,
+        env: Vec<(Symbol, Value)>,
         txn: Option<&mut Transaction>,
     ) -> Result<(), EvalError> {
         use std::sync::atomic::{AtomicU64, Ordering};
         static NEXT_ACTION_ID: AtomicU64 = AtomicU64::new(1);
 
-        // Dial the node address embedded in the ServiceId; send the slug as the
-        // service name the remote node uses to find its local service. This works
-        // even if the service was never imported into the current scope (#40).
-        let (addr, slug) = Self::split_service_id(service_id);
+        // Dial the node address embedded in the `ServiceNetId`; send the
+        // slug as the service name the remote node uses to find its local
+        // service. This works even if the service was never imported
+        // into the current scope
+        let (addr, slug) = Self::split_service_net_id(service_net_id);
         let request_id = NEXT_ACTION_ID.fetch_add(1, Ordering::SeqCst);
         let reply_to = self.local_reply_addr().await;
 
@@ -747,22 +837,38 @@ impl Manager {
         // commit/abort. Standalone (no txn) keeps the old commit-immediately path.
         let shared_tid = txn.as_ref().map(|t| t.id.clone());
 
-        // Pre-register the participant BEFORE sending. If the request times out
-        // or the response is lost after the remote already prepared and grabbed
-        // locks, the originator's abort path still iterates txn.participants and
-        // reaches this node to release them. If the remote never received the
-        // request, the Abort it gets is a harmless no-op.
+        // Pre-register the participant BEFORE sending. If the request times
+        // out or the response is lost after the remote already prepared
+        // and grabbed locks, the originator's abort path still iterates
+        // `txn.participants` and reaches this node to release them. If
+        // the remote never received the request, the `Abort` it gets is a
+        // harmless no-op
         if shared_tid.is_some() {
             if let Some(t) = txn {
                 t.participants.insert(addr.clone());
             }
         }
 
+        let net_stmts = stmts
+            .iter()
+            .map(|s| codec::encode_action_stmt(s, &self.interner))
+            .collect();
+
+        let net_env = env
+            .into_iter()
+            .map(|(sym, val)| {
+                (
+                    self.interner.get(sym).to_string(),
+                    codec::encode_value(&val, &self.interner),
+                )
+            })
+            .collect();
+
         let msg = MeerkatMessage::ActionRequest {
             request_id,
             service: slug.clone(),
-            stmts,
-            env,
+            stmts: net_stmts,
+            env: net_env,
             reply_to,
             txn_id: shared_tid,
         };
@@ -782,148 +888,214 @@ impl Manager {
                     // Participant already registered above; nothing more to do.
                     Ok(())
                 } else {
-                    Err(EvalError::NetworkError(
+                    Err(EvalError::LocalDispatchFailed(
                         error.unwrap_or_else(|| "Remote action failed".to_string()),
                     ))
                 }
             }
-            _ => Err(EvalError::NetworkError(
+            MeerkatMessage::Ping { .. }
+            | MeerkatMessage::Pong { .. }
+            | MeerkatMessage::Announce { .. }
+            | MeerkatMessage::Transaction { .. }
+            | MeerkatMessage::Propagation { .. }
+            | MeerkatMessage::LookupRequest { .. }
+            | MeerkatMessage::LookupResponse { .. }
+            | MeerkatMessage::LookupError { .. }
+            | MeerkatMessage::ActionRequest { .. }
+            | MeerkatMessage::Commit { .. }
+            | MeerkatMessage::CommitResponse { .. }
+            | MeerkatMessage::Abort { .. }
+            | MeerkatMessage::AbortResponse { .. }
+            | MeerkatMessage::WaitParked { .. } => Err(EvalError::LocalDispatchFailed(
                 "Unexpected reply to action request".to_string(),
             )),
         }
     }
 
-    /// Resolve an in-scope service name to its global ServiceId. Callers only
-    /// resolve names of local services here (remote reads and actions are routed
-    /// before reaching this), so this returns the service's stored, stable id.
-    /// The bare-name fallback is a defensive default for an unknown name and is
-    /// not used for genuine remote services, whose identities travel embedded in
-    /// their ActionClosures.
-    pub fn id_for_service(&self, service_name: &str) -> ServiceId {
-        self.services
-            .get(service_name)
-            .map(|s| s.id.clone())
-            .unwrap_or_else(|| ServiceId::new(service_name))
-    }
-
-    /// Find a local service (mutably) by its ServiceId.
-    fn service_by_id_mut(&mut self, id: &ServiceId) -> Option<&mut Service> {
-        self.services.values_mut().find(|s| &s.id == id)
-    }
-
-    /// Find the in-scope name of a local service from its ServiceId.
-    pub fn name_for_id(&self, id: &ServiceId) -> Option<String> {
-        self.services
-            .iter()
-            .find(|(_, s)| &s.id == id)
-            .map(|(n, _)| n.clone())
-    }
-
-    /// Split a service identity into the dialable node address and the service
-    /// slug (its trailing name segment). Lets remote_action use the address
-    /// embedded in an ActionClosure's ServiceId rather than requiring the
-    /// service to be imported into the current scope.
-    fn split_service_id(id: &ServiceId) -> (Address, String) {
-        match id.0.rfind('/') {
-            Some(i) => (Address::new(&id.0[..i]), id.0[i + 1..].to_string()),
-            None => (Address::new(String::new()), id.0.clone()),
+    /// Resolve an in-scope service name to its global `ServiceNetId`
+    ///
+    /// Callers only resolve names of local services here (remote reads
+    /// and actions are routed before reaching this), so this returns
+    /// the service's stored, stable ID
+    ///
+    /// The bare-name fallback is a defensive default for an unknown
+    /// name and is not used for genuine remote services, whose
+    /// identities travel embedded in their `ActionClosure`s
+    pub fn service_net_id_for_name(&self, service_name: Symbol) -> ServiceNetId {
+        if let Some(service) = self.services.get(&service_name) {
+            service.id.clone()
+        } else if let Some(addr) = self.remote_services.get(&service_name) {
+            ServiceNetId::new(addr.0.clone())
+        } else {
+            ServiceNetId::new(self.interner.get(service_name))
         }
     }
 
-    /// Try to acquire a write lock on a service variable.
-    /// Returns LockConflict if the variable is already locked.
+    /// Find a local service (mutably) by its `ServiceNetId`
+    fn service_by_net_id_mut(&mut self, service_net_id: &ServiceNetId) -> Option<&mut Service> {
+        self.services.values_mut().find(|s| &s.id == service_net_id)
+    }
+
+    /// Find the in-scope name of a local service from its `ServiceNetId`
+    pub fn service_name_for_net_id(&self, service_net_id: &ServiceNetId) -> Option<Symbol> {
+        self.services
+            .iter()
+            .find(|(_, s)| &s.id == service_net_id)
+            .map(|(n, _)| *n)
+    }
+
+    /// Split a service identity into the dialable node address and the
+    /// service slug (its trailing name segment)
+    ///
+    /// Allows `remote_action` to use the address embedded in an
+    /// `ActionClosure`'s `ServiceNetId` rather than requiring the
+    /// service to be imported into the current scope
+    fn split_service_net_id(service_net_id: &ServiceNetId) -> (Address, String) {
+        match service_net_id.0.rfind('/') {
+            Some(i) => (
+                Address::new(&service_net_id.0[..i]),
+                service_net_id.0[i + 1..].to_string(),
+            ),
+            None => (Address::new(String::new()), service_net_id.0.clone()),
+        }
+    }
+
+    /// Attempt to acquire a write lock on a service variable
+    ///
+    /// If lock contention occurs, determines whether the transaction
+    /// should wait or die according to the wait-die deadlock prevention
+    /// scheme
+    ///
+    /// Args:
+    ///     `service_name` (`Symbol`): The symbol of the service
+    ///     `var` (`Symbol`): The symbol of the variable to lock
+    ///     `txn_id` (`&TxnId`): The ID of the requesting transaction
+    ///
+    /// Returns:
+    ///     `Result<(), EvalError>`: `Ok` on successful lock acquisition, or an error
+    ///
+    /// Raises:
+    ///     `EvalError::VarNotFound`: If the variable does not exist
+    ///     `EvalError::ServiceNotFound`: If the service does not exist
+    ///     `EvalError::WaitDieAbort`: If the transaction aborts under wait-die
+    ///     `EvalError::WaitOn`: If the transaction must wait for the lock
     fn acquire_write_lock(
         &mut self,
-        service_name: &str,
-        var: &str,
+        service_name: Symbol,
+        var: Symbol,
         txn_id: &TxnId,
     ) -> Result<(), EvalError> {
-        let service = self.services.get_mut(service_name).ok_or_else(|| {
-            EvalError::LookupError(format!("Service '{}' not found", service_name))
+        let service = self.services.get_mut(&service_name).ok_or_else(|| {
+            EvalError::ServiceNotFound(format!("Service Symbol({}) not found", service_name))
         })?;
         let var_state = service
             .vars
-            .get_mut(var)
-            .ok_or_else(|| EvalError::LookupError(format!("Variable '{}' not found", var)))?;
+            .get_mut(&var)
+            .ok_or_else(|| EvalError::VarNotFound(format!("Variable Symbol({}) not found", var)))?;
         if var_state.lock.try_write(txn_id) {
             Ok(())
         } else {
             match var_state.lock.wait_die(txn_id) {
                 crate::runtime::txn::WaitDie::Die => Err(EvalError::WaitDieAbort(format!(
-                    "transaction died contending for write lock on '{}'",
+                    "transaction died contending for write lock on Symbol({})",
                     var
                 ))),
-                crate::runtime::txn::WaitDie::Wait => {
-                    Err(EvalError::WaitOn(service_name.to_string(), var.to_string()))
-                }
+                crate::runtime::txn::WaitDie::Wait => Err(EvalError::WaitOn(service_name, var)),
             }
         }
     }
 
-    /// Try to acquire a read lock on a service variable.
-    /// Returns LockConflict if a write lock is held.
+    /// Attempt to acquire a read lock on a service variable
+    ///
+    /// Multi-readers can share read locks, but will conflict with write locks
+    /// Uses wait-die deadlock prevention on contention
+    ///
+    /// Args:
+    ///     `service_name` (`Symbol`): The symbol of the service
+    ///     `var` (`Symbol`): The symbol of the variable to lock
+    ///     `txn_id` (`&TxnId`): The ID of the requesting transaction
+    ///
+    /// Returns:
+    ///     `Result<(), EvalError>`: `Ok` on successful lock acquisition, or an error
+    ///
+    /// Raises:
+    ///     `EvalError::VarNotFound`: If the variable does not exist
+    ///     `EvalError::ServiceNotFound`: If the service does not exist
+    ///     `EvalError::WaitDieAbort`: If the transaction aborts under wait-die
+    ///     `EvalError::WaitOn`: If the transaction must wait for the lock
     fn acquire_read_lock(
         &mut self,
-        service_name: &str,
-        var: &str,
+        service_name: Symbol,
+        var: Symbol,
         txn_id: &TxnId,
     ) -> Result<(), EvalError> {
-        let service = self.services.get_mut(service_name).ok_or_else(|| {
-            EvalError::LookupError(format!("Service '{}' not found", service_name))
+        let service = self.services.get_mut(&service_name).ok_or_else(|| {
+            EvalError::ServiceNotFound(format!("Service Symbol({}) not found", service_name))
         })?;
         let var_state = service
             .vars
-            .get_mut(var)
-            .ok_or_else(|| EvalError::LookupError(format!("Variable '{}' not found", var)))?;
+            .get_mut(&var)
+            .ok_or_else(|| EvalError::VarNotFound(format!("Variable Symbol({}) not found", var)))?;
         if var_state.lock.try_read(txn_id) {
             Ok(())
         } else {
             match var_state.lock.wait_die(txn_id) {
                 crate::runtime::txn::WaitDie::Die => Err(EvalError::WaitDieAbort(format!(
-                    "transaction died contending for read lock on '{}'",
+                    "transaction died contending for read lock on Symbol({})",
                     var
                 ))),
-                crate::runtime::txn::WaitDie::Wait => {
-                    Err(EvalError::WaitOn(service_name.to_string(), var.to_string()))
-                }
+                crate::runtime::txn::WaitDie::Wait => Err(EvalError::WaitOn(service_name, var)),
             }
         }
     }
 
-    /// Upgrade a read lock to a write lock on a service variable.
-    /// Used for read-then-write within the same transaction (e.g. x = x + 1).
+    /// Upgrade an existing read lock to a write lock on a service variable
+    ///
+    /// Used for read-then-write patterns in transactions to avoid conflicts
+    ///
+    /// Args:
+    ///     `service_name` (`Symbol`): The symbol of the service
+    ///     `var` (`Symbol`): The symbol of the variable to lock
+    ///     `txn_id` (`&TxnId`): The ID of the requesting transaction
+    ///
+    /// Returns:
+    ///     `Result<(), EvalError>`: `Ok` on successful lock upgrade, or an error
+    ///
+    /// Raises:
+    ///     `EvalError::VarNotFound`: If the variable does not exist
+    ///     `EvalError::ServiceNotFound`: If the service does not exist
+    ///     `EvalError::WaitDieAbort`: If the transaction aborts under wait-die
+    ///     `EvalError::WaitOn`: If the transaction must wait for the lock
     fn upgrade_to_write_lock(
         &mut self,
-        service_name: &str,
-        var: &str,
+        service_name: Symbol,
+        var: Symbol,
         txn_id: &TxnId,
     ) -> Result<(), EvalError> {
-        let service = self.services.get_mut(service_name).ok_or_else(|| {
-            EvalError::LookupError(format!("Service '{}' not found", service_name))
+        let service = self.services.get_mut(&service_name).ok_or_else(|| {
+            EvalError::ServiceNotFound(format!("Service Symbol({}) not found", service_name))
         })?;
         let var_state = service
             .vars
-            .get_mut(var)
-            .ok_or_else(|| EvalError::LookupError(format!("Variable '{}' not found", var)))?;
+            .get_mut(&var)
+            .ok_or_else(|| EvalError::VarNotFound(format!("Variable Symbol({}) not found", var)))?;
         if var_state.lock.upgrade_to_write(txn_id) {
             Ok(())
         } else {
             match var_state.lock.wait_die(txn_id) {
                 crate::runtime::txn::WaitDie::Die => Err(EvalError::WaitDieAbort(format!(
-                    "transaction died contending to upgrade lock on '{}'",
+                    "transaction died contending to upgrade lock on Symbol({})",
                     var
                 ))),
-                crate::runtime::txn::WaitDie::Wait => {
-                    Err(EvalError::WaitOn(service_name.to_string(), var.to_string()))
-                }
+                crate::runtime::txn::WaitDie::Wait => Err(EvalError::WaitOn(service_name, var)),
             }
         }
     }
 
-    /// Release all locks held by txn_id on the given variables.
-    fn release_locks(&mut self, locked: &HashSet<(ServiceId, String)>, txn_id: &TxnId) {
+    /// Release all locks held by `txn_id` on the given variables
+    fn release_locks(&mut self, locked: &HashSet<(ServiceNetId, Symbol)>, txn_id: &TxnId) {
         for (sid, var) in locked {
-            if let Some(service) = self.service_by_id_mut(sid) {
+            if let Some(service) = self.service_by_net_id_mut(sid) {
                 if let Some(var_state) = service.vars.get_mut(var) {
                     var_state.lock.release(txn_id);
                 }
@@ -931,43 +1103,37 @@ impl Manager {
         }
     }
 
-    /// Execute action statements as a transaction with lazy lock acquisition:
+    /// Execute action statements as a transaction with lazy lock
+    /// acquisition
     ///
-    /// Locks are acquired on demand as each variable is first read or written
-    /// during execution (inside `lookup` and `assign`), rather than upfront.
-    /// This handles actions invoked via function calls and conditional branches,
-    /// where the set of accessed variables can't be determined statically.
-    /// Read values are cached in the transaction to avoid re-fetching (which
-    /// also avoids redundant network round-trips for remote reads).
+    /// Locks are acquired on demand as each variable is first read or
+    /// written during execution (inside `lookup` and `assign`), rather
+    /// than upfront.
+    /// This handles actions invoked via function calls and conditional
+    /// branches, where the set of accessed variables cannot be
+    /// determined statically.
+    /// Read values are cached in the transaction to avoid re-fetching
+    /// (which also avoids redundant network round-trips for remote
+    /// reads)
     ///
-    /// On completion: commit records latest_write_txn for written variables,
-    /// then all locks are released (always, even on error).
+    /// On completion, a commit records `latest_write_txn` for written
+    /// variables, then all locks are released (always, even on error)
     ///
-    /// Deadlock prevention (wait-die) is deferred to a follow-up issue.
-    /// If a lock cannot be acquired, the transaction fails immediately.
+    /// If a lock cannot be acquired, wait-die deadlock prevention
+    /// determines whether the transaction waits or dies
     pub async fn execute_action_with_txn(
         &mut self,
-        service_name: &str,
+        service_name: Symbol,
         stmts: &[ActionStmt],
-        initial_env: &[(String, Value)],
+        initial_env: &[(Symbol, Value)],
     ) -> Result<(), EvalError> {
-        // Wait-die: a transaction that dies on a lock conflict (an older
-        // transaction holds the lock) aborts and retries with a higher
-        // iteration but the same age, bounded so a permanently held lock
-        // cannot loop forever. True blocking for the "wait" case (the older
-        // transaction holding its place) is tracked separately under #30
-        // stage 2.
         const MAX_WAIT_DIE_RETRIES: u32 = 10;
         let mut txn_id = TxnId::new(self.node_id);
 
         loop {
-            // The transaction owns all its state and is passed down through
-            // execution; nothing transaction-specific lives on the Manager.
             let mut txn = Transaction::new(txn_id.clone());
 
-            // Execute statements; read/write locks are acquired lazily inside
-            // lookup/assign as variables are accessed
-            let mut env: Vec<(String, Value)> = initial_env.to_vec();
+            let mut env: Vec<(Symbol, Value)> = initial_env.to_vec();
             let mut exec_error: Option<EvalError> = None;
             for stmt in stmts {
                 match execute(stmt, &env, self, service_name, Some(&mut txn)).await {
@@ -980,10 +1146,6 @@ impl Manager {
                 }
             }
 
-            // Wait-die abort: discard this attempt, abort participants, release
-            // locks, and retry with a higher iteration up to the bound. A died
-            // attempt never applies its buffered writes, so re-running from
-            // scratch is safe.
             if matches!(exec_error, Some(EvalError::WaitDieAbort(_))) {
                 for addr in txn.participants.iter().cloned().collect::<Vec<_>>() {
                     self.send_abort(addr, &txn.id).await;
@@ -996,26 +1158,17 @@ impl Manager {
                 return Err(exec_error.unwrap());
             }
 
-            // The commit/abort decision depends only on whether execution
-            // succeeded. Once execution succeeds the writes are applied and
-            // become visible, so commit messaging to participants is
-            // best-effort and never turns a successful transaction into a
-            // failed one (commit retries are tracked separately under issue
-            // #54).
             if exec_error.is_none() {
                 self.apply_committed_writes(&txn).await;
                 for addr in txn.participants.iter().cloned().collect::<Vec<_>>() {
                     let _ = self.send_commit(addr, &txn.id).await;
                 }
             } else {
-                // Execution failed: discard buffered writes and abort
-                // participants.
                 for addr in txn.participants.iter().cloned().collect::<Vec<_>>() {
                     self.send_abort(addr, &txn.id).await;
                 }
             }
 
-            // Release all locks held locally (always, even on error)
             self.release_locks(&txn.locked, &txn.id);
 
             return match exec_error {
@@ -1025,54 +1178,53 @@ impl Manager {
         }
     }
 
-    /// Apply a transaction's buffered writes to the owning services, record the
-    /// writing transaction, and propagate to dependent defs. Shared by local
-    /// commit and by a participant committing on a remote Commit message.
-    /// Infallible: once we are applying writes the transaction is committed, so
-    /// there is no going back. Propagation is best-effort (retries: issue #24).
+    /// Apply a transaction's buffered writes to the owning services, record
+    /// the writing transaction, and propagate to dependent definitions
+    ///
+    /// Shared by local commit and by a participant committing on a remote
+    /// `Commit` message
+    ///
+    /// Infallible: once we are applying writes the transaction is
+    /// committed, so there is no going back. Propagation is best-effort
     async fn apply_committed_writes(&mut self, txn: &Transaction) {
-        let writes: Vec<((ServiceId, String), Value)> = txn
+        let writes: Vec<((ServiceNetId, Symbol), Value)> = txn
             .written
             .iter()
             .map(|(k, v)| (k.clone(), v.clone()))
             .collect();
         let txn_id = txn.id.clone();
         for ((sid, var), value) in &writes {
-            if let Some(service) = self.service_by_id_mut(sid) {
+            if let Some(service) = self.service_by_net_id_mut(sid) {
                 if let Some(var_state) = service.vars.get_mut(var) {
                     var_state.value = value.clone();
                     var_state.latest_write_txn = Some(txn_id.clone());
                 }
             }
         }
-        // Propagate after all writes are applied so defs see a consistent state.
         for ((sid, var), _) in &writes {
-            if let Some(name) = self.name_for_id(sid) {
-                self.propagate(&name, var).await;
+            if let Some(name) = self.service_name_for_net_id(sid) {
+                self.propagate(name, *var).await;
             }
         }
     }
 
-    /// Participant side: execute a composed action under a shared transaction id
-    /// received from the originator, then hold the transaction (locks + buffered
-    /// writes) in `pending_txns` until a Commit or Abort arrives. Does not commit.
+    /// Participant side: execute a composed action under a shared transaction
+    /// ID received from the originator, then hold the transaction (locks and
+    /// buffered writes) in `pending_txns` until a `Commit` or `Abort` arrives
+    ///
+    /// Does not commit
     pub async fn execute_action_participant(
         &mut self,
-        service_name: &str,
+        service_name: Symbol,
         stmts: &[ActionStmt],
-        initial_env: &[(String, Value)],
+        initial_env: &[(Symbol, Value)],
         tid: TxnId,
     ) -> Result<(), EvalError> {
-        // Reuse an already-prepared transaction for this id if this node was
-        // already touched by the same distributed transaction (two services on
-        // one host, or transitive re-entry); otherwise start fresh. Pulling it
-        // out of pending_txns gives ownership so we can borrow &mut self below,
-        // and lets repeated actions accumulate into one prepared state.
         let mut txn = self
             .pending_txns
             .remove(&tid)
             .unwrap_or_else(|| Transaction::new(tid.clone()));
-        let mut env: Vec<(String, Value)> = initial_env.to_vec();
+        let mut env: Vec<(Symbol, Value)> = initial_env.to_vec();
         let mut exec_error: Option<EvalError> = None;
         for stmt in stmts {
             match execute(stmt, &env, self, service_name, Some(&mut txn)).await {
@@ -1085,40 +1237,26 @@ impl Manager {
             }
         }
         if let Some(e) = exec_error {
-            // Wait-die wait: this transaction is older than a current holder and
-            // must wait for the contended variable to free. Preserve its partial
-            // locks and buffered writes in pending_txns so that a re-dispatch on
-            // release skips the locks it already holds (guarded by txn.locked)
-            // and resumes at the contended variable. The owner parks the
-            // request; nothing is released here.
             if matches!(e, EvalError::WaitOn(_, _)) {
                 self.pending_txns.insert(tid, txn);
                 return Err(e);
             }
-            // Any other failure: release all locks held by this (possibly merged)
-            // transaction; do not keep it prepared. The originator's abort for
-            // this tid will then be a safe no-op here.
             self.release_locks(&txn.locked, &txn.id);
             return Err(e);
         }
-        // Prepared: hold the accumulated locks and buffered writes until commit/abort.
         self.pending_txns.insert(tid, txn);
         Ok(())
     }
 
-    /// Participant side: apply and release a held transaction on Commit.
+    /// Participant side: apply and release a held transaction on `Commit`
     pub async fn commit_participant(
         &mut self,
         tid: &TxnId,
-    ) -> Result<HashSet<(ServiceId, String)>, EvalError> {
+    ) -> Result<HashSet<(ServiceNetId, Symbol)>, EvalError> {
         if let Some(txn) = self.pending_txns.remove(tid) {
-            // The originator decided to commit, so applying is infallible.
             let freed = txn.locked.clone();
             self.apply_committed_writes(&txn).await;
             self.release_locks(&txn.locked, &txn.id);
-            // Forward the commit down the chain to any sub-participants this node
-            // composed (transitive composition: s1 -> s2 -> s3 ...). Forwarding
-            // failures are reported back but cannot undo the local commit.
             let mut forward_err = None;
             for addr in txn.participants.iter().cloned().collect::<Vec<_>>() {
                 if let Err(e) = self.send_commit(addr, tid).await {
@@ -1134,9 +1272,9 @@ impl Manager {
         }
     }
 
-    /// Participant side: discard and release a held transaction on Abort, and
-    /// forward the abort down the chain to any sub-participants.
-    pub async fn abort_participant(&mut self, tid: &TxnId) -> HashSet<(ServiceId, String)> {
+    /// Participant side: discard and release a held transaction on `Abort`, and
+    /// forward the abort down the chain to any sub-participants
+    pub async fn abort_participant(&mut self, tid: &TxnId) -> HashSet<(ServiceNetId, Symbol)> {
         if let Some(txn) = self.pending_txns.remove(tid) {
             let freed = txn.locked.clone();
             self.release_locks(&txn.locked, &txn.id);
@@ -1149,7 +1287,7 @@ impl Manager {
         }
     }
 
-    /// Originator side: ask a participant to commit, awaiting its acknowledgement.
+    /// Originator side: ask a participant to commit, awaiting its acknowledgement
     async fn send_commit(&mut self, addr: Address, tid: &TxnId) -> Result<(), EvalError> {
         use std::sync::atomic::{AtomicU64, Ordering};
         static NEXT_COMMIT_ID: AtomicU64 = AtomicU64::new(1);
@@ -1173,12 +1311,25 @@ impl Manager {
                 if success {
                     Ok(())
                 } else {
-                    Err(EvalError::NetworkError(
+                    Err(EvalError::LocalDispatchFailed(
                         error.unwrap_or_else(|| "Participant commit failed".to_string()),
                     ))
                 }
             }
-            _ => Err(EvalError::NetworkError(
+            MeerkatMessage::Ping { .. }
+            | MeerkatMessage::Pong { .. }
+            | MeerkatMessage::Announce { .. }
+            | MeerkatMessage::Transaction { .. }
+            | MeerkatMessage::Propagation { .. }
+            | MeerkatMessage::LookupRequest { .. }
+            | MeerkatMessage::LookupResponse { .. }
+            | MeerkatMessage::LookupError { .. }
+            | MeerkatMessage::ActionRequest { .. }
+            | MeerkatMessage::ActionResponse { .. }
+            | MeerkatMessage::Commit { .. }
+            | MeerkatMessage::Abort { .. }
+            | MeerkatMessage::AbortResponse { .. }
+            | MeerkatMessage::WaitParked { .. } => Err(EvalError::LocalDispatchFailed(
                 "Unexpected reply to commit".to_string(),
             )),
         }
@@ -1212,7 +1363,7 @@ impl Manager {
 
     pub async fn execute_action(
         &mut self,
-        service_name: &str,
+        service_name: Symbol,
         stmts: &[ActionStmt],
     ) -> Result<(), EvalError> {
         self.execute_action_with_txn(service_name, stmts, &[]).await
@@ -1220,9 +1371,9 @@ impl Manager {
 
     pub async fn execute_action_with_env(
         &mut self,
-        service_name: &str,
+        service_name: Symbol,
         stmts: &[ActionStmt],
-        initial_env: &[(String, Value)],
+        initial_env: &[(Symbol, Value)],
     ) -> Result<(), EvalError> {
         self.execute_action_with_txn(service_name, stmts, initial_env)
             .await
@@ -1231,7 +1382,7 @@ impl Manager {
 
 impl Default for Manager {
     fn default() -> Self {
-        Self::new()
+        Self::new(Interner::new())
     }
 }
 
@@ -1240,40 +1391,75 @@ mod tests {
     use super::*;
     use crate::ast::{Decl, Expr, Value};
 
+    struct TestContext {
+        manager: Manager,
+        foo: Symbol,
+        x: Symbol,
+        y: Symbol,
+        f: Symbol,
+        s1: Symbol,
+        s2: Symbol,
+        w: Symbol,
+        bump: Symbol,
+        nonexistent: Symbol,
+    }
+
+    impl TestContext {
+        fn new() -> Self {
+            let mut manager = Manager::default();
+            let foo = manager.interner.insert("foo");
+            let x = manager.interner.insert("x");
+            let y = manager.interner.insert("y");
+            let f = manager.interner.insert("f");
+            let s1 = manager.interner.insert("s1");
+            let s2 = manager.interner.insert("s2");
+            let w = manager.interner.insert("w");
+            let bump = manager.interner.insert("bump");
+            let nonexistent = manager.interner.insert("nonexistent");
+            Self {
+                manager,
+                foo,
+                x,
+                y,
+                f,
+                s1,
+                s2,
+                w,
+                bump,
+                nonexistent,
+            }
+        }
+    }
+
     #[tokio::test]
     async fn test_create_service_with_var() {
-        let mut manager = Manager::new();
+        let mut tc = TestContext::new();
         let decls = vec![Decl::VarDecl {
-            name: "x".to_string(),
+            name: tc.x,
             val: Expr::Literal {
                 val: Value::Number { val: 1 },
             },
         }];
-        manager
-            .create_service("foo".to_string(), decls)
-            .await
-            .unwrap();
-        let result = manager.lookup("x", "foo", None).await.unwrap();
+        tc.manager.create_service(tc.foo, decls).await.unwrap();
+        let result = tc.manager.lookup(tc.x, tc.foo, None).await.unwrap();
         assert_eq!(result, Value::Number { val: 1 });
     }
 
     #[tokio::test]
     async fn test_create_service_with_def() {
-        let mut manager = Manager::new();
+        let mut tc = TestContext::new();
         let decls = vec![
             Decl::VarDecl {
-                name: "x".to_string(),
+                name: tc.x,
                 val: Expr::Literal {
                     val: Value::Number { val: 2 },
                 },
             },
             Decl::DefDecl {
-                name: "f".to_string(),
+                name: tc.f,
                 val: Expr::Binop {
                     op: crate::ast::BinOp::Add,
-                    expr1: Box::new(Expr::Variable {
-                        ident: "x".to_string(),
-                    }),
+                    expr1: Box::new(Expr::Variable { name: tc.x }),
                     expr2: Box::new(Expr::Literal {
                         val: Value::Number { val: 3 },
                     }),
@@ -1281,43 +1467,34 @@ mod tests {
                 is_pub: true,
             },
         ];
-        manager
-            .create_service("foo".to_string(), decls)
-            .await
-            .unwrap();
-        let result = manager.lookup("f", "foo", None).await.unwrap();
+        tc.manager.create_service(tc.foo, decls).await.unwrap();
+        let result = tc.manager.lookup(tc.f, tc.foo, None).await.unwrap();
         assert_eq!(result, Value::Number { val: 5 });
     }
 
     #[tokio::test]
     async fn test_lookup_missing_var_returns_error() {
-        let mut manager = Manager::new();
-        manager
-            .create_service("foo".to_string(), vec![])
-            .await
-            .unwrap();
-        let result = manager.lookup("nonexistent", "foo", None).await;
+        let mut tc = TestContext::new();
+        tc.manager.create_service(tc.foo, vec![]).await.unwrap();
+        let result = tc.manager.lookup(tc.nonexistent, tc.foo, None).await;
         assert!(result.is_err());
     }
 
     #[tokio::test]
     async fn test_def_updates_after_var_change() {
-        let mut manager = Manager::new();
-        // service foo { var x = 1; def f = x + 10; }
+        let mut tc = TestContext::new();
         let decls = vec![
             Decl::VarDecl {
-                name: "x".to_string(),
+                name: tc.x,
                 val: Expr::Literal {
                     val: Value::Number { val: 1 },
                 },
             },
             Decl::DefDecl {
-                name: "f".to_string(),
+                name: tc.f,
                 val: Expr::Binop {
                     op: crate::ast::BinOp::Add,
-                    expr1: Box::new(Expr::Variable {
-                        ident: "x".to_string(),
-                    }),
+                    expr1: Box::new(Expr::Variable { name: tc.x }),
                     expr2: Box::new(Expr::Literal {
                         val: Value::Number { val: 10 },
                     }),
@@ -1325,168 +1502,168 @@ mod tests {
                 is_pub: true,
             },
         ];
-        manager
-            .create_service("foo".to_string(), decls)
-            .await
-            .unwrap();
+        tc.manager.create_service(tc.foo, decls).await.unwrap();
 
         // f should be 11 initially
-        let result = manager.lookup("f", "foo", None).await.unwrap();
+        let result = tc.manager.lookup(tc.f, tc.foo, None).await.unwrap();
         assert_eq!(result, Value::Number { val: 11 });
 
         // update x to 5, f should become 15
-        manager
-            .assign("foo", "x", Value::Number { val: 5 }, None)
+        tc.manager
+            .assign(tc.foo, tc.x, Value::Number { val: 5 }, None)
             .await
             .unwrap();
-        let result = manager.lookup("f", "foo", None).await.unwrap();
+        let result = tc.manager.lookup(tc.f, tc.foo, None).await.unwrap();
         assert_eq!(result, Value::Number { val: 15 });
     }
 
     // Helper: service with a single var x = 0
-    async fn manager_with_x() -> Manager {
-        let mut manager = Manager::new();
+    async fn manager_with_x() -> TestContext {
+        let mut tc = TestContext::new();
         let decls = vec![Decl::VarDecl {
-            name: "x".to_string(),
+            name: tc.x,
             val: Expr::Literal {
                 val: Value::Number { val: 0 },
             },
         }];
-        manager
-            .create_service("foo".to_string(), decls)
-            .await
-            .unwrap();
-        manager
+        tc.manager.create_service(tc.foo, decls).await.unwrap();
+        tc
     }
 
-    fn x_state(manager: &Manager) -> &VarState {
-        manager.services.get("foo").unwrap().vars.get("x").unwrap()
+    fn x_state(tc: &TestContext) -> &VarState {
+        tc.manager
+            .services
+            .get(&tc.foo)
+            .unwrap()
+            .vars
+            .get(&tc.x)
+            .unwrap()
     }
 
-    fn assert_x_unlocked(manager: &Manager) {
+    fn assert_x_unlocked(tc: &TestContext) {
         assert!(matches!(
-            &x_state(manager).lock,
+            &x_state(tc).lock,
             crate::runtime::txn::VarLock::Unlocked
         ));
     }
 
-    // x = x + 1 reads x (read lock) then writes x (must upgrade to write lock).
-    // This is the read-then-write pattern that the old upfront analysis mishandled.
     #[tokio::test]
     async fn test_txn_read_then_write_upgrades_lock() {
-        let mut manager = manager_with_x().await;
+        // `x = x + 1` reads `x` (read lock) then writes `x` (must upgrade
+        // to write lock)
+        // This is the read-then-write pattern that the old upfront
+        // analysis mishandled
+        let mut tc = manager_with_x().await;
         let stmts = vec![ActionStmt::Assign {
-            var: "x".to_string(),
+            name: tc.x,
             expr: Expr::Binop {
                 op: crate::ast::BinOp::Add,
-                expr1: Box::new(Expr::Variable {
-                    ident: "x".to_string(),
-                }),
+                expr1: Box::new(Expr::Variable { name: tc.x }),
                 expr2: Box::new(Expr::Literal {
                     val: Value::Number { val: 1 },
                 }),
             },
         }];
-        manager.execute_action("foo", &stmts).await.unwrap();
-        let result = manager.lookup("x", "foo", None).await.unwrap();
+        tc.manager.execute_action(tc.foo, &stmts).await.unwrap();
+        let result = tc.manager.lookup(tc.x, tc.foo, None).await.unwrap();
         assert_eq!(result, Value::Number { val: 1 });
     }
 
-    // Locks must be released after a transaction, so a second transaction
-    // can acquire them. Running x = x + 1 twice should yield x == 2.
     #[tokio::test]
     async fn test_txn_locks_released_between_transactions() {
-        let mut manager = manager_with_x().await;
+        // Locks must be released after a transaction, so a second
+        // transaction can acquire them. Running `x = x + 1` twice
+        // should yield `x == 2`
+        let mut tc = manager_with_x().await;
         let stmts = vec![ActionStmt::Assign {
-            var: "x".to_string(),
+            name: tc.x,
             expr: Expr::Binop {
                 op: crate::ast::BinOp::Add,
-                expr1: Box::new(Expr::Variable {
-                    ident: "x".to_string(),
-                }),
+                expr1: Box::new(Expr::Variable { name: tc.x }),
                 expr2: Box::new(Expr::Literal {
                     val: Value::Number { val: 1 },
                 }),
             },
         }];
-        manager.execute_action("foo", &stmts).await.unwrap();
-        manager.execute_action("foo", &stmts).await.unwrap();
-        let result = manager.lookup("x", "foo", None).await.unwrap();
+        tc.manager.execute_action(tc.foo, &stmts).await.unwrap();
+        tc.manager.execute_action(tc.foo, &stmts).await.unwrap();
+        let result = tc.manager.lookup(tc.x, tc.foo, None).await.unwrap();
         assert_eq!(result, Value::Number { val: 2 });
     }
 
-    // After a transaction completes, the variable's lock should be Unlocked.
     #[tokio::test]
     async fn test_txn_var_unlocked_after_commit() {
-        let mut manager = manager_with_x().await;
+        // After a transaction completes, the variable's lock should
+        // be `Unlocked`
+        let mut tc = manager_with_x().await;
         let stmts = vec![ActionStmt::Assign {
-            var: "x".to_string(),
+            name: tc.x,
             expr: Expr::Literal {
                 val: Value::Number { val: 42 },
             },
         }];
-        manager.execute_action("foo", &stmts).await.unwrap();
-        assert_x_unlocked(&manager);
+        tc.manager.execute_action(tc.foo, &stmts).await.unwrap();
+        assert_x_unlocked(&tc);
     }
 
-    // A successful transaction commits its buffered write and records the
-    // transaction as the latest writer for that variable.
     #[tokio::test]
     async fn test_txn_successful_write_updates_value_and_latest_write_txn() {
-        let mut manager = manager_with_x().await;
+        // A successful transaction commits its buffered write and records
+        // the transaction as the latest writer for that variable
+        let mut tc = manager_with_x().await;
         let stmts = vec![ActionStmt::Assign {
-            var: "x".to_string(),
+            name: tc.x,
             expr: Expr::Literal {
                 val: Value::Number { val: 42 },
             },
         }];
 
-        manager.execute_action("foo", &stmts).await.unwrap();
+        tc.manager.execute_action(tc.foo, &stmts).await.unwrap();
 
-        let state = x_state(&manager);
+        let state = x_state(&tc);
         assert_eq!(state.value, Value::Number { val: 42 });
         assert!(state.latest_write_txn.is_some());
     }
 
-    // A nested `do` (an action invoking another action) must reuse the same
-    // transaction, not start a fresh one. The inner write to x should commit and
-    // all locks should be released afterward. This guards the bug where nested
-    // execution clobbered the outer transaction's lock tracking.
     #[tokio::test]
     async fn test_txn_nested_do_reuses_transaction() {
-        let mut manager = manager_with_x().await;
-        // outer action: do (action { x = x + 1; });
+        // A nested `do` (an action invoking another action) must reuse
+        // the same transaction, not start a fresh one. The inner write
+        // to `x` should commit and all locks should be released afterward
+        // This guards the bug where nested execution clobbered the outer
+        // transaction's lock tracking
+        let mut tc = manager_with_x().await;
+        // outer action: `do` (action { `x` = `x` + 1 })
         let inner = Expr::Action(vec![ActionStmt::Assign {
-            var: "x".to_string(),
+            name: tc.x,
             expr: Expr::Binop {
                 op: crate::ast::BinOp::Add,
-                expr1: Box::new(Expr::Variable {
-                    ident: "x".to_string(),
-                }),
+                expr1: Box::new(Expr::Variable { name: tc.x }),
                 expr2: Box::new(Expr::Literal {
                     val: Value::Number { val: 1 },
                 }),
             },
         }]);
         let stmts = vec![ActionStmt::Do(inner)];
-        manager.execute_action("foo", &stmts).await.unwrap();
+        tc.manager.execute_action(tc.foo, &stmts).await.unwrap();
 
         // inner write took effect
-        let result = manager.lookup("x", "foo", None).await.unwrap();
-        assert_eq!(result, Value::Number { val: 1 });
+        let result = tc.manager.lookup(tc.x, tc.foo, None).await.unwrap();
         // and the lock was released
-        assert_x_unlocked(&manager);
+        assert_eq!(result, Value::Number { val: 1 });
+        assert_x_unlocked(&tc);
     }
 
-    // A transaction that fails partway must leave no partial writes: writes are
-    // buffered and applied only on a successful commit. Here the first statement
-    // writes x, the second fails (asserting false), so x must stay unchanged.
     #[tokio::test]
     async fn test_txn_failed_transaction_leaves_no_partial_writes() {
-        let mut manager = manager_with_x().await;
+        // A transaction that fails partway must leave no partial writes:
+        // writes are buffered and applied only on a successful commit
+        // Here the first statement writes `x`, the second fails
+        // (asserting `false`), so `x` must stay unchanged
+        let mut tc = manager_with_x().await;
         let stmts = vec![
             ActionStmt::Assign {
-                var: "x".to_string(),
+                name: tc.x,
                 expr: Expr::Literal {
                     val: Value::Number { val: 99 },
                 },
@@ -1495,36 +1672,37 @@ mod tests {
                 val: Value::Bool { val: false },
             }),
         ];
-        let result = manager.execute_action("foo", &stmts).await;
+        let result = tc.manager.execute_action(tc.foo, &stmts).await;
         assert!(result.is_err());
-        // x must remain 0 — the buffered write to 99 was never committed
-        let x = manager.lookup("x", "foo", None).await.unwrap();
-        assert_eq!(x, Value::Number { val: 0 });
+        // `x` must remain 0 — the buffered write to 99 was never committed
+        let x = tc.manager.lookup(tc.x, tc.foo, None).await.unwrap();
         // and the lock was released
-        assert_x_unlocked(&manager);
+        assert_eq!(x, Value::Number { val: 0 });
+        assert_x_unlocked(&tc);
     }
 
-    // A failed transaction must not update either committed state field: the
-    // value and latest writer should remain from the last successful commit.
     #[tokio::test]
     async fn test_txn_failed_transaction_preserves_previous_latest_write_txn() {
-        let mut manager = manager_with_x().await;
+        // A failed transaction must not update either committed state
+        // field: the value and latest writer should remain from the last
+        // successful commit
+        let mut tc = manager_with_x().await;
         let successful_write = vec![ActionStmt::Assign {
-            var: "x".to_string(),
+            name: tc.x,
             expr: Expr::Literal {
                 val: Value::Number { val: 1 },
             },
         }];
-        manager
-            .execute_action("foo", &successful_write)
+        tc.manager
+            .execute_action(tc.foo, &successful_write)
             .await
             .unwrap();
-        let previous_txn = x_state(&manager).latest_write_txn.clone();
+        let previous_txn = x_state(&tc).latest_write_txn.clone();
         assert!(previous_txn.is_some());
 
         let failing_write = vec![
             ActionStmt::Assign {
-                var: "x".to_string(),
+                name: tc.x,
                 expr: Expr::Literal {
                     val: Value::Number { val: 99 },
                 },
@@ -1534,62 +1712,60 @@ mod tests {
             }),
         ];
 
-        let result = manager.execute_action("foo", &failing_write).await;
+        let result = tc.manager.execute_action(tc.foo, &failing_write).await;
 
         assert!(result.is_err());
-        let state = x_state(&manager);
+        let state = x_state(&tc);
         assert_eq!(state.value, Value::Number { val: 1 });
         assert_eq!(state.latest_write_txn, previous_txn);
-        assert_x_unlocked(&manager);
+        assert_x_unlocked(&tc);
     }
 
-    // If a transaction fails after a read, its read lock must still be released.
     #[tokio::test]
     async fn test_txn_read_lock_released_after_failure() {
-        let mut manager = manager_with_x().await;
-        let stmts = vec![ActionStmt::Assert(Expr::Variable {
-            ident: "x".to_string(),
-        })];
+        // If a transaction fails after a read, its read lock must still
+        // be released
+        let mut tc = manager_with_x().await;
+        let stmts = vec![ActionStmt::Assert(Expr::Variable { name: tc.x })];
 
-        let result = manager.execute_action("foo", &stmts).await;
+        let result = tc.manager.execute_action(tc.foo, &stmts).await;
 
         assert!(result.is_err());
-        assert_eq!(x_state(&manager).value, Value::Number { val: 0 });
-        assert!(x_state(&manager).latest_write_txn.is_none());
-        assert_x_unlocked(&manager);
+        assert_eq!(x_state(&tc).value, Value::Number { val: 0 });
+        assert!(x_state(&tc).latest_write_txn.is_none());
+        assert_x_unlocked(&tc);
     }
 
-    // A transaction beginning in s1 composes an action defined in s2 (the
-    // example from issue #44). Both services' writes must commit under the one
-    // transaction, and the (service id, var) keying must keep them distinct.
     #[tokio::test]
     async fn test_txn_cross_service_composition() {
-        let mut manager = Manager::new();
-        // s2 owns w and an action that bumps it.
+        // A transaction beginning in `s1` composes an action defined in
+        // `s2` (the example from issue #44). Both services' writes must
+        // commit under the one transaction, and the `(service_net_id, var)`
+        // keying must keep them distinct
+        let mut tc = TestContext::new();
+        // s2 owns `w` and an action that bumps it
         let bump = Expr::Action(vec![ActionStmt::Assign {
-            var: "w".to_string(),
+            name: tc.w,
             expr: Expr::Binop {
                 op: crate::ast::BinOp::Add,
-                expr1: Box::new(Expr::Variable {
-                    ident: "w".to_string(),
-                }),
+                expr1: Box::new(Expr::Variable { name: tc.w }),
                 expr2: Box::new(Expr::Literal {
                     val: Value::Number { val: 5 },
                 }),
             },
         }]);
-        manager
+        tc.manager
             .create_service(
-                "s2".to_string(),
+                tc.s2,
                 vec![
                     Decl::VarDecl {
-                        name: "w".to_string(),
+                        name: tc.w,
                         val: Expr::Literal {
                             val: Value::Number { val: 10 },
                         },
                     },
                     Decl::DefDecl {
-                        name: "bump".to_string(),
+                        name: tc.bump,
                         val: bump,
                         is_pub: true,
                     },
@@ -1597,12 +1773,12 @@ mod tests {
             )
             .await
             .unwrap();
-        // s1 owns x.
-        manager
+        // s1 owns `x`
+        tc.manager
             .create_service(
-                "s1".to_string(),
+                tc.s1,
                 vec![Decl::VarDecl {
-                    name: "x".to_string(),
+                    name: tc.x,
                     val: Expr::Literal {
                         val: Value::Number { val: 0 },
                     },
@@ -1611,71 +1787,69 @@ mod tests {
             .await
             .unwrap();
 
-        // Transaction on s1: x = x + 1; do s2.bump;
+        // Transaction on `s1`: `x` = `x` + 1; `do` `s2.bump`
         let stmts = vec![
             ActionStmt::Assign {
-                var: "x".to_string(),
+                name: tc.x,
                 expr: Expr::Binop {
                     op: crate::ast::BinOp::Add,
-                    expr1: Box::new(Expr::Variable {
-                        ident: "x".to_string(),
-                    }),
+                    expr1: Box::new(Expr::Variable { name: tc.x }),
                     expr2: Box::new(Expr::Literal {
                         val: Value::Number { val: 1 },
                     }),
                 },
             },
             ActionStmt::Do(Expr::MemberAccess {
-                service: "s2".to_string(),
-                member: "bump".to_string(),
+                service_name: tc.s2,
+                member_name: tc.bump,
             }),
         ];
-        manager.execute_action("s1", &stmts).await.unwrap();
+        tc.manager.execute_action(tc.s1, &stmts).await.unwrap();
 
-        // Both services' writes committed.
+        // Both services' writes committed
         assert_eq!(
-            manager.lookup("x", "s1", None).await.unwrap(),
+            tc.manager.lookup(tc.x, tc.s1, None).await.unwrap(),
             Value::Number { val: 1 }
         );
         assert_eq!(
-            manager.lookup("w", "s2", None).await.unwrap(),
+            tc.manager.lookup(tc.w, tc.s2, None).await.unwrap(),
             Value::Number { val: 15 }
         );
-        // Locks released on both services.
+        // Locks released on both services
         assert!(matches!(
-            manager
+            tc.manager
                 .services
-                .get("s1")
+                .get(&tc.s1)
                 .unwrap()
                 .vars
-                .get("x")
+                .get(&tc.x)
                 .unwrap()
                 .lock,
             crate::runtime::txn::VarLock::Unlocked
         ));
         assert!(matches!(
-            manager
+            tc.manager
                 .services
-                .get("s2")
+                .get(&tc.s2)
                 .unwrap()
                 .vars
-                .get("w")
+                .get(&tc.w)
                 .unwrap()
                 .lock,
             crate::runtime::txn::VarLock::Unlocked
         ));
     }
 
-    // Wait-die: a younger transaction contending for a lock held by an older
-    // transaction dies (abort) rather than acquiring it.
     #[tokio::test]
     async fn test_wait_die_younger_dies_at_acquire() {
-        let mut manager = Manager::new();
-        manager
+        // Wait-die: a younger transaction contending for a lock held by
+        // an older transaction dies (abort) rather than acquiring it
+        let mut tc = TestContext::new();
+        tc.manager
             .create_service(
-                "s1".to_string(),
+                tc.s1,
                 vec![Decl::VarDecl {
-                    name: "x".to_string(),
+                    name: tc.x,
                     val: Expr::Literal {
                         val: Value::Number { val: 0 },
                     },
@@ -1688,12 +1862,12 @@ mod tests {
             node_id: 1,
             iteration: 0,
         };
-        manager
+        tc.manager
             .services
-            .get_mut("s1")
+            .get_mut(&tc.s1)
             .unwrap()
             .vars
-            .get_mut("x")
+            .get_mut(&tc.x)
             .unwrap()
             .lock = crate::runtime::txn::VarLock::WriteLocked(older);
         let younger = crate::runtime::txn::TxnId {
@@ -1701,21 +1875,22 @@ mod tests {
             node_id: 1,
             iteration: 0,
         };
-        let result = manager.acquire_write_lock("s1", "x", &younger);
+        let result = tc.manager.acquire_write_lock(tc.s1, tc.x, &younger);
         assert!(matches!(result, Err(EvalError::WaitDieAbort(_))));
     }
 
-    // Wait-die: an older transaction contending for a lock held by a younger
-    // transaction takes the wait path, surfaced as WaitOn carrying the
-    // contended (service, var) so the owner can park the request.
     #[tokio::test]
     async fn test_wait_die_older_takes_wait_path() {
-        let mut manager = Manager::new();
-        manager
+        // Wait-die: an older transaction contending for a lock held by
+        // a younger transaction takes the wait path, surfaced as
+        // `WaitOn` carrying the contended `(service, var)` so the owner
+        // can park the request
+        let mut tc = TestContext::new();
+        tc.manager
             .create_service(
-                "s1".to_string(),
+                tc.s1,
                 vec![Decl::VarDecl {
-                    name: "x".to_string(),
+                    name: tc.x,
                     val: Expr::Literal {
                         val: Value::Number { val: 0 },
                     },
@@ -1728,12 +1903,12 @@ mod tests {
             node_id: 1,
             iteration: 0,
         };
-        manager
+        tc.manager
             .services
-            .get_mut("s1")
+            .get_mut(&tc.s1)
             .unwrap()
             .vars
-            .get_mut("x")
+            .get_mut(&tc.x)
             .unwrap()
             .lock = crate::runtime::txn::VarLock::WriteLocked(younger);
         let older = crate::runtime::txn::TxnId {
@@ -1741,21 +1916,18 @@ mod tests {
             node_id: 1,
             iteration: 0,
         };
-        let result = manager.acquire_write_lock("s1", "x", &older);
+        let result = tc.manager.acquire_write_lock(tc.s1, tc.x, &older);
         assert!(matches!(result, Err(EvalError::WaitOn(_, _))));
     }
 
-    // Wait-die end to end: an action whose variable is held by an older
-    // transaction dies and retries, and after exhausting the bounded retries
-    // returns WaitDieAbort without disturbing the older holder's lock.
     #[tokio::test]
     async fn test_wait_die_action_dies_and_retries() {
-        let mut manager = Manager::new();
-        manager
+        let mut tc = TestContext::new();
+        tc.manager
             .create_service(
-                "s1".to_string(),
+                tc.s1,
                 vec![Decl::VarDecl {
-                    name: "x".to_string(),
+                    name: tc.x,
                     val: Expr::Literal {
                         val: Value::Number { val: 0 },
                     },
@@ -1768,59 +1940,58 @@ mod tests {
             node_id: 1,
             iteration: 0,
         };
-        manager
+        tc.manager
             .services
-            .get_mut("s1")
+            .get_mut(&tc.s1)
             .unwrap()
             .vars
-            .get_mut("x")
+            .get_mut(&tc.x)
             .unwrap()
             .lock = crate::runtime::txn::VarLock::WriteLocked(older);
         let stmts = vec![ActionStmt::Assign {
-            var: "x".to_string(),
+            name: tc.x,
             expr: Expr::Binop {
                 op: crate::ast::BinOp::Add,
-                expr1: Box::new(Expr::Variable {
-                    ident: "x".to_string(),
-                }),
+                expr1: Box::new(Expr::Variable { name: tc.x }),
                 expr2: Box::new(Expr::Literal {
                     val: Value::Number { val: 1 },
                 }),
             },
         }];
-        let result = manager.execute_action("s1", &stmts).await;
+        let result = tc.manager.execute_action(tc.s1, &stmts).await;
         assert!(matches!(result, Err(EvalError::WaitDieAbort(_))));
         assert!(matches!(
-            manager
+            tc.manager
                 .services
-                .get("s1")
+                .get(&tc.s1)
                 .unwrap()
                 .vars
-                .get("x")
+                .get(&tc.x)
                 .unwrap()
                 .lock,
             crate::runtime::txn::VarLock::WriteLocked(_)
         ));
     }
 
-    // Wait-die: a participant action that conflicts mid-execution parks by
-    // preserving its partial transaction (locks already taken stay held) in
-    // pending_txns, so a later re-dispatch can resume rather than restart.
     #[tokio::test]
     async fn test_wait_die_participant_preserves_partial_txn() {
-        let mut manager = Manager::new();
-        manager
+        // Wait-die: a participant action that conflicts mid-execution
+        // parks by preserving its partial transaction (locks already
+        // taken stay held) in `pending_txns`, so a later re-dispatch
+        // can resume rather than restart
+        let mut tc = TestContext::new();
+        tc.manager
             .create_service(
-                "s1".to_string(),
+                tc.s1,
                 vec![
                     Decl::VarDecl {
-                        name: "y".to_string(),
+                        name: tc.y,
                         val: Expr::Literal {
                             val: Value::Number { val: 0 },
                         },
                     },
                     Decl::VarDecl {
-                        name: "x".to_string(),
+                        name: tc.x,
                         val: Expr::Literal {
                             val: Value::Number { val: 0 },
                         },
@@ -1829,76 +2000,77 @@ mod tests {
             )
             .await
             .unwrap();
-        // A younger transaction holds a write lock on x.
+        // A younger transaction holds a write lock on `x`
         let younger = crate::runtime::txn::TxnId {
             timestamp: u128::MAX,
             node_id: 1,
             iteration: 0,
         };
-        manager
+        tc.manager
             .services
-            .get_mut("s1")
+            .get_mut(&tc.s1)
             .unwrap()
             .vars
-            .get_mut("x")
+            .get_mut(&tc.x)
             .unwrap()
             .lock = crate::runtime::txn::VarLock::WriteLocked(younger);
-        // Older transaction: write y (acquires y), then touch x (conflict, waits).
         let older = crate::runtime::txn::TxnId {
             timestamp: 1,
             node_id: 1,
             iteration: 0,
         };
+        // Older transaction: write `y` (acquires `y`), then touch `x`
+        // (conflict, waits)
         let stmts = vec![
             ActionStmt::Assign {
-                var: "y".to_string(),
+                name: tc.y,
                 expr: Expr::Literal {
                     val: Value::Number { val: 5 },
                 },
             },
             ActionStmt::Assign {
-                var: "x".to_string(),
+                name: tc.x,
                 expr: Expr::Binop {
                     op: crate::ast::BinOp::Add,
-                    expr1: Box::new(Expr::Variable {
-                        ident: "x".to_string(),
-                    }),
+                    expr1: Box::new(Expr::Variable { name: tc.x }),
                     expr2: Box::new(Expr::Literal {
                         val: Value::Number { val: 1 },
                     }),
                 },
             },
         ];
-        let result = manager
-            .execute_action_participant("s1", &stmts, &[], older.clone())
+        let result = tc
+            .manager
+            .execute_action_participant(tc.s1, &stmts, &[], older.clone())
             .await;
-        // Parked: returns WaitOn, and the partial transaction is preserved.
+        // Parked: returns `WaitOn`, and the partial transaction is preserved
         assert!(matches!(result, Err(EvalError::WaitOn(_, _))));
-        assert!(manager.pending_txns.contains_key(&older));
-        // The lock it already took on y is still held (not released on park).
+        assert!(tc.manager.pending_txns.contains_key(&older));
+        // The lock it already took on `y` is still held (not released on park)
         assert!(matches!(
-            manager
+            tc.manager
                 .services
-                .get("s1")
+                .get(&tc.s1)
                 .unwrap()
                 .vars
-                .get("y")
+                .get(&tc.y)
                 .unwrap()
                 .lock,
             crate::runtime::txn::VarLock::WriteLocked(_)
         ));
     }
 
-    // Wait-die: parked requests on a variable are served oldest-first when the
-    // lock frees, and a transaction's waiters are purged when it aborts.
     #[tokio::test]
     async fn test_wait_queue_oldest_first_and_purge() {
-        let mut manager = Manager::new();
-        manager
+        // Wait-die: parked requests on a variable are served oldest-first
+        // when the lock frees, and a transaction's waiters are purged
+        // when it aborts
+        let mut tc = TestContext::new();
+        tc.manager
             .create_service(
-                "s1".to_string(),
+                tc.s1,
                 vec![Decl::VarDecl {
-                    name: "x".to_string(),
+                    name: tc.x,
                     val: Expr::Literal {
                         val: Value::Number { val: 0 },
                     },
@@ -1909,7 +2081,7 @@ mod tests {
         let make = |rid: u64, tid: crate::runtime::txn::TxnId| ParkedRequest::Action {
             request_id: rid,
             reply_to: String::new(),
-            service: "s1".to_string(),
+            service: tc.s1,
             stmts: vec![],
             env: vec![],
             tid,
@@ -1924,32 +2096,33 @@ mod tests {
             node_id: 1,
             iteration: 0,
         };
-        manager.park_request("s1", "x".to_string(), make(1, mid.clone()));
-        manager.park_request("s1", "x".to_string(), make(2, old.clone()));
-        // Freeing x yields the oldest waiter first; the other stays parked.
+        tc.manager.park_request(tc.s1, tc.x, make(1, mid.clone()));
+        tc.manager.park_request(tc.s1, tc.x, make(2, old.clone()));
+        // Freeing `x` yields the oldest waiter first; the other stays parked
         let mut freed = std::collections::HashSet::new();
-        freed.insert((manager.id_for_service("s1"), "x".to_string()));
-        let ready = manager.take_ready_waiters(&freed);
+        freed.insert((tc.manager.service_net_id_for_name(tc.s1), tc.x));
+        let ready = tc.manager.take_ready_waiters(&freed);
         assert_eq!(ready.len(), 1);
         assert!(ready[0].tid() == &old);
-        // The remaining (mid) waiter is purged when its transaction aborts.
-        let removed = manager.purge_parked_txn(&mid);
+        // The remaining `mid` waiter is purged when its transaction aborts
+        let removed = tc.manager.purge_parked_txn(&mid);
         assert_eq!(removed.len(), 1);
-        assert!(manager.wait_queue.is_empty());
+        assert!(tc.manager.wait_queue.is_empty());
     }
 
-    // Wait-die end to end (single node, no network): an older transaction parks
-    // on a variable held by a younger one; when the younger aborts and frees the
-    // lock, the parked request is taken oldest-first and its re-run resumes from
-    // the preserved transaction and now succeeds.
     #[tokio::test]
     async fn test_wait_die_parked_request_resumes_after_release() {
-        let mut manager = Manager::new();
-        manager
+        // Wait-die end to end (single node, no network): an older
+        // transaction parks on a variable held by a younger one; when
+        // the younger aborts and frees the lock, the parked request is
+        // taken oldest-first and its re-run resumes from the preserved
+        // transaction and now succeeds
+        let mut tc = TestContext::new();
+        tc.manager
             .create_service(
-                "s1".to_string(),
+                tc.s1,
                 vec![Decl::VarDecl {
-                    name: "x".to_string(),
+                    name: tc.x,
                     val: Expr::Literal {
                         val: Value::Number { val: 0 },
                     },
@@ -1958,77 +2131,77 @@ mod tests {
             .await
             .unwrap();
 
-        // A younger transaction holds a write lock on x, prepared in pending_txns.
+        // A younger transaction holds a write lock on `x`, prepared in
+        // `pending_txns`
         let younger = crate::runtime::txn::TxnId {
             timestamp: u128::MAX,
             node_id: 1,
             iteration: 0,
         };
-        manager
+        tc.manager
             .services
-            .get_mut("s1")
+            .get_mut(&tc.s1)
             .unwrap()
             .vars
-            .get_mut("x")
+            .get_mut(&tc.x)
             .unwrap()
             .lock = crate::runtime::txn::VarLock::WriteLocked(younger.clone());
         let mut younger_txn = crate::runtime::txn::Transaction::new(younger.clone());
         younger_txn
             .locked
-            .insert((manager.id_for_service("s1"), "x".to_string()));
-        manager.pending_txns.insert(younger.clone(), younger_txn);
+            .insert((tc.manager.service_net_id_for_name(tc.s1), tc.x));
+        tc.manager.pending_txns.insert(younger.clone(), younger_txn);
 
-        // Older transaction: x = x + 1 conflicts -> WaitOn -> park it.
         let older = crate::runtime::txn::TxnId {
             timestamp: 1,
             node_id: 1,
             iteration: 0,
         };
+        // Older transaction: `x` = `x` + 1 conflicts -> `WaitOn` -> park it
         let stmts = vec![ActionStmt::Assign {
-            var: "x".to_string(),
+            name: tc.x,
             expr: Expr::Binop {
                 op: crate::ast::BinOp::Add,
-                expr1: Box::new(Expr::Variable {
-                    ident: "x".to_string(),
-                }),
+                expr1: Box::new(Expr::Variable { name: tc.x }),
                 expr2: Box::new(Expr::Literal {
                     val: Value::Number { val: 1 },
                 }),
             },
         }];
-        let r1 = manager
-            .execute_action_participant("s1", &stmts, &[], older.clone())
+        let r1 = tc
+            .manager
+            .execute_action_participant(tc.s1, &stmts, &[], older.clone())
             .await;
         assert!(matches!(r1, Err(EvalError::WaitOn(_, _))));
-        manager.park_request(
-            "s1",
-            "x".to_string(),
+        tc.manager.park_request(
+            tc.s1,
+            tc.x,
             ParkedRequest::Action {
                 request_id: 1,
                 reply_to: String::new(),
-                service: "s1".to_string(),
+                service: tc.s1,
                 stmts: stmts.clone(),
                 env: vec![],
                 tid: older.clone(),
             },
         );
 
-        // The younger holder aborts, freeing x.
-        let freed = manager.abort_participant(&younger).await;
+        // The younger holder aborts, freeing `x`
+        let freed = tc.manager.abort_participant(&younger).await;
         assert!(matches!(
-            manager
+            tc.manager
                 .services
-                .get("s1")
+                .get(&tc.s1)
                 .unwrap()
                 .vars
-                .get("x")
+                .get(&tc.x)
                 .unwrap()
                 .lock,
             crate::runtime::txn::VarLock::Unlocked
         ));
 
-        // Wake: take the oldest waiter and re-run it; it should now succeed.
-        let ready = manager.take_ready_waiters(&freed);
+        // Wake: take the oldest waiter and re-run it; it should now succeed
+        let ready = tc.manager.take_ready_waiters(&freed);
         assert_eq!(ready.len(), 1);
         if let ParkedRequest::Action {
             service,
@@ -2038,26 +2211,27 @@ mod tests {
             ..
         } = &ready[0]
         {
-            let r2 = manager
-                .execute_action_participant(service, stmts, env, tid.clone())
+            let r2 = tc
+                .manager
+                .execute_action_participant(*service, stmts, env, tid.clone())
                 .await;
             assert!(r2.is_ok());
         } else {
             panic!("expected an Action waiter");
         }
 
-        // The older transaction now holds x's write lock and is prepared.
+        // The older transaction now holds `x`'s write lock and is prepared
         assert!(matches!(
-            manager
+            tc.manager
                 .services
-                .get("s1")
+                .get(&tc.s1)
                 .unwrap()
                 .vars
-                .get("x")
+                .get(&tc.x)
                 .unwrap()
                 .lock,
             crate::runtime::txn::VarLock::WriteLocked(_)
         ));
-        assert!(manager.pending_txns.contains_key(&older));
+        assert!(tc.manager.pending_txns.contains_key(&older));
     }
 }

--- a/meerkat-lib/src/runtime/manager/mod.rs
+++ b/meerkat-lib/src/runtime/manager/mod.rs
@@ -758,7 +758,8 @@ impl Manager {
 
         match reply {
             MeerkatMessage::LookupResponse { value, .. } => {
-                let val = codec::decode_value(value, &mut self.interner);
+                let val = codec::decode_value(value, &mut self.interner)
+                    .map_err(|e| EvalError::LocalDispatchFailed(e.to_string()))?;
                 Ok(val)
             }
             MeerkatMessage::LookupError { error, .. } => Err(EvalError::LocalDispatchFailed(error)),
@@ -849,20 +850,21 @@ impl Manager {
             }
         }
 
-        let net_stmts = stmts
-            .iter()
-            .map(|s| codec::encode_action_stmt(s, &self.interner))
-            .collect();
+        let mut net_stmts = Vec::new();
+        for s in &stmts {
+            net_stmts.push(
+                codec::encode_action_stmt(s, &self.interner)
+                    .map_err(|e| EvalError::LocalDispatchFailed(e.to_string()))?,
+            );
+        }
 
-        let net_env = env
-            .into_iter()
-            .map(|(sym, val)| {
-                (
-                    self.interner.get(sym).to_string(),
-                    codec::encode_value(&val, &self.interner),
-                )
-            })
-            .collect();
+        let mut net_env = Vec::new();
+        for (sym, val) in env {
+            let key_str = self.interner.get(sym).to_string();
+            let enc_val = codec::encode_value(&val, &self.interner)
+                .map_err(|e| EvalError::LocalDispatchFailed(e.to_string()))?;
+            net_env.push((key_str, enc_val));
+        }
 
         let msg = MeerkatMessage::ActionRequest {
             request_id,

--- a/meerkat-lib/src/runtime/mod.rs
+++ b/meerkat-lib/src/runtime/mod.rs
@@ -1,7 +1,10 @@
 pub mod ast;
+pub mod interner;
 pub mod interpreter;
 pub mod manager;
 pub mod parser;
 pub mod semantic_analysis;
 pub mod txn;
+
+pub use interner::{Interner, Symbol};
 pub use manager::Manager;

--- a/meerkat-lib/src/runtime/mod.rs
+++ b/meerkat-lib/src/runtime/mod.rs
@@ -1,6 +1,7 @@
 pub mod ast;
 pub mod interner;
 pub mod interpreter;
+pub mod limits;
 pub mod manager;
 pub mod parser;
 pub mod semantic_analysis;

--- a/meerkat-lib/src/runtime/parser/meerkat.lalrpop
+++ b/meerkat-lib/src/runtime/parser/meerkat.lalrpop
@@ -133,7 +133,7 @@ Decls: Vec<Decl> = Decl*;
 
 Field: Field = {
    <i:Ident> ":" <t: DataType> "," => {
-    Field {name: i, type_: t}
+    Field {name: i, ty: t}
    } 
 }
 

--- a/meerkat-lib/src/runtime/parser/meerkat.lalrpop
+++ b/meerkat-lib/src/runtime/parser/meerkat.lalrpop
@@ -5,9 +5,10 @@
 // Initial grammar for L1 
 
 // Grammar 
-grammar<'input>;
+grammar<'input>(interner: &mut crate::runtime::interner::Interner);
 
 use crate::ast::{Stmt, ActionStmt, Decl, Expr, UnOp, BinOp, DataType, Field, Value};
+use crate::runtime::interner::{Interner, Symbol};
 use lalrpop_util::ParseError;
 use crate::runtime::parser::lex::Token;
 
@@ -87,10 +88,10 @@ Stmt: Stmt = {
         Stmt::Service { name: i, decls: ds }
     },
     "@test" "(" <i:Ident> ")" "{" <astmts: ActionStmts> "}" => {
-        Stmt::Test { service: i, stmts: astmts }
+        Stmt::Test { service_name: i, stmts: astmts }
     },
     "import" <i:Ident> => {
-        Stmt::Import { path: format!("{}.mkt", i), service: i }
+        Stmt::Import { path: format!("{}.mkt", interner.get(i)), service_name: i }
     },
     <a:ActionStmt> => Stmt::ActionStmt(a),
     "watch" <e:Expr> ";" => Stmt::Watch { expr: e },
@@ -109,7 +110,7 @@ ActionStmt: ActionStmt = {
     "insert"  <e: Expr> "into" <t: Ident> => {
         ActionStmt::Insert {row: e, table_name: t}
     },
-    <i:Ident> "=" <e:Expr> ";" => ActionStmt::Assign { var: i, expr: e },
+    <i:Ident> "=" <e:Expr> ";" => ActionStmt::Assign { name: i, expr: e },
     <e:Expr> ";" => ActionStmt::Expr(e),
 }
 
@@ -144,7 +145,7 @@ DataType: DataType = {
     "bool" => DataType::Bool,
 }
 
-Params: Vec<String> = {
+Params: Vec<Symbol> = {
     <mut v:(<Ident> ",")*> <e:Ident?> => 
     match e {
         None => v,
@@ -172,14 +173,14 @@ SubExpr: Expr = {
     <n:Number> => Expr::Literal { val: Value::Number { val: n } },
     <b:Bool> => Expr::Literal { val: Value::Bool { val: b } },
     <s: "strlit"> => Expr::Literal { val: Value::String { val: s.to_owned() } },
-    <i:Ident> => Expr::Variable { ident: i },
+    <i:Ident> => Expr::Variable { name: i },
     "{" <args: Args> "}" => Expr::Tuple {val: args},
     "(" <Expr> ")" => <>,
     
     <expr:SubExpr> "(" <args:Args> ")" => 
         Expr::Call { func: Box::new(expr), args },
 
-    <s:Ident> "." <m:Ident> => Expr::MemberAccess { service: s, member: m },
+    <s:Ident> "." <m:Ident> => Expr::MemberAccess { service_name: s, member_name: m },
 
     "action" "{" <stmts: ActionStmts> "}" => Expr::Action(stmts),
 }
@@ -195,7 +196,7 @@ Expr: Expr = {
     "!" <e:Expr> => {
         Expr::Unop { expr: Box::new(e), op: UnOp::Not }
     },
-    <i: Ident> ":" <e: Expr> => Expr::KeyVal {key: i, value: Box::new(e)},
+    <i: Ident> ":" <e: Expr> => Expr::KeyVal {name: i, value: Box::new(e)},
     
     
 
@@ -317,6 +318,6 @@ Number: i32 = {
     <n:"num"> => n
 }
 
-Ident: String = {
-    <i:"ident"> => i.to_owned()
+Ident: Symbol = {
+    <i:"ident"> => interner.insert(i)
 }

--- a/meerkat-lib/src/runtime/parser/mod.rs
+++ b/meerkat-lib/src/runtime/parser/mod.rs
@@ -7,42 +7,67 @@ pub mod meerkat {
     include!(concat!(env!("OUT_DIR"), "/runtime/parser/meerkat.rs"));
 }
 
-/// Result of attempting to parse a REPL input buffer.
+/// Result of attempting to parse a `REPL` input buffer using `ReplParseResult`
 pub enum ReplParseResult {
-    /// Input parsed successfully into one or more statements.
+    /// Input parsed successfully into one or more statements
     Complete(Vec<crate::ast::Stmt>),
-    /// Input is syntactically incomplete (e.g. an open brace with no matching close).
-    /// The REPL should prompt for more input and append it to the buffer.
+    /// Input is syntactically incomplete (e.g., an open brace with no matching close)
+    ///
+    /// The `REPL` should prompt for more input and append it to the buffer
     Incomplete,
-    /// Input has a real syntax error that won't be resolved by adding more text.
+    /// Input has a real syntax error that won't be resolved by adding more text
     Error(String),
 }
 
 use logos::Logos;
 
 use crate::ast::Stmt;
+use crate::runtime::interner::Interner;
 
-pub fn parse_string(input: &str) -> Result<Vec<Stmt>, String> {
+/// Parse a string input into a vector of statements
+///
+/// Args:
+///     `input` (`&str`): The raw string input to parse
+///     `interner` (`&mut Interner`): The string interner instance
+///
+/// Returns:
+///     `Result<Vec<Stmt>, String>`: The parsed statements, or an error string
+pub fn parse_string(input: &str, interner: &mut Interner) -> Result<Vec<Stmt>, String> {
     let lex_stream = lex::Token::lexer(input)
         .spanned()
         .map(|(t, span)| (span.start, t, span.end));
 
     meerkat::ProgParser::new()
-        .parse(lex_stream)
+        .parse(interner, lex_stream)
         .map_err(|e| format!("Parse error: {:?}", e))
 }
 
-pub fn parse_file(filename: &str) -> Result<Vec<Stmt>, String> {
+/// Parse a file path into a vector of statements
+///
+/// Args:
+///     `filename` (`&str`): The path of the file to parse
+///     `interner` (`&mut Interner`): The string interner instance
+///
+/// Returns:
+///     `Result<Vec<Stmt>, String>`: The parsed statements, or an error string
+pub fn parse_file(filename: &str, interner: &mut Interner) -> Result<Vec<Stmt>, String> {
     let content =
         std::fs::read_to_string(filename).map_err(|e| format!("Failed to read file: {}", e))?;
-    parse_string(&content)
+    parse_string(&content, interner)
 }
 
-/// Try to parse accumulated REPL input, distinguishing incomplete input from real errors.
+/// Try to parse accumulated `REPL` input, distinguishing incomplete input from real errors
 ///
 /// Returns `Incomplete` when the grammar signals `UnrecognizedEof`, meaning the user
-/// is mid-statement and the REPL should collect more lines before evaluating.
-pub fn parse_repl(input: &str) -> ReplParseResult {
+/// is mid-statement and the `REPL` should collect more lines before evaluating
+///
+/// Args:
+///     `input` (`&str`): The accumulated REPL input buffer
+///     `interner` (`&mut Interner`): The string interner instance
+///
+/// Returns:
+///     `ReplParseResult`: The parsed result status
+pub fn parse_repl(input: &str, interner: &mut Interner) -> ReplParseResult {
     use lalrpop_util::ParseError;
 
     if input.trim().is_empty() {
@@ -53,7 +78,7 @@ pub fn parse_repl(input: &str) -> ReplParseResult {
         .spanned()
         .map(|(t, span)| (span.start, t, span.end));
 
-    match meerkat::ProgParser::new().parse(lex_stream) {
+    match meerkat::ProgParser::new().parse(interner, lex_stream) {
         Ok(stmts) if !stmts.is_empty() => ReplParseResult::Complete(stmts),
         Ok(_) => ReplParseResult::Incomplete,
         Err(ParseError::UnrecognizedEof { .. }) => ReplParseResult::Incomplete,

--- a/meerkat-lib/src/runtime/parser/mod.rs
+++ b/meerkat-lib/src/runtime/parser/mod.rs
@@ -19,10 +19,10 @@ pub enum ReplParseResult {
     Error(String),
 }
 
-use logos::Logos;
-
 use crate::ast::Stmt;
 use crate::runtime::interner::Interner;
+use crate::runtime::limits::{MAX_IDENTIFIER_LENGTH, MAX_STRING_LITERAL_LENGTH};
+use logos::Logos;
 
 /// Parse a string input into a vector of statements
 ///
@@ -33,9 +33,29 @@ use crate::runtime::interner::Interner;
 /// Returns:
 ///     `Result<Vec<Stmt>, String>`: The parsed statements, or an error string
 pub fn parse_string(input: &str, interner: &mut Interner) -> Result<Vec<Stmt>, String> {
-    let lex_stream = lex::Token::lexer(input)
-        .spanned()
-        .map(|(t, span)| (span.start, t, span.end));
+    let mut lex_stream = Vec::new();
+    for (t, span) in lex::Token::lexer(input).spanned() {
+        match t {
+            lex::Token::Ident(name) => {
+                if name.len() > MAX_IDENTIFIER_LENGTH {
+                    return Err(format!(
+                        "Parse error: identifier exceeds maximum length of {} characters",
+                        MAX_IDENTIFIER_LENGTH
+                    ));
+                }
+            }
+            lex::Token::StrLit(val) => {
+                if val.len() > MAX_STRING_LITERAL_LENGTH {
+                    return Err(format!(
+                        "Parse error: string literal exceeds maximum length of {} characters",
+                        MAX_STRING_LITERAL_LENGTH
+                    ));
+                }
+            }
+            _ => {}
+        }
+        lex_stream.push((span.start, t, span.end));
+    }
 
     meerkat::ProgParser::new()
         .parse(interner, lex_stream)
@@ -74,14 +94,68 @@ pub fn parse_repl(input: &str, interner: &mut Interner) -> ReplParseResult {
         return ReplParseResult::Incomplete;
     }
 
-    let lex_stream = lex::Token::lexer(input)
-        .spanned()
-        .map(|(t, span)| (span.start, t, span.end));
+    let mut lex_stream = Vec::new();
+    for (t, span) in lex::Token::lexer(input).spanned() {
+        match t {
+            lex::Token::Ident(name) => {
+                if name.len() > MAX_IDENTIFIER_LENGTH {
+                    return ReplParseResult::Error(format!(
+                        "Parse error: identifier exceeds maximum length of {} characters",
+                        MAX_IDENTIFIER_LENGTH
+                    ));
+                }
+            }
+            lex::Token::StrLit(val) => {
+                if val.len() > MAX_STRING_LITERAL_LENGTH {
+                    return ReplParseResult::Error(format!(
+                        "Parse error: string literal exceeds maximum length of {} characters",
+                        MAX_STRING_LITERAL_LENGTH
+                    ));
+                }
+            }
+            _ => {}
+        }
+        lex_stream.push((span.start, t, span.end));
+    }
 
     match meerkat::ProgParser::new().parse(interner, lex_stream) {
         Ok(stmts) if !stmts.is_empty() => ReplParseResult::Complete(stmts),
         Ok(_) => ReplParseResult::Incomplete,
         Err(ParseError::UnrecognizedEof { .. }) => ReplParseResult::Incomplete,
         Err(e) => ReplParseResult::Error(format!("{:?}", e)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runtime::interner::Interner;
+
+    /// Verify that parsing an identifier exceeding the limit
+    /// returns an error
+    #[test]
+    fn test_parse_oversized_identifier() {
+        let mut interner = Interner::new();
+        let long_ident = "a".repeat(MAX_IDENTIFIER_LENGTH + 1);
+        let input = format!("let {} = 42;", long_ident);
+        let res = parse_string(&input, &mut interner);
+        assert!(res.is_err() == true);
+        assert!(res
+            .unwrap_err()
+            .contains("identifier exceeds maximum length"));
+    }
+
+    /// Verify that parsing a string literal exceeding the limit
+    /// returns an error
+    #[test]
+    fn test_parse_oversized_string_literal() {
+        let mut interner = Interner::new();
+        let long_str = "a".repeat(MAX_STRING_LITERAL_LENGTH + 1);
+        let input = format!("let x = \"{}\";", long_str);
+        let res = parse_string(&input, &mut interner);
+        assert!(res.is_err() == true);
+        assert!(res
+            .unwrap_err()
+            .contains("string literal exceeds maximum length"));
     }
 }

--- a/meerkat-lib/src/runtime/parser/mod.rs
+++ b/meerkat-lib/src/runtime/parser/mod.rs
@@ -44,13 +44,11 @@ pub fn parse_string(input: &str, interner: &mut Interner) -> Result<Vec<Stmt>, S
                     ));
                 }
             }
-            lex::Token::StrLit(val) => {
-                if val.len() > MAX_STRING_LITERAL_LENGTH {
-                    return Err(format!(
-                        "Parse error: string literal exceeds maximum length of {} characters",
-                        MAX_STRING_LITERAL_LENGTH
-                    ));
-                }
+            lex::Token::StrLit(val) if val.len() > MAX_STRING_LITERAL_LENGTH => {
+                return Err(format!(
+                    "Parse error: string literal exceeds maximum length of {} characters",
+                    MAX_STRING_LITERAL_LENGTH
+                ));
             }
             _ => {}
         }
@@ -105,13 +103,11 @@ pub fn parse_repl(input: &str, interner: &mut Interner) -> ReplParseResult {
                     ));
                 }
             }
-            lex::Token::StrLit(val) => {
-                if val.len() > MAX_STRING_LITERAL_LENGTH {
-                    return ReplParseResult::Error(format!(
-                        "Parse error: string literal exceeds maximum length of {} characters",
-                        MAX_STRING_LITERAL_LENGTH
-                    ));
-                }
+            lex::Token::StrLit(val) if val.len() > MAX_STRING_LITERAL_LENGTH => {
+                return ReplParseResult::Error(format!(
+                    "Parse error: string literal exceeds maximum length of {} characters",
+                    MAX_STRING_LITERAL_LENGTH
+                ));
             }
             _ => {}
         }
@@ -139,7 +135,7 @@ mod tests {
         let long_ident = "a".repeat(MAX_IDENTIFIER_LENGTH + 1);
         let input = format!("let {} = 42;", long_ident);
         let res = parse_string(&input, &mut interner);
-        assert!(res.is_err() == true);
+        assert!(res.is_err());
         assert!(res
             .unwrap_err()
             .contains("identifier exceeds maximum length"));
@@ -153,7 +149,7 @@ mod tests {
         let long_str = "a".repeat(MAX_STRING_LITERAL_LENGTH + 1);
         let input = format!("let x = \"{}\";", long_str);
         let res = parse_string(&input, &mut interner);
-        assert!(res.is_err() == true);
+        assert!(res.is_err());
         assert!(res
             .unwrap_err()
             .contains("string literal exceeds maximum length"));

--- a/meerkat-lib/src/runtime/semantic_analysis/var_analysis/alpha_rename.rs
+++ b/meerkat-lib/src/runtime/semantic_analysis/var_analysis/alpha_rename.rs
@@ -1,21 +1,26 @@
-use core::panic;
 use std::collections::{HashMap, HashSet};
 
 use crate::ast::{ActionStmt, Expr};
+use crate::runtime::interner::Symbol;
 
 impl Expr {
-    /// alpha renaming of expression e
-    /// rename x1, x2, ..., x_n to y1, y2, ..., y_n if x is free in expression e
+    /// Alpha renaming of expression `self`
+    ///
+    /// Rename variables if they are free in expression `self`
+    ///
+    /// Args:
+    ///     `var_binded` (`&HashSet<Symbol>`): The set of bound symbols
+    ///     `renames` (`&HashMap<Symbol, Symbol>`): The map of renames to apply
     pub fn alpha_rename(
         &mut self,
-        var_binded: &HashSet<String>,
-        renames: &HashMap<String, String>,
+        var_binded: &HashSet<Symbol>,
+        renames: &HashMap<Symbol, Symbol>,
     ) {
         match self {
             Expr::Literal { .. } => {}
-            Expr::Variable { ident } => {
-                if !var_binded.contains(ident) && renames.contains_key(ident) {
-                    *ident = renames.get(ident).unwrap().clone();
+            Expr::Variable { name } => {
+                if !var_binded.contains(name) && renames.contains_key(name) {
+                    *name = *renames.get(name).unwrap();
                 }
             }
             Expr::KeyVal { value, .. } => {
@@ -52,11 +57,6 @@ impl Expr {
 
             Expr::Action(stmts) => {
                 for stmt in stmts {
-                    // dest should never be renamed, not influenced by capture
-                    // let dest = &mut assn.dest;
-                    // if !var_binded.contains(dest) && renames.contains_key(dest){
-                    //     *dest = renames.get(dest).unwrap().clone();
-                    // }
                     stmt.alpha_rename(var_binded, renames);
                 }
             }
@@ -82,14 +82,18 @@ impl Expr {
 }
 
 impl ActionStmt {
+    /// Perform alpha renaming on an `ActionStmt`
+    ///
+    /// Args:
+    ///     `_var_binded` (`&HashSet<Symbol>`): The set of bound symbols
+    ///     `_renames` (`&HashMap<Symbol, Symbol>`): The map of renames to apply
     pub fn alpha_rename(
         &mut self,
-        // Added underscores to silence warnings due to this being a stub.
-        _var_binded: &HashSet<String>,
-        _renames: &HashMap<String, String>,
+        _var_binded: &HashSet<Symbol>,
+        _renames: &HashMap<Symbol, Symbol>,
     ) {
-        // TODO: Implement alpha renaming for ActionStmt based on its structure
-        // This is a placeholder - adjust based on ActionStmt's actual fields
+        // TODO: Implement alpha renaming for `ActionStmt` based on its structure
+        // This is a placeholder; adjust based on `ActionStmt`'s actual fields
         panic!("alpha_rename for ActionStmt is not implemented yet");
     }
 }

--- a/meerkat-lib/src/runtime/semantic_analysis/var_analysis/dep_analysis.rs
+++ b/meerkat-lib/src/runtime/semantic_analysis/var_analysis/dep_analysis.rs
@@ -1,34 +1,41 @@
 use super::DependAnalysis;
 use crate::ast;
+use crate::runtime::interner::Symbol;
 use std::collections::{HashMap, HashSet};
 
 impl DependAnalysis {
+    /// Initialize a new `DependAnalysis` from the declarations
+    ///
+    /// Args:
+    ///     `decls` (`&[ast::Decl]`): The sequence of declarations to analyze
+    ///
+    /// Returns:
+    ///     `DependAnalysis`: The new analysis state instance
     pub fn new(decls: &[ast::Decl]) -> DependAnalysis {
-        let mut vars: HashSet<String> = HashSet::new();
-        let mut defs: HashSet<String> = HashSet::new();
+        let mut vars: HashSet<Symbol> = HashSet::new();
+        let mut defs: HashSet<Symbol> = HashSet::new();
         let mut reactive_names = HashSet::new();
-        let mut tables: HashSet<String> = HashSet::new();
+        let mut tables: HashSet<Symbol> = HashSet::new();
 
-        let mut dep_graph: HashMap<String, HashSet<String>> = HashMap::new();
+        let mut dep_graph: HashMap<Symbol, HashSet<Symbol>> = HashMap::new();
 
         for decl in decls.iter() {
             match decl {
                 ast::Decl::VarDecl { name, .. } => {
-                    vars.insert(name.clone());
-                    reactive_names.insert(name.clone());
-                    dep_graph.insert(name.clone(), HashSet::new());
+                    vars.insert(*name);
+                    reactive_names.insert(*name);
+                    dep_graph.insert(*name, HashSet::new());
                 }
                 ast::Decl::DefDecl { name, val, .. } => {
-                    defs.insert(name.clone());
-                    reactive_names.insert(name.clone());
-                    // we calculated all reactive names so far
-
+                    defs.insert(*name);
+                    reactive_names.insert(*name);
+                    // Calculated all reactive names so far
                     let deps = val.free_var(&reactive_names, &HashSet::new());
-                    dep_graph.insert(name.clone(), deps);
+                    dep_graph.insert(*name, deps);
                 }
                 ast::Decl::TableDecl { name, .. } => {
-                    tables.insert(name.clone());
-                    dep_graph.insert(name.clone(), HashSet::new());
+                    tables.insert(*name);
+                    dep_graph.insert(*name, HashSet::new());
                 }
             }
         }
@@ -45,66 +52,71 @@ impl DependAnalysis {
     }
 
     /// Performs a depth-first search on the dependency graph to calculate
-    /// the transitive dependencies for a given variable or definition.
-    /// # Arguments
-    /// * `vars` - set of variable names (no dependencies).
-    /// * `tables` - set of table names (no dependencies).
-    /// * `visited` - set of visited nodes in dfs.
-    /// * `calced` - map of def to their computed dependencies, only appeared
-    ///   when finished computing for a def.
-    /// # Panics
-    /// * panic if a cycle is detected in the graph.
+    /// the transitive dependencies for a given variable or definition
+    ///
+    /// Args:
+    ///     `graph` (`&HashMap<Symbol, HashSet<Symbol>>`): The dependency graph
+    ///     `vars` (`&HashSet<Symbol>`): Set of variable names (no dependencies)
+    ///     `tables` (`&HashSet<Symbol>`): Set of table names (no dependencies)
+    ///     `visited` (`&mut HashSet<Symbol>`): Set of visited nodes in DFS
+    ///     `finished` (`&mut Vec<Symbol>`): List of finished nodes
+    ///     `calced` (`&mut HashMap<Symbol, HashSet<Symbol>>`): Map of definitions to their computed dependencies
+    ///     `name` (`Symbol`): The current symbol to process
+    ///
+    /// Raises:
+    ///     `Panic`: If a cycle is detected in the graph
     fn dfs_helper(
-        graph: &HashMap<String, HashSet<String>>,
-        vars: &HashSet<String>,
-        tables: &HashSet<String>,
-        visited: &mut HashSet<String>,
-        finished: &mut Vec<String>,
-        calced: &mut HashMap<String, HashSet<String>>,
-        name: &String,
+        graph: &HashMap<Symbol, HashSet<Symbol>>,
+        vars: &HashSet<Symbol>,
+        tables: &HashSet<Symbol>,
+        visited: &mut HashSet<Symbol>,
+        finished: &mut Vec<Symbol>,
+        calced: &mut HashMap<Symbol, HashSet<Symbol>>,
+        name: Symbol,
     ) {
-        if calced.contains_key(name) {
+        if calced.contains_key(&name) {
             return;
         }
 
-        if visited.contains(name) {
+        if visited.contains(&name) {
             panic!("Cycle detected in dependency graph of var and defs");
         }
 
-        visited.insert(name.clone());
-        // if visit var, notice var is transitively depend on itself
-        if vars.contains(name) || tables.contains(name) {
-            calced.insert(name.clone(), HashSet::from([name.clone()]));
-            finished.push(name.clone());
+        visited.insert(name);
+        // If visiting a `var`, note that a `var` transitively depends on itself
+        if vars.contains(&name) || tables.contains(&name) {
+            calced.insert(name, HashSet::from([name]));
+            finished.push(name);
             return;
         }
 
-        // else visit def
+        // Otherwise visit the `def`
         let mut dep = HashSet::new();
 
         for dep_name in graph
-            .get(name)
-            .unwrap_or_else(|| panic!("No such name in dep graph: {}", name))
+            .get(&name)
+            .unwrap_or_else(|| panic!("No such name in dep graph: {:?}", name))
         {
-            Self::dfs_helper(graph, vars, tables, visited, finished, calced, dep_name);
+            Self::dfs_helper(graph, vars, tables, visited, finished, calced, *dep_name);
             dep.extend(
                 calced
                     .get(dep_name)
                     .unwrap_or_else(|| {
                         panic!(
-                            "Not finished transitive dependency calculation of: {}",
+                            "Not finished transitive dependency calculation of: {:?}",
                             dep_name
                         )
                     })
                     .clone(),
             );
-            dep.insert(dep_name.clone());
+            dep.insert(*dep_name);
         }
 
-        calced.insert(name.clone(), dep);
-        finished.push(name.clone());
+        calced.insert(name, dep);
+        finished.push(name);
     }
 
+    /// Calculate dependent variables for all variables and definitions
     pub fn calc_dep_vars(&mut self) {
         let mut visited = HashSet::new();
 
@@ -120,7 +132,7 @@ impl DependAnalysis {
                 &mut visited,
                 &mut self.topo_order,
                 &mut self.dep_transitive,
-                name,
+                *name,
             );
         }
 
@@ -131,10 +143,10 @@ impl DependAnalysis {
             .chain(self.defs.iter().chain(self.tables.iter()))
         {
             self.dep_vars.insert(
-                name.clone(),
+                *name,
                 self.dep_transitive
                     .get(name)
-                    .unwrap_or_else(|| panic!("cannot find def {} in trans dep", name))
+                    .unwrap_or_else(|| panic!("cannot find def {:?} in trans dep", name))
                     .intersection(&vars_and_tables)
                     .cloned()
                     .collect(),

--- a/meerkat-lib/src/runtime/semantic_analysis/var_analysis/mod.rs
+++ b/meerkat-lib/src/runtime/semantic_analysis/var_analysis/mod.rs
@@ -7,25 +7,39 @@ use std::{
 };
 
 use crate::ast;
+use crate::runtime::interner::Symbol;
 
 pub mod alpha_rename;
 pub mod dep_analysis;
 pub mod read_write;
 
 pub struct DependAnalysis {
-    pub vars: HashSet<String>,
-    pub defs: HashSet<String>,
-    pub tables: HashSet<String>,
-    pub dep_graph: HashMap<String, HashSet<String>>,
-    pub topo_order: Vec<String>, // topological order of vars/defs
-    // transitively dependent vars/defs of a name
-    pub dep_transitive: HashMap<String, HashSet<String>>,
-    // transitively dependent vars of a name
-    // dep_vars[name] subset of dep_transitive[name]
-    pub dep_vars: HashMap<String, HashSet<String>>,
+    pub vars: HashSet<Symbol>,
+    pub defs: HashSet<Symbol>,
+    pub tables: HashSet<Symbol>,
+    pub dep_graph: HashMap<Symbol, HashSet<Symbol>>,
+    /// Topological order of variables and definitions represented by `Symbol`
+    pub topo_order: Vec<Symbol>,
+    /// Transitively dependent variables and definitions of a name
+    pub dep_transitive: HashMap<Symbol, HashSet<Symbol>>,
+    /// Transitively dependent variables of a name
+    ///
+    /// The `dep_vars` map values are a subset of `dep_transitive`
+    pub dep_vars: HashMap<Symbol, HashSet<Symbol>>,
 }
 
+/// Implement the `Display` trait for the `DependAnalysis` struct
+///
+/// This formats and displays the dependency graph, transitive
+/// dependencies, and topological order
 impl Display for DependAnalysis {
+    /// Format the dependency analysis result for display
+    ///
+    /// Args:
+    ///     `f` (`&mut std::fmt::Formatter<'_>`): The formatter target
+    ///
+    /// Returns:
+    ///     `std::fmt::Result`: The result of the formatting operation
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         writeln!(f, "Dependency Graph ")?;
         for (name, deps) in self.dep_graph.iter() {
@@ -53,6 +67,13 @@ impl Display for DependAnalysis {
     }
 }
 
+/// Calculate dependencies for a service from its declarations
+///
+/// Args:
+///     `decls` (`&[ast::Decl]`): The service declarations
+///
+/// Returns:
+///     `DependAnalysis`: The calculated dependency analysis state
 pub fn calc_dep_srv(decls: &[ast::Decl]) -> DependAnalysis {
     let mut da = DependAnalysis::new(decls);
     da.calc_dep_vars();
@@ -60,39 +81,51 @@ pub fn calc_dep_srv(decls: &[ast::Decl]) -> DependAnalysis {
     da
 }
 
-// enumerate services and call calc_dep_srv on each one
+/// Calculate dependencies for all services in a program
+///
+/// Args:
+///     `stmts` (`&[ast::Stmt]`): The statements of the program
 pub fn calc_dep_prog(stmts: &[ast::Stmt]) {
     for stmt in stmts.iter() {
         match stmt {
-            ast::Stmt::Service { decls, .. } | ast::Stmt::Update { decls, .. } => {
+            &ast::Stmt::Service { ref decls, .. } | &ast::Stmt::Update { ref decls, .. } => {
                 let _ = calc_dep_srv(decls);
             }
-            _ => {}
+            &ast::Stmt::ActionStmt(_) => {}
+            &ast::Stmt::Connect { .. }
+            | &ast::Stmt::Import { .. }
+            | &ast::Stmt::Test { .. }
+            | &ast::Stmt::Watch { .. } => {}
         }
     }
 }
 
+/// Unit tests for variable dependency analysis
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::ast::{Decl, Expr, Stmt, Value};
+    use crate::runtime::interner::Interner;
 
+    /// Verify dependency analysis on standard service definitions
     #[test]
     fn test_calc_dep_prog_service() {
+        let mut interner = Interner::new();
+        let s1 = interner.insert("s1");
+        let v2 = interner.insert("v2");
+        let v3 = interner.insert("v3");
         let stmts = vec![Stmt::Service {
-            name: "s".to_string(),
+            name: s1,
             decls: vec![
                 Decl::VarDecl {
-                    name: "x".to_string(),
+                    name: v2,
                     val: Expr::Literal {
                         val: Value::Number { val: 1 },
                     },
                 },
                 Decl::DefDecl {
-                    name: "y".to_string(),
-                    val: Expr::Variable {
-                        ident: "x".to_string(),
-                    },
+                    name: v3,
+                    val: Expr::Variable { name: v2 },
                     is_pub: false,
                 },
             ],
@@ -101,22 +134,25 @@ mod tests {
         calc_dep_prog(&stmts);
     }
 
+    /// Verify dependency analysis on service updates
     #[test]
     fn test_calc_dep_prog_update_service() {
+        let mut interner = Interner::new();
+        let s1 = interner.insert("s1");
+        let v2 = interner.insert("v2");
+        let v3 = interner.insert("v3");
         let stmts = vec![Stmt::Update {
-            service: "s".to_string(),
+            service_name: s1,
             decls: vec![
                 Decl::VarDecl {
-                    name: "x".to_string(),
+                    name: v2,
                     val: Expr::Literal {
                         val: Value::Number { val: 2 },
                     },
                 },
                 Decl::DefDecl {
-                    name: "y".to_string(),
-                    val: Expr::Variable {
-                        ident: "x".to_string(),
-                    },
+                    name: v3,
+                    val: Expr::Variable { name: v2 },
                     is_pub: true,
                 },
             ],

--- a/meerkat-lib/src/runtime/semantic_analysis/var_analysis/read_write.rs
+++ b/meerkat-lib/src/runtime/semantic_analysis/var_analysis/read_write.rs
@@ -1,22 +1,32 @@
 use crate::ast::{ActionStmt, Expr};
+use crate::runtime::interner::Symbol;
 use std::collections::HashSet;
 
 impl Expr {
-    /// return free variables in expr wrt var_binded, used for
-    /// 1. for extracting dependency of each def declaration
-    /// 2. for evaluation a expression (substitution based evaluation)
+    /// Returns the free variables in `self` with respect to `var_binded`
+    ///
+    /// This is used for:
+    /// - Extracting dependencies of each `def` declaration
+    /// - Evaluating an expression (substitution based evaluation)
+    ///
+    /// Args:
+    ///     `reactive_names` (`&HashSet<Symbol>`): The set of reactive names
+    ///     `var_binded` (`&HashSet<Symbol>`): The set of bound symbols
+    ///
+    /// Returns:
+    ///     `HashSet<Symbol>`: The set of free variables
     pub fn free_var(
         &self,
-        reactive_names: &HashSet<String>,
-        var_binded: &HashSet<String>,
-    ) -> HashSet<String> {
+        reactive_names: &HashSet<Symbol>,
+        var_binded: &HashSet<Symbol>,
+    ) -> HashSet<Symbol> {
         match self {
             Expr::Literal { .. } | Expr::Table { .. } => HashSet::new(),
-            Expr::Variable { ident } => {
-                if var_binded.contains(ident) {
+            Expr::Variable { name } => {
+                if var_binded.contains(name) {
                     HashSet::new()
                 } else {
-                    HashSet::from([ident.clone()])
+                    HashSet::from([*name])
                 }
             }
             Expr::KeyVal { value, .. } => value.free_var(reactive_names, var_binded),
@@ -59,7 +69,7 @@ impl Expr {
                 let mut free_vars = HashSet::new();
                 for stmt in stmts {
                     match stmt {
-                        ActionStmt::Assign { var: _, expr } => {
+                        ActionStmt::Assign { name: _, expr } => {
                             free_vars.extend(expr.free_var(reactive_names, var_binded));
                         }
                         ActionStmt::Do(expr) => {
@@ -91,7 +101,7 @@ impl Expr {
                 ..
             } => {
                 let mut free_vars = where_clause.free_var(reactive_names, var_binded);
-                free_vars.insert(table_name.clone());
+                free_vars.insert(*table_name);
                 free_vars
             }
             Expr::Fold {

--- a/meerkat-lib/src/runtime/txn.rs
+++ b/meerkat-lib/src/runtime/txn.rs
@@ -1,51 +1,58 @@
-//! Transaction ID and per-variable lock state for the Manager.
+//! Transaction ID and per-variable lock state for the `Manager`
 
-use crate::net::{Address, ServiceId};
+use crate::net::{Address, ServiceNetId};
 use crate::runtime::ast::Value;
+use crate::runtime::interner::Symbol;
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 use std::sync::Mutex;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-/// A globally unique transaction identifier.
+/// A globally unique transaction identifier represented by `TxnId`
 ///
-/// Per the Historiographer design a tid is a (unique node identifier,
-/// timestamp) pair. The timestamp is nanoseconds since the Unix epoch; the
-/// node_id makes ids from different nodes distinct and serves as the age
-/// tiebreaker. Serializable so it can travel in cross-node messages.
+/// Per the `Historiographer` design, a `tid` is a (unique node
+/// identifier, timestamp) pair. The timestamp is nanoseconds since
+/// the Unix epoch; the `node_id` makes IDs from different nodes
+/// distinct and serves as the age tiebreaker. Serializable so it
+/// can travel in cross-node messages
 ///
-/// Age (for future wait-die): older = smaller timestamp, with node_id as
-/// tiebreaker. Higher iteration = higher priority among retries of the same
-/// transaction.
+/// Age (for wait-die): older = smaller timestamp, with `node_id` as
+/// tiebreaker. Higher `iteration` = higher priority among retries
+/// of the same transaction
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct TxnId {
-    /// Creation time as nanoseconds since the Unix epoch, used as a logical
-    /// clock: monotonically increasing per node so two transactions minted in
-    /// the same wall-clock tick still get distinct ids.
+    /// Creation time as nanoseconds since the Unix epoch, used as a
+    /// logical clock: monotonically increasing per node so two
+    /// transactions minted in the same wall-clock tick still get
+    /// distinct IDs
     pub timestamp: u128,
-    /// (Probabilistically) unique identifier of the originating node.
+    /// (Probabilistically) unique identifier of the originating node
     pub node_id: u64,
-    /// Incremented on retry so retried transactions gain priority.
+    /// Incremented on retry so retried transactions gain priority
     pub iteration: u32,
 }
 
-/// Last nanosecond timestamp handed out as a TxnId on this process. Acts as a
-/// logical clock: if the wall clock has not advanced past it, we bump by one so
-/// two transactions in the same tick still get distinct (and ordered) ids. This
-/// guarantees uniqueness on a node, which matters because TxnId aliases lock
-/// owners and keys participant-held transaction state.
+/// Last nanosecond timestamp handed out as a `TxnId` on this process
+///
+/// Acts as a logical clock: if the wall clock has not advanced past
+/// it, we bump by one so two transactions in the same tick still
+/// get distinct (and ordered) IDs
+/// This guarantees uniqueness on a node, which matters because
+/// `TxnId` aliases lock owners and keys participant-held transaction
+/// state
 static LAST_TXN_NANOS: Mutex<u128> = Mutex::new(0);
 
 impl TxnId {
-    /// Create a new, node-unique transaction id originating from the given node.
+    /// Create a new, node-unique transaction ID originating from the given node
     pub fn new(node_id: u64) -> Self {
         let now = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .map(|d| d.as_nanos())
             .unwrap_or(0);
-        // Claim a timestamp strictly greater than any previously issued one,
-        // even if the clock repeated or went backwards. A clock error (now == 0)
-        // can no longer cause a collision because we still take last + 1.
+        // Claim a timestamp strictly greater than any previously issued
+        // one, even if the clock repeated or went backwards. A clock
+        // error (`now == 0`) can no longer cause a collision because we
+        // still take `last + 1`
         let timestamp = {
             let mut last = LAST_TXN_NANOS.lock().unwrap_or_else(|e| e.into_inner());
             let ts = now.max(*last + 1);
@@ -59,8 +66,8 @@ impl TxnId {
         }
     }
 
-    /// Return a new TxnId with the same timestamp/node but higher iteration,
-    /// for use when retrying an aborted transaction.
+    /// Return a new `TxnId` with the same timestamp/node but higher
+    /// iteration, for use when retrying an aborted transaction
     pub fn retry(&self) -> Self {
         TxnId {
             timestamp: self.timestamp,
@@ -78,9 +85,9 @@ impl PartialOrd for TxnId {
 
 impl Ord for TxnId {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        // Age ordering: older timestamp = smaller = higher priority, with
-        // node_id as the tiebreaker. Higher iteration = higher priority among
-        // retries of the same transaction.
+        // Age ordering: older `timestamp` = smaller = higher priority, with
+        // `node_id` as the tiebreaker. Higher `iteration` = higher priority among
+        // retries of the same transaction
         self.timestamp
             .cmp(&other.timestamp)
             .then(self.node_id.cmp(&other.node_id))
@@ -88,8 +95,9 @@ impl Ord for TxnId {
     }
 }
 
-/// Per-variable lock state used by the Manager.
-/// Multiple readers are allowed simultaneously; writers are exclusive.
+/// Per-variable lock state used by the `Manager`
+///
+/// Multiple readers are allowed simultaneously; writers are exclusive
 #[derive(Debug, Clone)]
 pub enum VarLock {
     Unlocked,
@@ -108,7 +116,7 @@ impl VarLock {
         VarLock::Unlocked
     }
 
-    /// Try to acquire a read lock. Succeeds unless write-locked.
+    /// Try to acquire a read lock, succeeding unless write-locked
     pub fn try_read(&mut self, txn_id: &TxnId) -> bool {
         match self {
             VarLock::Unlocked => {
@@ -125,18 +133,18 @@ impl VarLock {
         }
     }
 
-    /// Try to acquire an exclusive write lock. Fails if any lock is held.
+    /// Try to acquire an exclusive write lock, failing if any lock is held
     pub fn try_write(&mut self, txn_id: &TxnId) -> bool {
         match self {
             VarLock::Unlocked => {
                 *self = VarLock::WriteLocked(txn_id.clone());
                 true
             }
-            _ => false,
+            VarLock::ReadLocked(_) | VarLock::WriteLocked(_) => false,
         }
     }
 
-    /// Release a read lock held by txn_id.
+    /// Release a read lock held by `txn_id`
     pub fn release_read(&mut self, txn_id: &TxnId) {
         if let VarLock::ReadLocked(set) = self {
             set.remove(txn_id);
@@ -146,16 +154,18 @@ impl VarLock {
         }
     }
 
-    /// Release the write lock if currently held by txn_id.
+    /// Release the write lock if currently held by `txn_id`
     pub fn release_write(&mut self, txn_id: &TxnId) {
         if matches!(self, VarLock::WriteLocked(tid) if tid == txn_id) {
             *self = VarLock::Unlocked;
         }
     }
 
-    /// Upgrade a read lock held solely by txn_id to a write lock.
-    /// Needed for read-then-write patterns (e.g. x = x + 1).
-    /// Returns true if upgrade succeeded or var is already write-locked by txn_id.
+    /// Upgrade a read lock held solely by `txn_id` to a write lock
+    ///
+    /// Needed for read-then-write patterns (e.g., `x = x + 1`)
+    /// Returns `true` if upgrade succeeded or variable is already
+    /// write-locked by `txn_id`
     pub fn upgrade_to_write(&mut self, txn_id: &TxnId) -> bool {
         match self {
             VarLock::ReadLocked(set) if set.len() == 1 && set.contains(txn_id) => {
@@ -163,11 +173,12 @@ impl VarLock {
                 true
             }
             VarLock::WriteLocked(tid) if tid == txn_id => true,
-            _ => false,
+            VarLock::Unlocked => false,
+            VarLock::ReadLocked(_) | VarLock::WriteLocked(_) => false,
         }
     }
 
-    /// Release any lock (read or write) held by txn_id.
+    /// Release any lock (read or write) held by `txn_id`
     pub fn release(&mut self, txn_id: &TxnId) {
         match self {
             VarLock::ReadLocked(_) => self.release_read(txn_id),
@@ -177,19 +188,22 @@ impl VarLock {
     }
 }
 
-/// Composite state for a single variable, consolidating value, lock, and
-/// transaction history into one structure instead of three separate maps.
+/// Composite state for a single variable represented by `VarState`
+///
+/// Consolidates value, lock, and transaction history into one
+/// structure instead of three separate maps
 #[derive(Debug, Clone)]
 pub struct VarState {
-    /// Current value of the variable.
+    /// Current value of the variable
     pub value: crate::runtime::ast::Value,
-    /// Lock state for 2-phase locking.
+    /// Lock state for two-phase locking
     pub lock: VarLock,
-    /// Most recent transaction to write this variable.
+    /// Most recent transaction to write this variable
     pub latest_write_txn: Option<TxnId>,
 }
 
 impl VarState {
+    /// Create a new `VarState` instance
     pub fn new(value: crate::runtime::ast::Value) -> Self {
         VarState {
             value,
@@ -199,29 +213,33 @@ impl VarState {
     }
 }
 
-/// Per-transaction state, owned by the code executing a transaction and passed
-/// around during execution rather than stored on the Manager. A single Manager
-/// may eventually run multiple transactions concurrently, so transaction state
-/// must not live on the Manager.
+/// Per-transaction state represented by `Transaction`
+///
+/// Owned by the code executing a transaction and passed around
+/// during execution rather than stored on the `Manager`
+///
+/// A single `Manager` may eventually run multiple transactions
+/// concurrently, so transaction state must not live on the `Manager`
 #[derive(Debug)]
 pub struct Transaction {
-    /// Globally unique transaction identifier.
+    /// Globally unique transaction identifier
     pub id: TxnId,
-    /// (service, variable) pairs this transaction currently holds a lock on.
-    pub locked: HashSet<(ServiceId, String)>,
+    /// Pairs of `(ServiceNetId, Symbol)` this transaction currently holds a lock on
+    pub locked: HashSet<(ServiceNetId, Symbol)>,
     /// Values already read in this transaction, keyed by (service, variable)
-    /// (avoids re-fetching, including redundant network round-trips).
-    pub read_cache: HashMap<(ServiceId, String), Value>,
+    /// (avoids re-fetching, including redundant network round-trips)
+    pub read_cache: HashMap<(ServiceNetId, Symbol), Value>,
     /// Values written by this transaction, keyed by (service, variable),
-    /// buffered and applied only on successful commit (so a failed transaction
-    /// leaves no partial writes).
-    pub written: HashMap<(ServiceId, String), Value>,
+    /// buffered and applied only on successful commit (so a failed
+    /// transaction leaves no partial writes)
+    pub written: HashMap<(ServiceNetId, Symbol), Value>,
     /// Remote nodes that joined this transaction (executed a composed action
-    /// under this id and are holding locks/buffered writes until commit/abort).
+    /// under this `id` and are holding locks or buffered writes until commit or abort)
     pub participants: HashSet<Address>,
 }
 
 impl Transaction {
+    /// Create a new `Transaction` instance
     pub fn new(id: TxnId) -> Self {
         Transaction {
             id,
@@ -233,9 +251,11 @@ impl Transaction {
     }
 }
 
-/// Outcome of a wait-die conflict check. The requesting transaction either
-/// waits for the lock (it is older / higher priority than every conflicting
-/// holder) or dies and retries (some current holder is older).
+/// Outcome of a wait-die conflict check represented by `WaitDie`
+///
+/// The requesting transaction either waits for the lock (it is older /
+/// higher priority than every conflicting holder) or dies and retries
+/// (some current holder is older)
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum WaitDie {
     Wait,
@@ -243,11 +263,12 @@ pub enum WaitDie {
 }
 
 impl VarLock {
-    /// Wait-die decision for a `requester` that conflicts with this lock.
-    /// Returns `Die` if any current holder is strictly older (smaller tid,
-    /// higher priority) than the requester; otherwise `Wait`. A holder equal
-    /// to the requester is ignored, since a transaction never conflicts with
-    /// itself.
+    /// Wait-die decision for a `requester` that conflicts with this lock
+    ///
+    /// Returns `Die` if any current holder is strictly older (smaller
+    /// `TxnId`, higher priority) than the `requester`; otherwise `Wait`
+    /// A holder equal to the `requester` is ignored, since a transaction
+    /// never conflicts with itself
     pub fn wait_die(&self, requester: &TxnId) -> WaitDie {
         let holder_older = match self {
             VarLock::Unlocked => false,

--- a/meerkat-lib/tests/interning_tests.rs
+++ b/meerkat-lib/tests/interning_tests.rs
@@ -1,0 +1,182 @@
+//! `AST` interning integration tests
+//!
+//! This module contains integration tests for the string interning
+//! functionality, `AstPrinter` symbol formatting, and key indexing
+//! behavior in `Transaction` maps and wait queues
+
+use meerkat_lib::net::ServiceNetId;
+use meerkat_lib::runtime::ast::{AstPrinter, Decl, Stmt};
+use meerkat_lib::runtime::txn::{Transaction, TxnId};
+use meerkat_lib::runtime::{Interner, Symbol};
+use std::collections::HashMap;
+
+/// Verify `AstPrinter` formatting for symbols
+///
+/// Ensures that `AstPrinter::format_symbol` formats a `Symbol` using the
+/// correct format `id ("name")`
+#[test]
+fn test_ast_printer_format_symbol() {
+    let mut interner = Interner::new();
+    let symbol = interner.insert("my_variable");
+    let printer = AstPrinter::new(&interner);
+    let formatted = printer.format_symbol(symbol);
+
+    let expected = format!("{} (\"my_variable\")", symbol);
+    assert_eq!(formatted, expected);
+}
+
+/// Verify `Transaction` maps indexing behavior
+///
+/// Asserts key typing and insertion for transaction maps: `locked`,
+/// `read_cache`, and `written` using `ServiceNetId` and `Symbol`
+#[test]
+fn test_transaction_maps_indexing() {
+    let mut interner = Interner::new();
+    let service_id = ServiceNetId::new("/ip4/127.0.0.1/tcp/9000/p2p/some_id/my_service");
+    let symbol = interner.insert("my_variable");
+
+    let txn_id = TxnId {
+        timestamp: 1000,
+        node_id: 1,
+        iteration: 0,
+    };
+    let mut txn = Transaction::new(txn_id);
+    let key = (service_id, symbol);
+
+    txn.locked.insert(key.clone());
+    assert!(txn.locked.contains(&key));
+
+    let read_value = meerkat_lib::runtime::ast::Value::Number { val: 42 };
+    txn.read_cache.insert(key.clone(), read_value.clone());
+    assert_eq!(txn.read_cache.get(&key), Some(&read_value));
+
+    let write_value = meerkat_lib::runtime::ast::Value::Number { val: 100 };
+    txn.written.insert(key.clone(), write_value.clone());
+    assert_eq!(txn.written.get(&key), Some(&write_value));
+}
+
+/// Verify manager wait queue indexing behavior
+///
+/// Verifies key insertion into the manager wait queue using
+/// `ServiceNetId` and `Symbol`
+#[test]
+fn test_manager_wait_queue_indexing() {
+    let mut interner = Interner::new();
+    let service_id = ServiceNetId::new("/ip4/127.0.0.1/tcp/9000/p2p/some_id/my_service");
+    let symbol = interner.insert("my_variable");
+
+    let mut wait_queue =
+        HashMap::<(ServiceNetId, Symbol), Vec<meerkat_lib::runtime::manager::ParkedRequest>>::new();
+    let key = (service_id, symbol);
+
+    assert!(!wait_queue.contains_key(&key));
+    wait_queue.insert(key.clone(), Vec::new());
+    assert!(wait_queue.contains_key(&key));
+}
+
+/// Verify new `Interner` initialization
+///
+/// Ensures that a newly initialized `Interner` has the empty string
+/// mapped to symbol `0`
+#[test]
+fn test_interner_new_empty() {
+    let interner = Interner::new();
+    assert_eq!(interner.get(Symbol::empty()), "");
+}
+
+/// Verify `Interner` duplicate handling
+///
+/// Ensures that inserting the same string multiple times returns
+/// the same `Symbol`
+#[test]
+fn test_interner_insert_duplicate() {
+    let mut interner = Interner::new();
+    let sym1 = interner.insert("duplicate");
+    let sym2 = interner.insert("duplicate");
+    assert_eq!(sym1, sym2);
+}
+
+/// Verify `AstPrinter` formatting for empty symbol
+///
+/// Ensures that symbol `0` is formatted correctly as empty string
+#[test]
+fn test_ast_printer_format_symbol_empty() {
+    let interner = Interner::new();
+    let printer = AstPrinter::new(&interner);
+    let formatted = printer.format_symbol(Symbol::empty());
+    assert_eq!(formatted, "0 (\"\")");
+}
+
+/// Verify `Symbol` copy semantics
+///
+/// Ensures that `Symbol` implements copy semantics and behaves
+/// correctly when copied by value
+#[test]
+fn test_symbol_copy_semantics() {
+    let sym1 = Symbol::empty();
+    let sym2 = sym1;
+    assert_eq!(sym1, sym2);
+}
+
+/// Verify custom spacing in `AstPrinter`
+///
+/// Ensures that formatting with a custom indentation level works
+/// and formats symbols identically
+#[test]
+fn test_ast_printer_custom_spaces() {
+    let mut interner = Interner::new();
+    let symbol = interner.insert("test_spacing");
+    let printer = AstPrinter::with_spaces(4, &interner);
+    let formatted = printer.format_symbol(symbol);
+    let expected = format!("{} (\"test_spacing\")", symbol);
+    assert_eq!(formatted, expected);
+}
+
+/// Verify parser interning
+///
+/// Ensures that parsing a service declaration correctly inserts the
+/// service and variable names into the `Interner`
+#[test]
+fn test_parser_simple_expression_interning() {
+    let mut interner = Interner::new();
+    let input = "service my_service { var my_var = 42; }";
+    let parse_result = meerkat_lib::runtime::parser::parse_string(input, &mut interner);
+    assert!(parse_result.is_ok());
+    let prog = parse_result.unwrap();
+    assert_eq!(prog.len(), 1);
+
+    if let Stmt::Service { name, decls } = &prog[0] {
+        assert_eq!(interner.get(*name), "my_service");
+        assert_eq!(decls.len(), 1);
+        if let Decl::VarDecl {
+            name: var_name,
+            val: _,
+        } = &decls[0]
+        {
+            assert_eq!(interner.get(*var_name), "my_var");
+        } else {
+            panic!("expected VarDecl statement");
+        }
+    } else {
+        panic!("expected Service statement");
+    }
+}
+
+/// Verify `ServiceNetId` equality and hashing
+///
+/// Ensures that `ServiceNetId` behaves correctly when placed in a map
+/// and matches keys as expected
+#[test]
+fn test_servicenetid_equality_and_hashing() {
+    let id1 = ServiceNetId::new("my_service");
+    let id2 = ServiceNetId::new("my_service");
+    let id3 = ServiceNetId::new("other_service");
+
+    assert_eq!(id1, id2);
+    assert_ne!(id1, id3);
+
+    let mut map = HashMap::new();
+    map.insert(id1.clone(), 100);
+    assert_eq!(map.get(&id2), Some(&100));
+    assert_eq!(map.get(&id3), None);
+}

--- a/meerkat/src/main.rs
+++ b/meerkat/src/main.rs
@@ -4,11 +4,14 @@ use clap::Parser;
 use meerkat_lib::net::network_layer::NetworkLayer;
 use meerkat_lib::net::types::NodeType;
 use meerkat_lib::net::NetworkActor;
-use meerkat_lib::net::{Address, MeerkatMessage, NetworkCommand, NetworkEvent, ServiceId};
-use meerkat_lib::runtime::ast::Stmt;
+use meerkat_lib::net::{
+    codec, Address, MeerkatMessage, NetworkCommand, NetworkEvent, NetworkReply, ServiceNetId,
+};
+use meerkat_lib::runtime::ast::{ActionStmt, AstPrinter, Stmt, Value};
+use meerkat_lib::runtime::interner::{Interner, Symbol};
 use meerkat_lib::runtime::interpreter::EvalError;
 use meerkat_lib::runtime::manager::ParkedRequest;
-use meerkat_lib::runtime::Manager;
+use meerkat_lib::runtime::{parser, Manager};
 use std::collections::HashSet;
 use std::error::Error;
 
@@ -69,15 +72,17 @@ pub async fn main() -> Result<(), Box<dyn Error>> {
         }
     }
 
+    let mut interner = Interner::new();
+
     match args.input_file {
         Some(ref file) => {
-            let prog = meerkat_lib::runtime::parser::parse_file(file)
+            let prog = parser::parse_file(file, &mut interner)
                 .map_err(|e| format!("Parse error: {}", e))?;
 
             // This must appear prior to `check_only` or it will never print. These
             // modes are designed to work both in isolation and in tandem
             if args.ast {
-                let printer = meerkat_lib::runtime::ast::AstPrinter::new();
+                let printer = AstPrinter::new(&interner);
                 printer.print_program(&prog);
             }
 
@@ -96,9 +101,9 @@ pub async fn main() -> Result<(), Box<dyn Error>> {
             }
 
             if args.server {
-                run_server(prog, remote_url_map, args.port, args.local).await
+                run_server(prog, remote_url_map, args.port, args.local, interner).await
             } else {
-                run_client(prog, file, remote_url_map, args.local).await
+                run_client(prog, file, remote_url_map, args.local, interner).await
             }
         }
         None => {
@@ -107,7 +112,7 @@ pub async fn main() -> Result<(), Box<dyn Error>> {
                     "Expected a .mkt file (-f) for --server, --check, or --ast mode.".into(),
                 );
             }
-            let mut manager = Manager::new();
+            let mut manager = Manager::new(interner);
             manager.local = args.local;
             repl::run_repl(manager, remote_url_map).await
         }
@@ -129,12 +134,12 @@ async fn run_and_reply_or_park(manager: &mut Manager, parked: ParkedRequest) {
             tid,
         } => {
             match manager
-                .execute_action_participant(&service, &stmts, &env, tid.clone())
+                .execute_action_participant(service, &stmts, &env, tid.clone())
                 .await
             {
                 Err(EvalError::WaitOn(svc, var)) => {
                     manager.park_request(
-                        &svc,
+                        svc,
                         var,
                         ParkedRequest::Action {
                             request_id,
@@ -170,12 +175,12 @@ async fn run_and_reply_or_park(manager: &mut Manager, parked: ParkedRequest) {
             tid,
         } => {
             match manager
-                .remote_read_participant(&service, &member, tid.clone())
+                .remote_read_participant(service, member, tid.clone())
                 .await
             {
                 Err(EvalError::WaitOn(svc, var)) => {
                     manager.park_request(
-                        &svc,
+                        svc,
                         var,
                         ParkedRequest::Lookup {
                             request_id,
@@ -189,7 +194,7 @@ async fn run_and_reply_or_park(manager: &mut Manager, parked: ParkedRequest) {
                 Ok(val) => {
                     let response = MeerkatMessage::LookupResponse {
                         request_id,
-                        value: serde_json::to_string(&val).unwrap_or_default(),
+                        value: codec::encode_value(&val, &manager.interner),
                     };
                     if let Some(net) = manager.network.as_mut() {
                         net.handle_command(NetworkCommand::SendMessage {
@@ -219,7 +224,7 @@ async fn run_and_reply_or_park(manager: &mut Manager, parked: ParkedRequest) {
 
 /// After a holder releases its locks on commit or abort, re-dispatch the parked
 /// requests waiting on the freed variables, oldest first.
-async fn wake_ready(manager: &mut Manager, freed: HashSet<(ServiceId, String)>) {
+async fn wake_ready(manager: &mut Manager, freed: HashSet<(ServiceNetId, Symbol)>) {
     for parked in manager.take_ready_waiters(&freed) {
         run_and_reply_or_park(manager, parked).await;
     }
@@ -230,9 +235,10 @@ async fn run_server(
     remote_url_map: std::collections::HashMap<String, String>,
     port: u16,
     local: bool,
+    interner: Interner,
 ) -> Result<(), Box<dyn Error>> {
     let mut net = NetworkActor::new(NodeType::Server).await?;
-    let mut manager = Manager::new();
+    let mut manager = Manager::new(interner);
     manager.local = local;
 
     let node_ip = manager.get_node_ip();
@@ -242,9 +248,11 @@ async fn run_server(
         .handle_command(NetworkCommand::Listen { addr: listen_addr })
         .await;
     let actual_addr = match reply {
-        meerkat_lib::net::NetworkReply::ListenSuccess { addr } => addr,
-        meerkat_lib::net::NetworkReply::Failure(e) => return Err(e.into()),
-        _ => return Err("Unexpected reply".into()),
+        NetworkReply::ListenSuccess { addr } => addr,
+        NetworkReply::Failure(e) => return Err(e.into()),
+        NetworkReply::MessageSent { .. } | NetworkReply::LocalAddresses { .. } => {
+            return Err("Unexpected reply".into())
+        }
     };
 
     let peer_id = net.local_peer_id();
@@ -259,15 +267,16 @@ async fn run_server(
     // Print service URLs
     for stmt in &prog {
         if let Stmt::Service { name, .. } = stmt {
-            println!("Service URL: {}/{}", full_addr, name);
+            println!("Service URL: {}/{}", full_addr, manager.interner.get(*name));
         }
     }
 
     // Register any remote services from -i flags
     for (svc_name, url) in &remote_url_map {
+        let svc_sym = manager.interner.insert(svc_name);
         manager
             .remote_services
-            .insert(svc_name.clone(), Address::new(url.as_str()));
+            .insert(svc_sym, Address::new(url.as_str()));
         println!("Remote service '{}' registered at {}", svc_name, url);
     }
 
@@ -282,10 +291,10 @@ async fn run_server(
     for stmt in &prog {
         if let Stmt::Service { name, decls } = stmt {
             manager
-                .create_service(name.clone(), decls.clone())
+                .create_service(*name, decls.clone())
                 .await
                 .map_err(|e| format!("Service error: {}", e))?;
-            println!("Service '{}' loaded", name);
+            println!("Service '{}' loaded", manager.interner.get(*name));
         }
     }
 
@@ -316,43 +325,47 @@ async fn run_server(
                     member,
                     reply_to,
                     txn_id,
-                } => match txn_id {
-                    // Transactional read: park if older than a holder.
-                    Some(tid) => {
-                        run_and_reply_or_park(
-                            &mut manager,
-                            ParkedRequest::Lookup {
-                                request_id,
-                                reply_to,
-                                service,
-                                member,
-                                tid,
-                            },
-                        )
-                        .await;
-                    }
-                    // Plain unlocked read: reply immediately.
-                    None => {
-                        let result = manager.lookup(&member, &service, None).await;
-                        let response = match result {
-                            Ok(val) => MeerkatMessage::LookupResponse {
-                                request_id,
-                                value: serde_json::to_string(&val).unwrap_or_default(),
-                            },
-                            Err(e) => MeerkatMessage::LookupError {
-                                request_id,
-                                error: e.to_string(),
-                            },
-                        };
-                        if let Some(net) = manager.network.as_mut() {
-                            net.handle_command(NetworkCommand::SendMessage {
-                                addr: Address::new(&reply_to),
-                                msg: response,
-                            })
+                } => {
+                    let svc_sym = manager.interner.insert(&service);
+                    let mem_sym = manager.interner.insert(&member);
+                    match txn_id {
+                        // Transactional read: park if older than a holder
+                        Some(tid) => {
+                            run_and_reply_or_park(
+                                &mut manager,
+                                ParkedRequest::Lookup {
+                                    request_id,
+                                    reply_to,
+                                    service: svc_sym,
+                                    member: mem_sym,
+                                    tid,
+                                },
+                            )
                             .await;
                         }
+                        // Plain unlocked read: reply immediately
+                        None => {
+                            let result = manager.lookup(mem_sym, svc_sym, None).await;
+                            let response = match result {
+                                Ok(val) => MeerkatMessage::LookupResponse {
+                                    request_id,
+                                    value: codec::encode_value(&val, &manager.interner),
+                                },
+                                Err(e) => MeerkatMessage::LookupError {
+                                    request_id,
+                                    error: e.to_string(),
+                                },
+                            };
+                            if let Some(net) = manager.network.as_mut() {
+                                net.handle_command(NetworkCommand::SendMessage {
+                                    addr: Address::new(&reply_to),
+                                    msg: response,
+                                })
+                                .await;
+                            }
+                        }
                     }
-                },
+                }
                 MeerkatMessage::ActionRequest {
                     request_id,
                     service,
@@ -360,42 +373,58 @@ async fn run_server(
                     env: action_env,
                     reply_to,
                     txn_id,
-                } => match txn_id {
-                    // Part of a distributed transaction: park if older
-                    // than a holder, otherwise reply.
-                    Some(tid) => {
-                        run_and_reply_or_park(
-                            &mut manager,
-                            ParkedRequest::Action {
-                                request_id,
-                                reply_to,
-                                service,
-                                stmts,
-                                env: action_env,
-                                tid,
-                            },
-                        )
-                        .await;
-                    }
-                    // Standalone: commit immediately and reply.
-                    None => {
-                        let result = manager
-                            .execute_action_with_env(&service, &stmts, &action_env)
-                            .await;
-                        let response = MeerkatMessage::ActionResponse {
-                            request_id,
-                            success: result.is_ok(),
-                            error: result.err().map(|e| e.to_string()),
-                        };
-                        if let Some(net) = manager.network.as_mut() {
-                            net.handle_command(NetworkCommand::SendMessage {
-                                addr: Address::new(&reply_to),
-                                msg: response,
-                            })
+                } => {
+                    let svc_sym = manager.interner.insert(&service);
+                    let local_stmts: Vec<ActionStmt> = stmts
+                        .into_iter()
+                        .map(|s| codec::decode_action_stmt(s, &mut manager.interner))
+                        .collect();
+                    let local_env: Vec<(Symbol, Value)> = action_env
+                        .into_iter()
+                        .map(|(k, v)| {
+                            (
+                                manager.interner.insert(&k),
+                                codec::decode_value(v, &mut manager.interner),
+                            )
+                        })
+                        .collect();
+                    match txn_id {
+                        // Part of a distributed transaction: park if older
+                        // than a holder, otherwise reply
+                        Some(tid) => {
+                            run_and_reply_or_park(
+                                &mut manager,
+                                ParkedRequest::Action {
+                                    request_id,
+                                    reply_to,
+                                    service: svc_sym,
+                                    stmts: local_stmts,
+                                    env: local_env,
+                                    tid,
+                                },
+                            )
                             .await;
                         }
+                        // Standalone: commit immediately and reply
+                        None => {
+                            let result = manager
+                                .execute_action_with_env(svc_sym, &local_stmts, &local_env)
+                                .await;
+                            let response = MeerkatMessage::ActionResponse {
+                                request_id,
+                                success: result.is_ok(),
+                                error: result.err().map(|e| e.to_string()),
+                            };
+                            if let Some(net) = manager.network.as_mut() {
+                                net.handle_command(NetworkCommand::SendMessage {
+                                    addr: Address::new(&reply_to),
+                                    msg: response,
+                                })
+                                .await;
+                            }
+                        }
                     }
-                },
+                }
                 MeerkatMessage::Commit {
                     request_id,
                     txn_id,
@@ -442,7 +471,17 @@ async fn run_server(
                     // abort just released.
                     wake_ready(&mut manager, freed).await;
                 }
-                _ => {}
+                MeerkatMessage::Ping { .. }
+                | MeerkatMessage::Pong { .. }
+                | MeerkatMessage::Announce { .. }
+                | MeerkatMessage::Transaction { .. }
+                | MeerkatMessage::Propagation { .. }
+                | MeerkatMessage::LookupResponse { .. }
+                | MeerkatMessage::LookupError { .. }
+                | MeerkatMessage::ActionResponse { .. }
+                | MeerkatMessage::CommitResponse { .. }
+                | MeerkatMessage::AbortResponse { .. }
+                | MeerkatMessage::WaitParked { .. } => {}
             }
         }
 
@@ -455,8 +494,9 @@ async fn run_client(
     input_file: &str,
     remote_url_map: std::collections::HashMap<String, String>,
     local: bool,
+    interner: Interner,
 ) -> Result<(), Box<dyn Error>> {
-    let mut manager = Manager::new();
+    let mut manager = Manager::new(interner);
     manager.local = local;
 
     // Start network if we have remote imports
@@ -471,7 +511,7 @@ async fn run_client(
         let reply = n
             .handle_command(NetworkCommand::Listen { addr: listen_addr })
             .await;
-        if let meerkat_lib::net::NetworkReply::ListenSuccess { addr } = reply {
+        if let NetworkReply::ListenSuccess { addr } = reply {
             let node_ip = manager.get_node_ip();
             let peer_id = n.local_peer_id();
             let addr_str = addr
@@ -495,49 +535,63 @@ async fn run_client(
 
     for stmt in &prog {
         match stmt {
-            Stmt::Service { name, decls } => {
+            &Stmt::Service { name, ref decls } => {
                 manager
-                    .create_service(name.clone(), decls.clone())
+                    .create_service(name, decls.clone())
                     .await
                     .map_err(|e| format!("Service error: {}", e))?;
-                println!("Service '{}' loaded", name);
+                println!("Service '{}' loaded", manager.interner.get(name));
             }
-            Stmt::Test { service, stmts } => {
-                manager
-                    .execute_action(service, stmts)
-                    .await
-                    .map_err(|e| format!("Test failed in '{}': {}", service, e))?;
-                println!("@test({}) passed", service);
-            }
-            Stmt::Import {
-                path,
-                service: svc_name,
+            &Stmt::Test {
+                service_name,
+                ref stmts,
             } => {
-                if let Some(url) = remote_url_map.get(svc_name) {
+                manager
+                    .execute_action(service_name, stmts)
+                    .await
+                    .map_err(|e| {
+                        format!(
+                            "Test failed in '{}': {}",
+                            manager.interner.get(service_name),
+                            e
+                        )
+                    })?;
+                println!("@test({}) passed", manager.interner.get(service_name));
+            }
+            &Stmt::Import {
+                ref path,
+                service_name,
+            } => {
+                if let Some(url) = remote_url_map.get(manager.interner.get(service_name)) {
                     manager
                         .remote_services
-                        .insert(svc_name.clone(), Address::new(url.as_str()));
-                    println!("Remote service '{}' registered at {}", svc_name, url);
+                        .insert(service_name, Address::new(url.as_str()));
+                    println!(
+                        "Remote service '{}' registered at {}",
+                        manager.interner.get(service_name),
+                        url
+                    );
                 } else {
                     let base_dir = std::path::Path::new(input_file)
                         .parent()
                         .unwrap_or(std::path::Path::new("."));
                     let import_path = base_dir.join(path);
                     let import_stmts =
-                        meerkat_lib::runtime::parser::parse_file(import_path.to_str().unwrap())
+                        parser::parse_file(import_path.to_str().unwrap(), &mut manager.interner)
                             .map_err(|e| format!("Import parse error: {}", e))?;
                     for import_stmt in &import_stmts {
-                        if let Stmt::Service { name, decls } = import_stmt {
+                        if let &Stmt::Service { name, ref decls } = import_stmt {
                             manager
-                                .create_service(name.clone(), decls.clone())
+                                .create_service(name, decls.clone())
                                 .await
                                 .map_err(|e| format!("Import service error: {}", e))?;
-                            println!("Imported service '{}'", name);
+                            println!("Imported service '{}'", manager.interner.get(name));
                         }
                     }
                 }
             }
-            _ => {}
+            &Stmt::ActionStmt(_) => {}
+            &Stmt::Update { .. } | &Stmt::Connect { .. } | &Stmt::Watch { .. } => {}
         }
     }
 

--- a/meerkat/src/main.rs
+++ b/meerkat/src/main.rs
@@ -7,7 +7,7 @@ use meerkat_lib::net::NetworkActor;
 use meerkat_lib::net::{
     codec, Address, MeerkatMessage, NetworkCommand, NetworkEvent, NetworkReply, ServiceNetId,
 };
-use meerkat_lib::runtime::ast::{ActionStmt, AstPrinter, Stmt, Value};
+use meerkat_lib::runtime::ast::{AstPrinter, Stmt};
 use meerkat_lib::runtime::interner::{Interner, Symbol};
 use meerkat_lib::runtime::interpreter::EvalError;
 use meerkat_lib::runtime::manager::ParkedRequest;
@@ -192,9 +192,15 @@ async fn run_and_reply_or_park(manager: &mut Manager, parked: ParkedRequest) {
                     );
                 }
                 Ok(val) => {
-                    let response = MeerkatMessage::LookupResponse {
-                        request_id,
-                        value: codec::encode_value(&val, &manager.interner),
+                    let response = match codec::encode_value(&val, &manager.interner) {
+                        Ok(enc_val) => MeerkatMessage::LookupResponse {
+                            request_id,
+                            value: enc_val,
+                        },
+                        Err(e) => MeerkatMessage::LookupError {
+                            request_id,
+                            error: e.to_string(),
+                        },
                     };
                     if let Some(net) = manager.network.as_mut() {
                         net.handle_command(NetworkCommand::SendMessage {
@@ -347,9 +353,15 @@ async fn run_server(
                         None => {
                             let result = manager.lookup(mem_sym, svc_sym, None).await;
                             let response = match result {
-                                Ok(val) => MeerkatMessage::LookupResponse {
-                                    request_id,
-                                    value: codec::encode_value(&val, &manager.interner),
+                                Ok(val) => match codec::encode_value(&val, &manager.interner) {
+                                    Ok(enc_val) => MeerkatMessage::LookupResponse {
+                                        request_id,
+                                        value: enc_val,
+                                    },
+                                    Err(e) => MeerkatMessage::LookupError {
+                                        request_id,
+                                        error: e.to_string(),
+                                    },
                                 },
                                 Err(e) => MeerkatMessage::LookupError {
                                     request_id,
@@ -375,19 +387,47 @@ async fn run_server(
                     txn_id,
                 } => {
                     let svc_sym = manager.interner.insert(&service);
-                    let local_stmts: Vec<ActionStmt> = stmts
-                        .into_iter()
-                        .map(|s| codec::decode_action_stmt(s, &mut manager.interner))
-                        .collect();
-                    let local_env: Vec<(Symbol, Value)> = action_env
-                        .into_iter()
-                        .map(|(k, v)| {
-                            (
-                                manager.interner.insert(&k),
-                                codec::decode_value(v, &mut manager.interner),
-                            )
-                        })
-                        .collect();
+                    let mut local_stmts = Vec::new();
+                    let mut decode_failed = false;
+                    let mut error_msg = None;
+                    for s in stmts {
+                        match codec::decode_action_stmt(s, &mut manager.interner) {
+                            Ok(ds) => local_stmts.push(ds),
+                            Err(e) => {
+                                decode_failed = true;
+                                error_msg = Some(e.to_string());
+                                break;
+                            }
+                        }
+                    }
+                    let mut local_env = Vec::new();
+                    if !decode_failed {
+                        for (k, v) in action_env {
+                            match codec::decode_value(v, &mut manager.interner) {
+                                Ok(dv) => local_env.push((manager.interner.insert(&k), dv)),
+                                Err(e) => {
+                                    decode_failed = true;
+                                    error_msg = Some(e.to_string());
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                    if decode_failed {
+                        let response = MeerkatMessage::ActionResponse {
+                            request_id,
+                            success: false,
+                            error: error_msg,
+                        };
+                        if let Some(net) = manager.network.as_mut() {
+                            net.handle_command(NetworkCommand::SendMessage {
+                                addr: Address::new(&reply_to),
+                                msg: response,
+                            })
+                            .await;
+                        }
+                        continue;
+                    }
                     match txn_id {
                         // Part of a distributed transaction: park if older
                         // than a holder, otherwise reply

--- a/meerkat/src/repl.rs
+++ b/meerkat/src/repl.rs
@@ -1,4 +1,5 @@
 use meerkat_lib::runtime::ast::{Expr, Stmt, Value};
+use meerkat_lib::runtime::interner::Symbol;
 use meerkat_lib::runtime::interpreter::{eval, execute, EvalContext, ExecuteEffect};
 use meerkat_lib::runtime::parser::ReplParseResult;
 use meerkat_lib::runtime::parser::{parse_file, parse_repl};
@@ -12,22 +13,25 @@ use std::io::{self, IsTerminal};
 const PROMPT: &str = "meerkat> ";
 const PROMPT_CONT: &str = "       > ";
 
-/// A registered watch: the original source text, the expression, and its last known value.
+/// A registered watch represented by `Watch`
+///
+/// Keeps track of the original source text, the expression, and its
+/// last known value
 struct Watch {
     label: String,
     expr: Expr,
     last: Option<Value>,
 }
 
-/// Re-evaluate all watches and print any that have changed.
-async fn check_watches(watches: &mut [Watch], manager: &mut Manager, repl_env: &[(String, Value)]) {
+/// Re-evaluate all watches and print any that have changed
+async fn check_watches(watches: &mut [Watch], manager: &mut Manager, repl_env: &[(Symbol, Value)]) {
     for w in watches.iter_mut() {
         let result = eval(
             &w.expr,
             repl_env,
             &mut EvalContext {
                 manager,
-                service_name: "",
+                service_name: Symbol::empty(),
                 txn: None,
             },
         )
@@ -48,6 +52,7 @@ async fn check_watches(watches: &mut [Watch], manager: &mut Manager, repl_env: &
     }
 }
 
+/// Run the `REPL` loop for interactive execution
 pub async fn run_repl(
     mut manager: Manager,
     remote_url_map: std::collections::HashMap<String, String>,
@@ -89,7 +94,7 @@ pub async fn run_repl(
         manager.network = Some(n);
     }
 
-    let mut repl_env: Vec<(String, Value)> = Vec::new();
+    let mut repl_env: Vec<(Symbol, Value)> = Vec::new();
     let mut watches: Vec<Watch> = Vec::new();
 
     let mut buffer = String::new();
@@ -127,7 +132,7 @@ pub async fn run_repl(
             continue;
         }
 
-        match parse_repl(&buffer) {
+        match parse_repl(&buffer, &mut manager.interner) {
             ReplParseResult::Incomplete => {
                 continuation = true;
             }
@@ -171,58 +176,64 @@ pub async fn run_repl(
     Ok(())
 }
 
+/// Execute a single statement inside the `REPL` loop
 async fn exec_stmt(
     stmt: Stmt,
     manager: &mut Manager,
-    repl_env: &mut Vec<(String, Value)>,
+    repl_env: &mut Vec<(Symbol, Value)>,
     watches: &mut Vec<Watch>,
     remote_url_map: &std::collections::HashMap<String, String>,
 ) -> Result<Option<String>, Box<dyn std::error::Error>> {
     match stmt {
         Stmt::Service { name, decls } => {
             manager
-                .create_service(name.clone(), decls)
+                .create_service(name, decls)
                 .await
-                .map_err(|e| format!("Service '{}': {}", name, e))?;
-            Ok(Some(format!("Service '{}' loaded.", name)))
+                .map_err(|e| format!("Service '{}': {}", manager.interner.get(name), e))?;
+            Ok(Some(format!(
+                "Service '{}' loaded.",
+                manager.interner.get(name)
+            )))
         }
-        Stmt::Test { service, stmts } => {
-            manager
-                .execute_action(&service, &stmts)
-                .await
-                .map_err(|e| format!("@test({}): {}", service, e))?;
-            Ok(Some(format!("@test({}) passed.", service)))
-        }
-        Stmt::Import {
-            path,
-            service: svc_name,
+        Stmt::Test {
+            service_name,
+            stmts,
         } => {
-            if let Some(url) = remote_url_map.get(&svc_name) {
-                manager.remote_services.insert(
-                    svc_name.clone(),
-                    meerkat_lib::net::Address::new(url.as_str()),
-                );
+            manager
+                .execute_action(service_name, &stmts)
+                .await
+                .map_err(|e| format!("@test({}): {}", manager.interner.get(service_name), e))?;
+            Ok(Some(format!(
+                "@test({}) passed.",
+                manager.interner.get(service_name)
+            )))
+        }
+        Stmt::Import { path, service_name } => {
+            let svc_name_str = manager.interner.get(service_name);
+            if let Some(url) = remote_url_map.get(svc_name_str) {
+                manager
+                    .remote_services
+                    .insert(service_name, meerkat_lib::net::Address::new(url.as_str()));
                 return Ok(Some(format!(
                     "Remote service '{}' registered at {}.",
-                    svc_name, url
+                    svc_name_str, url
                 )));
             }
-            let import_stmts =
-                parse_file(&path).map_err(|e| format!("Import '{}': {}", path, e))?;
+            let import_stmts = parse_file(&path, &mut manager.interner)
+                .map_err(|e| format!("Import '{}': {}", path, e))?;
             let mut loaded = Vec::new();
             for s in import_stmts {
                 if let Stmt::Service { name, decls } = s {
-                    manager
-                        .create_service(name.clone(), decls)
-                        .await
-                        .map_err(|e| format!("Imported service '{}': {}", name, e))?;
-                    loaded.push(name);
+                    manager.create_service(name, decls).await.map_err(|e| {
+                        format!("Imported service '{}': {}", manager.interner.get(name), e)
+                    })?;
+                    loaded.push(manager.interner.get(name).to_string());
                 }
             }
             Ok(Some(format!("Imported service(s): {}.", loaded.join(", "))))
         }
         Stmt::ActionStmt(action_stmt) => {
-            let effect = execute(&action_stmt, repl_env, manager, "", None)
+            let effect = execute(&action_stmt, repl_env, manager, Symbol::empty(), None)
                 .await
                 .map_err(|e| format!("{}", e))?;
             match effect {
@@ -242,7 +253,7 @@ async fn exec_stmt(
                 repl_env,
                 &mut EvalContext {
                     manager,
-                    service_name: "",
+                    service_name: Symbol::empty(),
                     txn: None,
                 },
             )
@@ -259,9 +270,7 @@ async fn exec_stmt(
             });
             Ok(Some(msg))
         }
-        other => Ok(Some(format!(
-            "(not yet supported in REPL: {:?})",
-            std::mem::discriminant(&other)
-        ))),
+        Stmt::Update { .. } => Ok(Some("(not yet supported in REPL: Update)".to_string())),
+        Stmt::Connect { .. } => Ok(Some("(not yet supported in REPL: Connect)".to_string())),
     }
 }


### PR DESCRIPTION
Integrates a new string interning system across the entire codebase, replacing Rust `String` with a lightweight `Symbol` for identifiers.

By interning service, variable, table, and field names, we significantly reduce memory overhead, eliminate pointer indirection, and lay the foundation for future name resolution and type checking passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a network AST + codec layer to serialize/deserialize runtime values and statements across the wire.
* **Improvements**
  * Introduced identifier interning with a shared interner, updating parsing, evaluation, execution, and AST printing to use symbols.
  * Migrated distributed addressing to globally unique network identifiers.
  * Enforced identifier and string-literal length limits at network codec boundaries and improved related error messages.
* **Tests**
  * Added/updated coverage for symbol formatting, interning behavior, parsing with interner, and updated transaction/queue keying.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->