### PR TITLE
feat: stringify meerkat assertions in ast

### DIFF
--- a/meerkat-lib/src/net/ast.rs
+++ b/meerkat-lib/src/net/ast.rs
@@ -23,7 +23,10 @@ pub enum NetActionStmt {
     /// A `do` statement to evaluate an expression for side effects
     Do(NetExpr),
     /// An `assert` statement to check invariants
-    Assert(NetExpr),
+    ///
+    /// The `String` parameter captures the exact raw source
+    /// string of the assertion condition for error reporting
+    Assert(NetExpr, String),
     /// Re-assign a value to an existing variable
     Assign { name: String, expr: NetExpr },
     /// Insert a record into a table

--- a/meerkat-lib/src/net/codec.rs
+++ b/meerkat-lib/src/net/codec.rs
@@ -1105,7 +1105,15 @@ mod tests {
         let encoded = encode_action_stmt(&stmt, &interner).unwrap();
         let mut interner_new = Interner::new();
         let decoded = decode_action_stmt(encoded, &mut interner_new).unwrap();
-        assert_eq!(format!("{}", stmt), format!("{}", decoded));
+        match decoded {
+            ActionStmt::Assert(
+                Expr::Literal {
+                    val: Value::Bool { val: false },
+                },
+                text,
+            ) => assert_eq!(text, "x == 5"),
+            other => panic!("unexpected decoded stmt: {:?}", other),
+        }
     }
 
     /// Verify decoding an assertion with oversized text fails

--- a/meerkat-lib/src/net/codec.rs
+++ b/meerkat-lib/src/net/codec.rs
@@ -465,7 +465,13 @@ pub fn encode_action_stmt(stmt: &ActionStmt, interner: &Interner) -> Result<NetA
         }
         ActionStmt::Expr(expr) => Ok(NetActionStmt::Expr(encode_expr(expr, interner)?)),
         ActionStmt::Do(expr) => Ok(NetActionStmt::Do(encode_expr(expr, interner)?)),
-        ActionStmt::Assert(expr) => Ok(NetActionStmt::Assert(encode_expr(expr, interner)?)),
+        ActionStmt::Assert(expr, text) => {
+            validate_string_literal(text)?;
+            Ok(NetActionStmt::Assert(
+                encode_expr(expr, interner)?,
+                text.clone(),
+            ))
+        }
         ActionStmt::Assign { name, expr } => {
             let name_str = interner.get(*name);
             validate_identifier(name_str)?;
@@ -504,7 +510,10 @@ pub fn decode_action_stmt(stmt: NetActionStmt, interner: &mut Interner) -> Resul
         }
         NetActionStmt::Expr(expr) => Ok(ActionStmt::Expr(decode_expr(expr, interner)?)),
         NetActionStmt::Do(expr) => Ok(ActionStmt::Do(decode_expr(expr, interner)?)),
