### PR TITLE
feat: Initialize services in `create_service` with a single transaction

### DIFF
--- a/meerkat-lib/src/runtime/manager/mod.rs
+++ b/meerkat-lib/src/runtime/manager/mod.rs
@@ -2336,7 +2336,7 @@ mod tests {
                 is_pub: true,
             },
         ];
-        tc.manager.create_service(tc.f, decls).await.unwrap();
+        tc.manager.create_service(tc.foo, decls).await.unwrap();
 
         let foo = tc.manager.services.get(&tc.foo).unwrap();
         let tid = foo.vars.get(&tc.x).unwrap().latest_write_txn.clone();

--- a/meerkat-lib/src/runtime/manager/mod.rs
+++ b/meerkat-lib/src/runtime/manager/mod.rs
@@ -231,35 +231,50 @@ impl Manager {
         let mut env: Vec<(Symbol, Value)> = vec![];
         let svc_name = name;
 
+        let mut txn = Transaction::new(TxnId::new(self.node_id));
+        let mut init_error = None;
+
         for decl in decls {
             match decl {
                 Decl::VarDecl { name, val } => {
-                    let value = eval(
+                    let value = match eval(
                         &val,
                         &env,
                         &mut EvalContext {
                             manager: self,
                             service_name: svc_name,
-                            txn: None,
+                            txn: Some(&mut txn),
                         },
                     )
-                    .await?;
+                    .await {
+                        Ok(v) => v,
+                        Err(e) => {
+                            init_error = Some(e);
+                            break;
+                        }
+                    };
                     env.push((name, value.clone()));
                     if let Some(service) = self.services.get_mut(&svc_name) {
                         service.vars.insert(name, VarState::new(value));
                     }
                 }
                 Decl::DefDecl { name, val, .. } => {
-                    let value = eval(
+                    let value = match eval(
                         &val,
                         &env,
                         &mut EvalContext {
                             manager: self,
                             service_name: svc_name,
-                            txn: None,
+                            txn: Some(&mut txn),
                         },
                     )
-                    .await?;
+                    .await {
+                            Ok(v) => v,
+                        Err(e) => {
+                            init_error = Some(e);
+                            break;
+                        }
+                    };
                     env.push((name, value.clone()));
                     if let Some(service) = self.services.get_mut(&svc_name) {
                         service.vars.insert(name, VarState::new(value));
@@ -267,12 +282,37 @@ impl Manager {
                     }
                 }
                 Decl::TableDecl { .. } => {
-                    return Err(EvalError::NotImplemented);
+                    // we still need to release locks, so no longer return directly after 
+                    // encountering a TableDecl
+                    init_error = Some(EvalError::NotImplemented);
+                    break;
                 }
             }
+        };
+
+        // code for handling transaction errors copied over from execute_action_with_txn
+
+
+        if init_error.is_none() {
+            self.apply_committed_writes(&txn).await;
+            for addr in txn.participants.iter().cloned().collect::<Vec<_>>() {
+                let _ = self.send_commit(addr, &txn.id).await;
+            }
+        } else {
+            // Execution failed: discard buffered writes and abort participants.
+            for addr in txn.participants.iter().cloned().collect::<Vec<_>>() {
+                self.send_abort(addr, &txn.id).await;
+            }
+            self.services.remove(&svc_name);
         }
 
-        Ok(())
+        // Release all locks held locally (always, even on error)
+        self.release_locks(&txn.locked, &txn.id);
+
+        match init_error {
+            Some(e) => Err(e),
+            None => Ok(()),
+        }
     }
 
     /// Lookup a variable or def's value within a service

--- a/meerkat-lib/src/runtime/manager/mod.rs
+++ b/meerkat-lib/src/runtime/manager/mod.rs
@@ -246,7 +246,8 @@ impl Manager {
                             txn: Some(&mut txn),
                         },
                     )
-                    .await {
+                    .await
+                    {
                         Ok(v) => v,
                         Err(e) => {
                             init_error = Some(e);
@@ -270,8 +271,9 @@ impl Manager {
                             txn: Some(&mut txn),
                         },
                     )
-                    .await {
-                            Ok(v) => v,
+                    .await
+                    {
+                        Ok(v) => v,
                         Err(e) => {
                             init_error = Some(e);
                             break;
@@ -286,16 +288,15 @@ impl Manager {
                     }
                 }
                 Decl::TableDecl { .. } => {
-                    // we still need to release locks, so no longer return directly after 
+                    // we still need to release locks, so no longer return directly after
                     // encountering a TableDecl
                     init_error = Some(EvalError::NotImplemented);
                     break;
                 }
             }
-        };
+        }
 
         // code for handling transaction errors copied over from execute_action_with_txn
-
 
         if init_error.is_none() {
             self.apply_committed_writes(&txn).await;
@@ -2307,84 +2308,133 @@ mod tests {
         assert!(tc.manager.pending_txns.contains_key(&older));
     }
     #[tokio::test]
-  async fn test_create_service_uses_single_transaction() {
-      let mut manager = Manager::new();
-      let decls = vec![
-          Decl::VarDecl { name: "x".into(), val: Expr::Literal { val: Value::Number { val: 1 } } },
-          Decl::VarDecl { name: "y".into(), val: Expr::Literal { val: Value::Number { val: 2 } } },
-          Decl::DefDecl {
-              name: "f".into(),
-              val: Expr::Binop {
-                  op: crate::ast::BinOp::Add,
-                  expr1: Box::new(Expr::Variable { ident: "x".into() }),
-                  expr2: Box::new(Expr::Variable { ident: "y".into() }),
-              },
-              is_pub: true,
-          },
-      ];
-      manager.create_service("foo".into(), decls).await.unwrap();
+    async fn test_create_service_uses_single_transaction() {
+        let mut manager = Manager::new();
+        let decls = vec![
+            Decl::VarDecl {
+                name: "x".into(),
+                val: Expr::Literal {
+                    val: Value::Number { val: 1 },
+                },
+            },
+            Decl::VarDecl {
+                name: "y".into(),
+                val: Expr::Literal {
+                    val: Value::Number { val: 2 },
+                },
+            },
+            Decl::DefDecl {
+                name: "f".into(),
+                val: Expr::Binop {
+                    op: crate::ast::BinOp::Add,
+                    expr1: Box::new(Expr::Variable { ident: "x".into() }),
+                    expr2: Box::new(Expr::Variable { ident: "y".into() }),
+                },
+                is_pub: true,
+            },
+        ];
+        manager.create_service("foo".into(), decls).await.unwrap();
 
-      let foo = manager.services.get("foo").unwrap();
-      let tid = foo.vars.get("x").unwrap().latest_write_txn.clone();
-      assert!(tid.is_some(), "init writes must record a writer txn from create_service");
-      // every var/def initialized by the same transaction
-      assert_eq!(foo.vars.get("y").unwrap().latest_write_txn, tid);
-      assert_eq!(foo.vars.get("f").unwrap().latest_write_txn, tid);
-  }
+        let foo = manager.services.get("foo").unwrap();
+        let tid = foo.vars.get("x").unwrap().latest_write_txn.clone();
+        assert!(
+            tid.is_some(),
+            "init writes must record a writer txn from create_service"
+        );
+        // every var/def initialized by the same transaction
+        assert_eq!(foo.vars.get("y").unwrap().latest_write_txn, tid);
+        assert_eq!(foo.vars.get("f").unwrap().latest_write_txn, tid);
+    }
 
-  #[tokio::test]
-  async fn test_create_service_rolls_back_on_partial_failure() {
-      let mut manager = Manager::new();
-      let decls = vec![
-          Decl::VarDecl {
-              name: "x".to_string(),
-              val: Expr::Literal { val: Value::Number { val: 1 } },
-          },
-          // adding a bool and number should be a type error
-          Decl::VarDecl {
-              name: "y".to_string(),
-              val: Expr::Binop {
-                  op: crate::ast::BinOp::Add,
-                  expr1: Box::new(Expr::Literal { val: Value::Bool { val: true } }),
-                  expr2: Box::new(Expr::Literal { val: Value::Number { val: 1 } }),
-              },
-          },
-      ];
-      let result = manager.create_service("foo".into(), decls).await;
-      assert!(result.is_err());
-      assert!(manager.services.is_empty(), "no services should've been created");
-  }
-
-
-  // full disclosure: I'm not sure how to test that create_service actually occurs under a single transaction
-  // in the sense that a lock is truly acquired, so I had Claude write a test for me
     #[tokio::test]
-  async fn test_create_service_read_conflicts_under_one_txn() {
-      let mut manager = Manager::new();
-      manager.create_service("s1".into(), vec![
-          Decl::VarDecl { name: "x".into(), val: Expr::Literal { val: Value::Number { val: 7 } } },
-      ]).await.unwrap();
+    async fn test_create_service_rolls_back_on_partial_failure() {
+        let mut manager = Manager::new();
+        let decls = vec![
+            Decl::VarDecl {
+                name: "x".to_string(),
+                val: Expr::Literal {
+                    val: Value::Number { val: 1 },
+                },
+            },
+            // adding a bool and number should be a type error
+            Decl::VarDecl {
+                name: "y".to_string(),
+                val: Expr::Binop {
+                    op: crate::ast::BinOp::Add,
+                    expr1: Box::new(Expr::Literal {
+                        val: Value::Bool { val: true },
+                    }),
+                    expr2: Box::new(Expr::Literal {
+                        val: Value::Number { val: 1 },
+                    }),
+                },
+            },
+        ];
+        let result = manager.create_service("foo".into(), decls).await;
+        assert!(result.is_err());
+        assert!(
+            manager.services.is_empty(),
+            "no services should've been created"
+        );
+    }
 
-      // Simulate another in-flight transaction holding a write lock on s1.x.
-      let ext = TxnId::new(manager.node_id);
-      assert!(manager.services.get_mut("s1").unwrap()
-          .vars.get_mut("x").unwrap().lock.try_write(&ext));
+    // full disclosure: I'm not sure how to test that create_service actually occurs under a single transaction
+    // in the sense that a lock is truly acquired, so I had Claude write a test for me
+    #[tokio::test]
+    async fn test_create_service_read_conflicts_under_one_txn() {
+        let mut manager = Manager::new();
+        manager
+            .create_service(
+                "s1".into(),
+                vec![Decl::VarDecl {
+                    name: "x".into(),
+                    val: Expr::Literal {
+                        val: Value::Number { val: 7 },
+                    },
+                }],
+            )
+            .await
+            .unwrap();
 
-      // s2's init reads s1.x; under a real transaction this must fail to read-lock.
-      let result = manager.create_service("s2".into(), vec![
-          Decl::DefDecl {
-              name: "f".into(),
-              val: Expr::MemberAccess { service: "s1".into(), member: "x".into() },
-              is_pub: true,
-          },
-      ]).await;
+        // Simulate another in-flight transaction holding a write lock on s1.x.
+        let ext = TxnId::new(manager.node_id);
+        assert!(manager
+            .services
+            .get_mut("s1")
+            .unwrap()
+            .vars
+            .get_mut("x")
+            .unwrap()
+            .lock
+            .try_write(&ext));
 
-      assert!(matches!(result, Err(EvalError::LockConflict(_))), "init read must respect the lock");
-      assert!(manager.services.get("s2").is_none(), "failed init rolls back");
-      // the foreign lock is untouched
-      assert!(matches!(
-          manager.services.get("s1").unwrap().vars.get("x").unwrap().lock,
-          crate::runtime::txn::VarLock::WriteLocked(ref t) if *t == ext
-      ));
-  }
+        // s2's init reads s1.x; under a real transaction this must fail to read-lock.
+        let result = manager
+            .create_service(
+                "s2".into(),
+                vec![Decl::DefDecl {
+                    name: "f".into(),
+                    val: Expr::MemberAccess {
+                        service: "s1".into(),
+                        member: "x".into(),
+                    },
+                    is_pub: true,
+                }],
+            )
+            .await;
+
+        assert!(
+            matches!(result, Err(EvalError::LockConflict(_))),
+            "init read must respect the lock"
+        );
+        assert!(
+            manager.services.get("s2").is_none(),
+            "failed init rolls back"
+        );
+        // the foreign lock is untouched
+        assert!(matches!(
+            manager.services.get("s1").unwrap().vars.get("x").unwrap().lock,
+            crate::runtime::txn::VarLock::WriteLocked(ref t) if *t == ext
+        ));
+    }
 }

--- a/meerkat-lib/src/runtime/manager/mod.rs
+++ b/meerkat-lib/src/runtime/manager/mod.rs
@@ -2312,56 +2312,56 @@ mod tests {
     }
     #[tokio::test]
     async fn test_create_service_uses_single_transaction() {
-        let mut manager = Manager::new();
+        let mut tc = TestContext::new();
         let decls = vec![
             Decl::VarDecl {
-                name: "x".into(),
+                name: tc.x,
                 val: Expr::Literal {
                     val: Value::Number { val: 1 },
                 },
             },
             Decl::VarDecl {
-                name: "y".into(),
+                name: tc.y,
                 val: Expr::Literal {
                     val: Value::Number { val: 2 },
                 },
             },
             Decl::DefDecl {
-                name: "f".into(),
+                name: tc.f,
                 val: Expr::Binop {
                     op: crate::ast::BinOp::Add,
-                    expr1: Box::new(Expr::Variable { ident: "x".into() }),
-                    expr2: Box::new(Expr::Variable { ident: "y".into() }),
+                    expr1: Box::new(Expr::Variable { name: tc.x }),
+                    expr2: Box::new(Expr::Variable { name: tc.y }),
                 },
                 is_pub: true,
             },
         ];
-        manager.create_service("foo".into(), decls).await.unwrap();
+        tc.manager.create_service(tc.f, decls).await.unwrap();
 
-        let foo = manager.services.get("foo").unwrap();
-        let tid = foo.vars.get("x").unwrap().latest_write_txn.clone();
+        let foo = tc.manager.services.get(&tc.foo).unwrap();
+        let tid = foo.vars.get(&tc.x).unwrap().latest_write_txn.clone();
         assert!(
             tid.is_some(),
             "init writes must record a writer txn from create_service"
         );
         // every var/def initialized by the same transaction
-        assert_eq!(foo.vars.get("y").unwrap().latest_write_txn, tid);
-        assert_eq!(foo.vars.get("f").unwrap().latest_write_txn, tid);
+        assert_eq!(foo.vars.get(&tc.y).unwrap().latest_write_txn, tid);
+        assert_eq!(foo.vars.get(&tc.f).unwrap().latest_write_txn, tid);
     }
 
     #[tokio::test]
     async fn test_create_service_rolls_back_on_partial_failure() {
-        let mut manager = Manager::new();
+        let mut tc = TestContext::new();
         let decls = vec![
             Decl::VarDecl {
-                name: "x".to_string(),
+                name: tc.x,
                 val: Expr::Literal {
                     val: Value::Number { val: 1 },
                 },
             },
             // adding a bool and number should be a type error
             Decl::VarDecl {
-                name: "y".to_string(),
+                name: tc.y,
                 val: Expr::Binop {
                     op: crate::ast::BinOp::Add,
                     expr1: Box::new(Expr::Literal {
@@ -2373,10 +2373,10 @@ mod tests {
                 },
             },
         ];
-        let result = manager.create_service("foo".into(), decls).await;
+        let result = tc.manager.create_service(tc.foo, decls).await;
         assert!(result.is_err());
         assert!(
-            manager.services.is_empty(),
+            tc.manager.services.is_empty(),
             "no services should've been created"
         );
     }
@@ -2385,12 +2385,12 @@ mod tests {
     // in the sense that a lock is truly acquired, so I had Claude write a test for me
     #[tokio::test]
     async fn test_create_service_read_conflicts_under_one_txn() {
-        let mut manager = Manager::new();
-        manager
+        let mut tc = TestContext::new();
+        tc.manager
             .create_service(
-                "s1".into(),
+                tc.s1,
                 vec![Decl::VarDecl {
-                    name: "x".into(),
+                    name: tc.x,
                     val: Expr::Literal {
                         val: Value::Number { val: 7 },
                     },
@@ -2400,26 +2400,28 @@ mod tests {
             .unwrap();
 
         // Simulate another in-flight transaction holding a write lock on s1.x.
-        let ext = TxnId::new(manager.node_id);
-        assert!(manager
+        let ext = TxnId::new(tc.manager.node_id);
+        assert!(tc
+            .manager
             .services
-            .get_mut("s1")
+            .get_mut(&tc.s1)
             .unwrap()
             .vars
-            .get_mut("x")
+            .get_mut(&tc.x)
             .unwrap()
             .lock
             .try_write(&ext));
 
         // s2's init reads s1.x; under a real transaction this must fail to read-lock.
-        let result = manager
+        let result = tc
+            .manager
             .create_service(
-                "s2".into(),
+                tc.s2,
                 vec![Decl::DefDecl {
-                    name: "f".into(),
+                    name: tc.f,
                     val: Expr::MemberAccess {
-                        service: "s1".into(),
-                        member: "x".into(),
+                        service_name: tc.s1,
+                        member_name: tc.x,
                     },
                     is_pub: true,
                 }],
@@ -2431,12 +2433,12 @@ mod tests {
             "init read must respect the lock"
         );
         assert!(
-            !manager.services.contains_key("s2"),
+            !tc.manager.services.contains_key(&tc.s2),
             "failed init rolls back"
         );
         // the foreign lock is untouched
         assert!(matches!(
-            manager.services.get("s1").unwrap().vars.get("x").unwrap().lock,
+            tc.manager.services.get(&tc.s1).unwrap().vars.get(&tc.x).unwrap().lock,
             crate::runtime::txn::VarLock::WriteLocked(ref t) if *t == ext
         ));
     }

--- a/meerkat-lib/src/runtime/manager/mod.rs
+++ b/meerkat-lib/src/runtime/manager/mod.rs
@@ -1795,6 +1795,7 @@ mod tests {
         // If a transaction fails after a read, its read lock must still
         // be released
         let mut tc = manager_with_x().await;
+        let last_txn = x_state(&tc).latest_write_txn.clone();
         let stmts = vec![ActionStmt::Assert(
             Expr::Variable { name: tc.x },
             "x".to_string(),
@@ -1805,7 +1806,7 @@ mod tests {
         assert!(result.is_err());
         assert_eq!(x_state(&tc).value, Value::Number { val: 0 });
         // this is probably wrong? since the initialization of the manager should have involved a txn
-        assert!(x_state(&tc).latest_write_txn.is_none());
+        assert_eq!(x_state(&tc).latest_write_txn, last_txn);
         assert_x_unlocked(&tc);
     }
 

--- a/meerkat-lib/src/runtime/manager/mod.rs
+++ b/meerkat-lib/src/runtime/manager/mod.rs
@@ -255,7 +255,9 @@ impl Manager {
                     };
                     env.push((name, value.clone()));
                     if let Some(service) = self.services.get_mut(&svc_name) {
-                        service.vars.insert(name, VarState::new(value));
+                        let mut var_value = VarState::new(value);
+                        var_value.latest_write_txn = Some(txn.id.clone());
+                        service.vars.insert(name, var_value);
                     }
                 }
                 Decl::DefDecl { name, val, .. } => {
@@ -277,7 +279,9 @@ impl Manager {
                     };
                     env.push((name, value.clone()));
                     if let Some(service) = self.services.get_mut(&svc_name) {
-                        service.vars.insert(name, VarState::new(value));
+                        let mut var_value = VarState::new(value);
+                        var_value.latest_write_txn = Some(txn.id.clone());
+                        service.vars.insert(name, var_value);
                         service.defs.insert(name, val); // store original expr
                     }
                 }
@@ -1799,6 +1803,7 @@ mod tests {
 
         assert!(result.is_err());
         assert_eq!(x_state(&tc).value, Value::Number { val: 0 });
+        // this is probably wrong? since the initialization of the manager should have involved a txn
         assert!(x_state(&tc).latest_write_txn.is_none());
         assert_x_unlocked(&tc);
     }
@@ -2301,4 +2306,85 @@ mod tests {
         ));
         assert!(tc.manager.pending_txns.contains_key(&older));
     }
+    #[tokio::test]
+  async fn test_create_service_uses_single_transaction() {
+      let mut manager = Manager::new();
+      let decls = vec![
+          Decl::VarDecl { name: "x".into(), val: Expr::Literal { val: Value::Number { val: 1 } } },
+          Decl::VarDecl { name: "y".into(), val: Expr::Literal { val: Value::Number { val: 2 } } },
+          Decl::DefDecl {
+              name: "f".into(),
+              val: Expr::Binop {
+                  op: crate::ast::BinOp::Add,
+                  expr1: Box::new(Expr::Variable { ident: "x".into() }),
+                  expr2: Box::new(Expr::Variable { ident: "y".into() }),
+              },
+              is_pub: true,
+          },
+      ];
+      manager.create_service("foo".into(), decls).await.unwrap();
+
+      let foo = manager.services.get("foo").unwrap();
+      let tid = foo.vars.get("x").unwrap().latest_write_txn.clone();
+      assert!(tid.is_some(), "init writes must record a writer txn from create_service");
+      // every var/def initialized by the same transaction
+      assert_eq!(foo.vars.get("y").unwrap().latest_write_txn, tid);
+      assert_eq!(foo.vars.get("f").unwrap().latest_write_txn, tid);
+  }
+
+  #[tokio::test]
+  async fn test_create_service_rolls_back_on_partial_failure() {
+      let mut manager = Manager::new();
+      let decls = vec![
+          Decl::VarDecl {
+              name: "x".to_string(),
+              val: Expr::Literal { val: Value::Number { val: 1 } },
+          },
+          // adding a bool and number should be a type error
+          Decl::VarDecl {
+              name: "y".to_string(),
+              val: Expr::Binop {
+                  op: crate::ast::BinOp::Add,
+                  expr1: Box::new(Expr::Literal { val: Value::Bool { val: true } }),
+                  expr2: Box::new(Expr::Literal { val: Value::Number { val: 1 } }),
+              },
+          },
+      ];
+      let result = manager.create_service("foo".into(), decls).await;
+      assert!(result.is_err());
+      assert!(manager.services.is_empty(), "no services should've been created");
+  }
+
+
+  // full disclosure: I'm not sure how to test that create_service actually occurs under a single transaction
+  // in the sense that a lock is truly acquired, so I had Claude write a test for me
+    #[tokio::test]
+  async fn test_create_service_read_conflicts_under_one_txn() {
+      let mut manager = Manager::new();
+      manager.create_service("s1".into(), vec![
+          Decl::VarDecl { name: "x".into(), val: Expr::Literal { val: Value::Number { val: 7 } } },
+      ]).await.unwrap();
+
+      // Simulate another in-flight transaction holding a write lock on s1.x.
+      let ext = TxnId::new(manager.node_id);
+      assert!(manager.services.get_mut("s1").unwrap()
+          .vars.get_mut("x").unwrap().lock.try_write(&ext));
+
+      // s2's init reads s1.x; under a real transaction this must fail to read-lock.
+      let result = manager.create_service("s2".into(), vec![
+          Decl::DefDecl {
+              name: "f".into(),
+              val: Expr::MemberAccess { service: "s1".into(), member: "x".into() },
+              is_pub: true,
+          },
+      ]).await;
+
+      assert!(matches!(result, Err(EvalError::LockConflict(_))), "init read must respect the lock");
+      assert!(manager.services.get("s2").is_none(), "failed init rolls back");
+      // the foreign lock is untouched
+      assert!(matches!(
+          manager.services.get("s1").unwrap().vars.get("x").unwrap().lock,
+          crate::runtime::txn::VarLock::WriteLocked(ref t) if *t == ext
+      ));
+  }
 }

--- a/meerkat-lib/src/runtime/manager/mod.rs
+++ b/meerkat-lib/src/runtime/manager/mod.rs
@@ -2424,7 +2424,7 @@ mod tests {
             .await;
 
         assert!(
-            matches!(result, Err(EvalError::LockConflict(_))),
+            matches!(result, Err(EvalError::WaitDieAbort(_))),
             "init read must respect the lock"
         );
         assert!(

--- a/meerkat-lib/src/runtime/manager/mod.rs
+++ b/meerkat-lib/src/runtime/manager/mod.rs
@@ -1805,7 +1805,9 @@ mod tests {
 
         assert!(result.is_err());
         assert_eq!(x_state(&tc).value, Value::Number { val: 0 });
-        // this is probably wrong? since the initialization of the manager should have involved a txn
+        // NOTE: changed this test case to check that the latest_write_txn is the txn that created
+        // the service and not none (as it was previously). Since this is changing a test case,
+        // please make sure to review it
         assert_eq!(x_state(&tc).latest_write_txn, last_txn);
         assert_x_unlocked(&tc);
     }

--- a/meerkat-lib/src/runtime/manager/mod.rs
+++ b/meerkat-lib/src/runtime/manager/mod.rs
@@ -2413,6 +2413,7 @@ mod tests {
             .try_write(&ext));
 
         // s2's init reads s1.x; under a real transaction this must fail to read-lock.
+        // since s2 is younger, it should die instead of waiting
         let result = tc
             .manager
             .create_service(

--- a/meerkat-lib/src/runtime/manager/mod.rs
+++ b/meerkat-lib/src/runtime/manager/mod.rs
@@ -2428,7 +2428,7 @@ mod tests {
             "init read must respect the lock"
         );
         assert!(
-            manager.services.get("s2").is_none(),
+            !manager.services.contains_key("s2"),
             "failed init rolls back"
         );
         // the foreign lock is untouched


### PR DESCRIPTION
### Description
Previously, service initialization in `create_service` was done entirely without the use of transactions. Presumably this could lead to race conditions and other concurrency bugs if multiple nodes tried to create a service at the same time, as stated by issue #45. This PR implements that.

### Changes
- Add a transaction to `create_service`
- `eval` within `create_service` now uses that transaction
- Add error handling for transaction failures along the pattern of `execute_action_with_txn`
- Add code to acquire/release locks
- Make it so `latest_write_txn` records the transaction of `create_service`
- Add some test cases

### Additional Info/Notes for review
To be quite honest I think I still don't fully understand the transaction model and codebase. That said, there are a few things that stand out to me as suspicious.
- On lines 242 and 246, I'm not sure if it's still correct to just push the variable value directly onto the environment and the service.vars, or if this also needs to go behind a transaction somehow for concurrency purposes. There's also a symmetric case for this for definitions.
- in the test case `test_txn_read_lock_released_after_failure`, there's an assertion that the `latest_write_txn` `is_none()`. I suspect that, since we now have `create_service` use a txn, this should be updated to check that the latest txn is the same as the one used by `create_service`. This currently produces a test case failure, so I'd greatly appreciate knowing if the test case is wrong or if I'm wrong.
- Speaking of test cases, I'm honestly not sure how to test that the transaction does what is advertised (i.e. it makes it so service initialization is fully atomic). To be completely honest I let Claude write the test cases, and I believe the last test case it wrote, `test_create_service_read_conflicts_under_one_txn`, tries to test this. However, I don't fully understand the concurrency stuff, so I'm not sure if this test case is robust and actually tests this behavior. (The other two test cases in this PR were also written by Claude, but at least for those I've gone through them fully and convinced myself that they are robust and test what they claim to test. This is very much not the case for the last test case). 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved service initialization so all variable/definition initializers run under a single shared transaction for atomic behavior.
  * Initialization errors now trigger a clean abort/rollback flow (best-effort abort, remove partially created service), while successful initialization commits and records the same transaction consistently.
  * Initialization locks are now released reliably after either success or failure.

* **Tests**
  * Updated and added coverage for transactional initialization behavior, rollback correctness, service removal on partial failures, and lock-conflict handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->