-        NetActionStmt::Assert(expr) => Ok(ActionStmt::Assert(decode_expr(expr, interner)?)),
+        NetActionStmt::Assert(expr, text) => {
+            validate_string_literal(&text)?;
+            Ok(ActionStmt::Assert(decode_expr(expr, interner)?, text))
+        }
         NetActionStmt::Assign { name, expr } => {
             validate_identifier(&name)?;
             Ok(ActionStmt::Assign {
@@ -975,9 +984,12 @@ mod tests {
 
         // 3. Assert
         let interner = Interner::new();
-        let stmt_assert = ActionStmt::Assert(Expr::Literal {
-            val: Value::Bool { val: true },
-        });
+        let stmt_assert = ActionStmt::Assert(
+            Expr::Literal {
+                val: Value::Bool { val: true },
+            },
+            "true".to_string(),
+        );
         run_stmt_test(&stmt_assert, &interner);
 
         // 4. Assign
@@ -1075,6 +1087,39 @@ mod tests {
         let val = Value::String { val: long_str };
         let interner = Interner::new();
         let res = encode_value(&val, &interner);
+        assert!(res.is_err());
+        assert!(matches!(res.unwrap_err(), Error::LimitExceeded(_)));
+    }
+
+    /// Verify round-trip encoding and decoding for
+    /// assertion statement
+    #[test]
+    fn test_codec_assert_roundtrip() {
+        let interner = Interner::new();
+        let stmt = ActionStmt::Assert(
+            Expr::Literal {
+                val: Value::Bool { val: false },
+            },
+            "x == 5".to_string(),
+        );
+        let encoded = encode_action_stmt(&stmt, &interner).unwrap();
+        let mut interner_new = Interner::new();
+        let decoded = decode_action_stmt(encoded, &mut interner_new).unwrap();
+        assert_eq!(format!("{}", stmt), format!("{}", decoded));
+    }
+
+    /// Verify decoding an assertion with oversized text fails
+    #[test]
+    fn test_codec_decode_oversized_assert() {
+        let long_str = "a".repeat(MAX_STRING_LITERAL_LENGTH + 1);
+        let net_stmt = NetActionStmt::Assert(
+            NetExpr::Literal {
+                val: NetValue::Bool { val: false },
+            },
+            long_str,
+        );
+        let mut interner = Interner::new();
+        let res = decode_action_stmt(net_stmt, &mut interner);
         assert!(res.is_err());
         assert!(matches!(res.unwrap_err(), Error::LimitExceeded(_)));
     }

--- a/meerkat-lib/src/runtime/ast/mod.rs
+++ b/meerkat-lib/src/runtime/ast/mod.rs
@@ -27,12 +27,25 @@ pub enum BinOp {
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum ActionStmt {
-    Let { name: Symbol, expr: Expr },
+    Let {
+        name: Symbol,
+        expr: Expr,
+    },
     Expr(Expr),
     Do(Expr),
-    Assert(Expr),
-    Assign { name: Symbol, expr: Expr },
-    Insert { row: Expr, table_name: Symbol },
+    /// An `assert` statement to check invariants
+    ///
+    /// The `String` parameter captures the exact raw source
+    /// string of the assertion condition for error reporting
+    Assert(Expr, String),
+    Assign {
+        name: Symbol,
+        expr: Expr,
+    },
+    Insert {
+        row: Expr,
+        table_name: Symbol,
+    },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -356,7 +369,7 @@ impl Display for ActionStmt {
             ActionStmt::Let { name, expr } => write!(f, "let {} = {}", name, expr),
             ActionStmt::Expr(expr) => write!(f, "{}", expr),
             ActionStmt::Do(expr) => write!(f, "do {}", expr),
-            ActionStmt::Assert(expr) => write!(f, "assert {}", expr),
+            ActionStmt::Assert(expr, _) => write!(f, "assert {}", expr),
             ActionStmt::Assign { name, expr } => write!(f, "{} = {}", name, expr),
             ActionStmt::Insert { row, table_name } => {
                 write!(f, "insert into {} {}", table_name, row)

--- a/meerkat-lib/src/runtime/ast/printer.rs
+++ b/meerkat-lib/src/runtime/ast/printer.rs
@@ -167,8 +167,8 @@ impl<'a> AstPrinter<'a> {
                 println!("Do:");
                 self.print_expr(expr, indent + 1);
             }
-            ActionStmt::Assert(expr) => {
-                println!("Assert:");
+            ActionStmt::Assert(expr, text) => {
+                println!("Assert: {{ text: \"{}\" }}", text);
                 self.print_expr(expr, indent + 1);
             }
             ActionStmt::Assign { name, expr } => {

--- a/meerkat-lib/src/runtime/ast/printer.rs
+++ b/meerkat-lib/src/runtime/ast/printer.rs
@@ -168,7 +168,7 @@ impl<'a> AstPrinter<'a> {
                 self.print_expr(expr, indent + 1);
             }
             ActionStmt::Assert(expr, text) => {
-                println!("Assert: {{ text: \"{}\" }}", text);
+                println!("Assert: {{ text: {:?} }}", text);
                 self.print_expr(expr, indent + 1);
             }
             ActionStmt::Assign { name, expr } => {

--- a/meerkat-lib/src/runtime/interpreter/evaluator.rs
+++ b/meerkat-lib/src/runtime/interpreter/evaluator.rs
@@ -14,6 +14,7 @@ pub enum EvalError {
     NotImplemented,
     WaitDieAbort(String),
     WaitOn(Symbol, Symbol),
+    AssertionError(String),
 }
 
 /// Implement the `Display` trait for the `EvalError` type
@@ -39,6 +40,7 @@ impl std::fmt::Display for EvalError {
             EvalError::WaitOn(service, var) => {
                 write!(f, "Wait-die wait on Symbol({})::Symbol({})", service, var)
             }
+            EvalError::AssertionError(s) => write!(f, "Assertion failed: {}", s),
         }
     }
 }

--- a/meerkat-lib/src/runtime/interpreter/executor.rs
+++ b/meerkat-lib/src/runtime/interpreter/executor.rs
@@ -91,7 +91,7 @@ pub async fn execute(
                 _ => Err(EvalError::TypeError("do expects an action".to_string())),
             }
         }
-        ActionStmt::Assert(expr) => {
+        ActionStmt::Assert(expr, text) => {
             let val = eval(
                 expr,
                 env,
@@ -104,10 +104,13 @@ pub async fn execute(
             .await?;
             match val {
                 Value::Bool { val: true } => Ok(ExecuteEffect::None),
-                Value::Bool { val: false } => Err(EvalError::TypeError(
-                    "Assertion failed: ".to_string() + &expr.to_string(),
-                )),
-                _ => Err(EvalError::TypeError("assert expects a boolean".to_string())),
+                Value::Bool { val: false } => Err(EvalError::AssertionError(text.clone())),
+                Value::Number { .. }
+                | Value::String { .. }
+                | Value::Closure { .. }
+                | Value::ActionClosure { .. } => {
+                    Err(EvalError::TypeError("assert expects a boolean".to_string()))
+                }
             }
         }
         ActionStmt::Let { name, expr } => {
@@ -137,5 +140,50 @@ pub async fn execute(
             Ok(ExecuteEffect::ExprValue(val))
         }
         ActionStmt::Insert { .. } => Err(EvalError::NotImplemented),
+    }
+}
+
+/// Unit tests for the executor
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ast::Expr;
+    use crate::runtime::interner::Interner;
+
+    /// Verify that `EvalError::AssertionError` formats
+    /// correctly and is returned upon assertion failure
+    #[tokio::test]
+    async fn test_assertion_error_execution_and_formatting() {
+        let err = EvalError::AssertionError("x == 5".to_string());
+        assert_eq!(err.to_string(), "Assertion failed: x == 5");
+
+        let mut manager = Manager::new(Interner::new());
+        let stmt = ActionStmt::Assert(
+            Expr::Literal {
+                val: Value::Bool { val: false },
+            },
+            "x == 5".to_string(),
+        );
+
+        let res = execute(&stmt, &[], &mut manager, Symbol::empty(), None).await;
+
+        match res {
+            Ok(_) => panic!("Expected assertion to fail"),
+            Err(err) => match err {
+                EvalError::AssertionError(text) => {
+                    assert_eq!(text, "x == 5");
+                }
+                EvalError::TypeError(_)
+                | EvalError::VarNotFound(_)
+                | EvalError::ServiceNotFound(_)
+                | EvalError::LocalDispatchFailed(_)
+                | EvalError::RemoteDispatchFailed(_)
+                | EvalError::NotImplemented
+                | EvalError::WaitDieAbort(_)
+                | EvalError::WaitOn(_, _) => {
+                    panic!("Expected EvalError::AssertionError")
+                }
+            },
+        }
     }
 }

--- a/meerkat-lib/src/runtime/manager/mod.rs
+++ b/meerkat-lib/src/runtime/manager/mod.rs
@@ -1686,9 +1686,12 @@ mod tests {
                     val: Value::Number { val: 99 },
                 },
             },
-            ActionStmt::Assert(Expr::Literal {
-                val: Value::Bool { val: false },
-            }),
+            ActionStmt::Assert(
+                Expr::Literal {
+                    val: Value::Bool { val: false },
+                },
+                "false".to_string(),
+            ),
         ];
         let result = tc.manager.execute_action(tc.foo, &stmts).await;
         assert!(result.is_err());
@@ -1725,9 +1728,12 @@ mod tests {
                     val: Value::Number { val: 99 },
                 },
             },
-            ActionStmt::Assert(Expr::Literal {
-                val: Value::Bool { val: false },
-            }),
+            ActionStmt::Assert(
+                Expr::Literal {
+                    val: Value::Bool { val: false },
+                },
+                "false".to_string(),
+            ),
         ];
 
         let result = tc.manager.execute_action(tc.foo, &failing_write).await;
@@ -1744,7 +1750,10 @@ mod tests {
         // If a transaction fails after a read, its read lock must still
         // be released
         let mut tc = manager_with_x().await;
-        let stmts = vec![ActionStmt::Assert(Expr::Variable { name: tc.x })];
+        let stmts = vec![ActionStmt::Assert(
+            Expr::Variable { name: tc.x },
+            "x".to_string(),
+        )];
 
         let result = tc.manager.execute_action(tc.foo, &stmts).await;
 

--- a/meerkat-lib/src/runtime/parser/meerkat.lalrpop
+++ b/meerkat-lib/src/runtime/parser/meerkat.lalrpop
@@ -5,12 +5,16 @@
 // Initial grammar for L1 
 
 // Grammar 
-grammar<'input>(interner: &mut crate::runtime::interner::Interner);
+grammar<'input>(
+    input: &'input str,
+    interner: &mut Interner
+);
 
 use crate::ast::{Stmt, ActionStmt, Decl, Expr, UnOp, BinOp, DataType, Field, Value};
 use crate::runtime::interner::{Interner, Symbol};
 use lalrpop_util::ParseError;
 use crate::runtime::parser::lex::Token;
+use crate::runtime::limits::MAX_STRING_LITERAL_LENGTH;
 
 use std::str::FromStr;
 
@@ -104,8 +108,20 @@ ActionStmt: ActionStmt = {
     "do" <e: Expr> ";" => {
         ActionStmt::Do(e)
     },
-    "assert" "(" <e:Expr> ")" ";" => {
-        ActionStmt::Assert(e)
+    "assert" "(" <l: @L> <e:Expr> <r: @R> ")" ";" =>? {
+        let assert_text = input[l..r].to_string();
+        let limit = MAX_STRING_LITERAL_LENGTH;
+        if assert_text.len() > limit {
+            Err(ParseError::User {
+                error: format!(
+                    "Assertion text exceeds maximum length of {} \
+                     characters",
+                    limit
+                ),
+            })
+        } else {
+            Ok(ActionStmt::Assert(e, assert_text))
+        }
     },
     "insert"  <e: Expr> "into" <t: Ident> => {
         ActionStmt::Insert {row: e, table_name: t}

--- a/meerkat-lib/src/runtime/parser/meerkat.lalrpop
+++ b/meerkat-lib/src/runtime/parser/meerkat.lalrpop
@@ -109,7 +109,7 @@ ActionStmt: ActionStmt = {
         ActionStmt::Do(e)
     },
     "assert" "(" <l: @L> <e:Expr> <r: @R> ")" ";" =>? {
-        let assert_text = input[l..r].to_string();
+        let assert_text = &input[l..r];
         let limit = MAX_STRING_LITERAL_LENGTH;
         if assert_text.len() > limit {
             Err(ParseError::User {
@@ -120,7 +120,7 @@ ActionStmt: ActionStmt = {
                 ),
             })
         } else {
-            Ok(ActionStmt::Assert(e, assert_text))
+            Ok(ActionStmt::Assert(e, assert_text.to_string()))
         }
     },
     "insert"  <e: Expr> "into" <t: Ident> => {

--- a/meerkat-lib/src/runtime/parser/mod.rs
+++ b/meerkat-lib/src/runtime/parser/mod.rs
@@ -56,7 +56,7 @@ pub fn parse_string(input: &str, interner: &mut Interner) -> Result<Vec<Stmt>, S
     }
 
     meerkat::ProgParser::new()
-        .parse(interner, lex_stream)
+        .parse(input, interner, lex_stream)
         .map_err(|e| format!("Parse error: {:?}", e))
 }
 
@@ -114,9 +114,12 @@ pub fn parse_repl(input: &str, interner: &mut Interner) -> ReplParseResult {
         lex_stream.push((span.start, t, span.end));
     }
 
-    match meerkat::ProgParser::new().parse(interner, lex_stream) {
-        Ok(stmts) if !stmts.is_empty() => ReplParseResult::Complete(stmts),
-        Ok(_) => ReplParseResult::Incomplete,
+    let parser = meerkat::ProgParser::new();
+    match parser.parse(input, interner, lex_stream) {
+        Ok(stmts) => match stmts.first() {
+            Some(_) => ReplParseResult::Complete(stmts),
+            None => ReplParseResult::Incomplete,
+        },
         Err(ParseError::UnrecognizedEof { .. }) => ReplParseResult::Incomplete,
         Err(e) => ReplParseResult::Error(format!("{:?}", e)),
     }
@@ -153,5 +156,39 @@ mod tests {
         assert!(res
             .unwrap_err()
             .contains("string literal exceeds maximum length"));
+    }
+    /// Verify that parsing an assertion captures the correct
+    /// raw string
+    #[test]
+    fn test_parse_assert_captures_string() {
+        use crate::ast::{ActionStmt, Stmt};
+
+        let mut interner = Interner::new();
+        let input = "assert (x == 5);";
+        let res = parse_string(input, &mut interner);
+        assert!(res.is_ok());
+        let ast = res.unwrap();
+        assert_eq!(ast.len(), 1);
+        match &ast[0] {
+            Stmt::ActionStmt(ActionStmt::Assert(_, text)) => {
+                assert_eq!(text, "x == 5");
+            }
+            _ => panic!("Expected ActionStmt::Assert"),
+        }
+    }
+
+    /// Verify that parsing an assertion exceeding length
+    /// limit fails
+    #[test]
+    fn test_parse_oversized_assert() {
+        let mut interner = Interner::new();
+        let limit = MAX_STRING_LITERAL_LENGTH;
+        let long_expr = "1+".repeat((limit / 2) + 1) + "1";
+        let input = format!("assert ({});", long_expr);
+        let res = parse_string(&input, &mut interner);
+        assert!(res.is_err());
+        assert!(res
+            .unwrap_err()
+            .contains("Assertion text exceeds maximum length"));
     }
 }

--- a/meerkat-lib/src/runtime/parser/mod.rs
+++ b/meerkat-lib/src/runtime/parser/mod.rs
@@ -191,4 +191,28 @@ mod tests {
             .unwrap_err()
             .contains("Assertion text exceeds maximum length"));
     }
+
+    /// Verify that parsing an `assert` exceeding the length limit
+    /// returns a `ParseError::User` error variant
+    #[test]
+    fn test_parse_oversized_assert_error_type() {
+        use lalrpop_util::ParseError;
+        let mut interner = Interner::new();
+        let limit = MAX_STRING_LITERAL_LENGTH;
+        let half_limit = limit / 2;
+        let repeat_count = half_limit + 1;
+        let repeated = "1+".repeat(repeat_count);
+        let long_expr = format!("{}1", repeated);
+        let input = format!("assert ({});", long_expr);
+        let mut lex_stream = Vec::new();
+        for (t, span) in lex::Token::lexer(&input).spanned() {
+            lex_stream.push((span.start, t, span.end));
+        }
+        let parser = meerkat::ProgParser::new();
+        let res = parser.parse(&input, &mut interner, lex_stream);
+        assert!(matches!(
+            res,
+            Err(ParseError::User { ref error }) if error.contains("Assertion text exceeds maximum length")
+        ));
+    }
 }

--- a/meerkat-lib/src/runtime/semantic_analysis/var_analysis/read_write.rs
+++ b/meerkat-lib/src/runtime/semantic_analysis/var_analysis/read_write.rs
@@ -75,7 +75,7 @@ impl Expr {
                         ActionStmt::Do(expr) => {
                             free_vars.extend(expr.free_var(reactive_names, var_binded));
                         }
-                        ActionStmt::Assert(expr) => {
+                        ActionStmt::Assert(expr, _) => {
                             free_vars.extend(expr.free_var(reactive_names, var_binded));
                         }
                         ActionStmt::Let { name: _, expr } => {


### PR DESCRIPTION
Stringify Meerkat assertions by embedding into the assertion AST nodes. Expand the error handling to account for this. The objective is to display human-readable assertion messages in a way that is similar to other programming languages with assertion features; on assertion failure, the original source text as the programmer would see it, is sliced out and echoed back to them.

This PR is intended to address the final review comments on the now merged PR #81, which we merged to allow others to continue to work and split off into an incremental change in this PR.

This PR is ready for AI and human review/feedback.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced assertion error messages to include the original source condition text for improved diagnostics
  * Added validation to enforce maximum length limits on assertion conditions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->