### PR TITLE
Asynchronous change-notification propagation (#24)

### DIFF
--- a/meerkat-lib/src/net/actor.rs
+++ b/meerkat-lib/src/net/actor.rs
@@ -35,6 +35,9 @@ enum PendingRelayState {
     Listening(Address, Sender<Result<Address, String>>, ListenerId),
 }
 
+// Command payloads intentionally carry a full MeerkatMessage; boxing buys
+// nothing for these short-lived channel messages.
+#[allow(clippy::large_enum_variant)]
 enum SwarmCommand {
     Send {
         id: MessageId,

--- a/meerkat-lib/src/net/codec.rs
+++ b/meerkat-lib/src/net/codec.rs
@@ -8,7 +8,7 @@ use crate::net::ast::{
     NetActionStmt, NetBinOp, NetExpr, NetField, NetParam, NetTableType, NetType, NetUnOp, NetValue,
 };
 use crate::runtime::ast::{ActionStmt, BinOp, Expr, Field, TableType, UnOp, Value};
-use crate::runtime::interner::Interner;
+use crate::runtime::interner::{Interner, Symbol};
 use crate::runtime::limits::{MAX_IDENTIFIER_LENGTH, MAX_STRING_LITERAL_LENGTH, MAX_TYPE_DEPTH};
 use crate::runtime::tt::{Param, TupleType, Type};
 
@@ -30,6 +30,51 @@ fn validate_string_literal(s: &str) -> Result<()> {
         )));
     }
     Ok(())
+}
+
+/// #24: validate and intern the identifier fields of a `RequestUpdates`
+/// message arriving over the wire. Per the zero-trust boundary, all interning
+/// of network-sourced names happens here in codec (never in the manager or
+/// main), after `validate_identifier`. `listener_service` and `reply_to` are
+/// network addresses, not identifiers, so they are not interned here.
+///
+/// Returns `(service, member, listener_def)` as interned `Symbol`s.
+pub fn decode_request_updates(
+    service: &str,
+    member: &str,
+    listener_def: &str,
+    interner: &mut Interner,
+) -> Result<(Symbol, Symbol, Symbol)> {
+    validate_identifier(service)?;
+    validate_identifier(member)?;
+    validate_identifier(listener_def)?;
+    Ok((
+        interner.insert(service),
+        interner.insert(member),
+        interner.insert(listener_def),
+    ))
+}
+
+/// #24: validate and intern the identifier fields of an `Update` message
+/// arriving over the wire (the `value` is decoded separately via
+/// `decode_value`). As with `decode_request_updates`, all interning of
+/// network-sourced names happens here after validation.
+///
+/// Returns `(listener_def, source_service, member)` as interned `Symbol`s.
+pub fn decode_update(
+    listener_def: &str,
+    source_service: &str,
+    member: &str,
+    interner: &mut Interner,
+) -> Result<(Symbol, Symbol, Symbol)> {
+    validate_identifier(listener_def)?;
+    validate_identifier(source_service)?;
+    validate_identifier(member)?;
+    Ok((
+        interner.insert(listener_def),
+        interner.insert(source_service),
+        interner.insert(member),
+    ))
 }
 
 /// Encode a runtime `Type` using recursion depth accumulator

--- a/meerkat-lib/src/net/codec.rs
+++ b/meerkat-lib/src/net/codec.rs
@@ -19,6 +19,23 @@ fn validate_identifier(s: &str) -> Result<()> {
             MAX_IDENTIFIER_LENGTH
         )));
     }
+    // Match the lexer's identifier rule ([A-Za-z_][A-Za-z0-9_]*) so a name
+    // arriving over the wire is rejected unless the parser would also accept
+    // it locally. Without this, length-valid but non-identifier strings
+    // (empty, whitespace, punctuation) could still be interned from the wire.
+    let mut chars = s.chars();
+    let valid = match chars.next() {
+        Some(c) if c.is_ascii_alphabetic() || c == '_' => {
+            chars.all(|c| c.is_ascii_alphanumeric() || c == '_')
+        }
+        _ => false,
+    };
+    if !valid {
+        return Err(Error::LimitExceeded(format!(
+            "invalid identifier (must match [A-Za-z_][A-Za-z0-9_]*): {:?}",
+            s
+        )));
+    }
     Ok(())
 }
 
@@ -1319,6 +1336,31 @@ mod tests {
         let res = decode_value(net_val, &mut interner);
         assert!(res.is_err());
         assert!(matches!(res.unwrap_err(), Error::LimitExceeded(_)));
+    }
+
+    /// #24: verify the codec rejects wire identifiers that the lexer would not
+    /// accept locally (whitespace, punctuation, leading digit, empty), so a
+    /// remote peer cannot grow the interner with non-identifier strings.
+    #[test]
+    fn test_codec_decode_rejects_non_identifier() {
+        let mut interner = Interner::new();
+        for bad in ["bad name", "bad!name", "1leading", "", "has.dot", "sp ace"] {
+            let res = decode_request_updates(bad, "member", "ldef", &mut interner);
+            assert!(
+                res.is_err(),
+                "decode_request_updates should reject service {:?}",
+                bad
+            );
+            let res = decode_update("ldef", bad, "member", &mut interner);
+            assert!(
+                res.is_err(),
+                "decode_update should reject source_service {:?}",
+                bad
+            );
+        }
+        // A well-formed identifier is accepted.
+        assert!(decode_request_updates("svc", "y", "z", &mut interner).is_ok());
+        assert!(decode_update("z", "svc", "y", &mut interner).is_ok());
     }
 
     /// Verify that encoding a value with an oversized string

--- a/meerkat-lib/src/net/messages.rs
+++ b/meerkat-lib/src/net/messages.rs
@@ -4,6 +4,9 @@ use kameo::Reply;
 
 /// Messages TO Network Actor (from Manager)
 #[derive(Debug)]
+// Command payloads intentionally carry a full MeerkatMessage; boxing buys
+// nothing for these short-lived channel messages.
+#[allow(clippy::large_enum_variant)]
 pub enum NetworkCommand {
     SendMessage { addr: Address, msg: MeerkatMessage },
     Listen { addr: Address },

--- a/meerkat-lib/src/net/types.rs
+++ b/meerkat-lib/src/net/types.rs
@@ -139,6 +139,30 @@ pub enum MeerkatMessage {
     /// request is alive and still queued, so it keeps waiting
     /// instead of timing out
     WaitParked { request_id: u64 },
+
+    /// #24: subscribe `listener_service.listener_def` (living on the sender's
+    /// node) as a listener on `service.member` (on this node). The owner
+    /// registers it and replies with an initial `Update` carrying the current
+    /// value. Names are strings; symbols are interner-local.
+    RequestUpdates {
+        request_id: u64,
+        service: String,
+        member: String,
+        listener_service: String,
+        listener_def: String,
+        reply_to: String,
+    },
+
+    /// #24: tell a remote listener that `source_service.member` changed (also
+    /// used for the initial value on subscribe). The receiver caches `value`
+    /// and recomputes `listener_def`.
+    Update {
+        listener_service: String,
+        listener_def: String,
+        source_service: String,
+        member: String,
+        value: NetValue,
+    },
 }
 
 /// Errors that can occur when sending messages

--- a/meerkat-lib/src/net/types.rs
+++ b/meerkat-lib/src/net/types.rs
@@ -143,7 +143,10 @@ pub enum MeerkatMessage {
     /// #24: subscribe `listener_service.listener_def` (living on the sender's
     /// node) as a listener on `service.member` (on this node). The owner
     /// registers it and replies with an initial `Update` carrying the current
-    /// value. Names are strings; symbols are interner-local.
+    /// value. Services, members, and defs are carried as strings rather than
+    /// symbols: symbols are interner ids local to one node, but these messages
+    /// cross nodes, so each side must resolve the names through its own interner
+    /// to know which service/member the request refers to.
     RequestUpdates {
         request_id: u64,
         service: String,

--- a/meerkat-lib/src/runtime/interpreter/evaluator.rs
+++ b/meerkat-lib/src/runtime/interpreter/evaluator.rs
@@ -255,6 +255,18 @@ pub async fn eval(
             service_name,
             member_name,
         } => {
+            // #24: during a reactive recompute the cross-service deps are already
+            // cached, so resolve from the cache and skip the lookup (which for a
+            // remote service would be a network round-trip).
+            if let Some(v) = ctx
+                .manager
+                .reactive_cache
+                .as_ref()
+                .and_then(|c| c.get(&(service_name, member_name)))
+                .cloned()
+            {
+                return Ok(v);
+            }
             // The `Manager` determines whether the service is local or
             // remote
             ctx.manager

--- a/meerkat-lib/src/runtime/interpreter/evaluator.rs
+++ b/meerkat-lib/src/runtime/interpreter/evaluator.rs
@@ -255,9 +255,10 @@ pub async fn eval(
             service_name,
             member_name,
         } => {
-            // #24: during a reactive recompute the cross-service deps are already
-            // cached, so resolve from the cache and skip the lookup (which for a
-            // remote service would be a network round-trip).
+            // #24: during a reactive update we check the cache first. If this
+            // (service, member) was already fetched for the def being recomputed,
+            // use the cached value instead of doing a lookup (which for a remote
+            // service would be a network round-trip).
             if let Some(v) = ctx
                 .manager
                 .reactive_cache

--- a/meerkat-lib/src/runtime/manager/mod.rs
+++ b/meerkat-lib/src/runtime/manager/mod.rs
@@ -97,6 +97,11 @@ pub struct Manager {
     /// #24: reply address for each remote listener, keyed by the listener's
     /// ServiceNetId, so the owner can route Updates back to it.
     pub listener_addrs: HashMap<ServiceNetId, String>,
+    /// #24: RequestUpdates/Update messages seen by the sync reply-router
+    /// (dispatch_network_events) while awaiting a reply. They carry no
+    /// request_id, so they are buffered here and drained in async context so a
+    /// reactive update arriving mid-wait is applied, not dropped.
+    pub pending_reactive: Vec<MeerkatMessage>,
 }
 
 impl Manager {
@@ -114,6 +119,7 @@ impl Manager {
             interner,
             reactive_cache: None,
             listener_addrs: HashMap::new(),
+            pending_reactive: Vec::new(),
         }
     }
 
@@ -839,6 +845,15 @@ impl Manager {
             let event = n.try_recv_event();
             match event {
                 Some(NetworkEvent::MessageReceived { msg, .. }) => {
+                    // #24: these carry no request_id and are not replies; buffer
+                    // them for async draining instead of dropping them here.
+                    if matches!(
+                        msg,
+                        MeerkatMessage::RequestUpdates { .. } | MeerkatMessage::Update { .. }
+                    ) {
+                        self.pending_reactive.push(msg);
+                        continue;
+                    }
                     let rid = match &msg {
                         MeerkatMessage::LookupResponse { request_id, .. } => Some(*request_id),
                         MeerkatMessage::LookupError { request_id, .. } => Some(*request_id),
@@ -873,6 +888,53 @@ impl Manager {
     }
 
     /// shared by remote_lookup and remote_action.
+    /// #24: handle any reactive messages the sync router buffered. Called in
+    /// async context (after each dispatch_network_events) so RequestUpdates and
+    /// Update arriving mid-wait are applied rather than lost.
+    async fn drain_pending_reactive(&mut self) {
+        while !self.pending_reactive.is_empty() {
+            let batch = std::mem::take(&mut self.pending_reactive);
+            for msg in batch {
+                match msg {
+                    MeerkatMessage::RequestUpdates {
+                        service,
+                        member,
+                        listener_service,
+                        listener_def,
+                        reply_to,
+                        ..
+                    } => {
+                        self.handle_request_updates(
+                            service,
+                            member,
+                            listener_service,
+                            listener_def,
+                            reply_to,
+                        )
+                        .await;
+                    }
+                    MeerkatMessage::Update {
+                        listener_service,
+                        listener_def,
+                        source_service,
+                        member,
+                        value,
+                    } => {
+                        self.handle_update(
+                            listener_service,
+                            listener_def,
+                            source_service,
+                            member,
+                            value,
+                        )
+                        .await;
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+
     async fn send_and_await_reply(
         &mut self,
         addr: Address,
@@ -900,6 +962,7 @@ impl Manager {
 
         loop {
             self.dispatch_network_events();
+            self.drain_pending_reactive().await;
             tokio::select! {
                 biased;
                 result = &mut rx => {
@@ -1985,6 +2048,81 @@ mod tests {
                 .get(&ServiceNetId("remote-s2-id".to_string()))
                 .map(|a| a.as_str()),
             Some("/ip4/1.2.3.4/tcp/9")
+        );
+    }
+
+    // #24: an Update buffered by the sync reply-router (because it carries no
+    // request_id) must still be applied when drained, not dropped. This is the
+    // dual-role case Copilot flagged: a node awaiting a reply receives an Update.
+    #[tokio::test]
+    async fn test_buffered_update_is_applied_on_drain() {
+        let mut tc = TestContext::new();
+        let z = tc.manager.interner.insert("z");
+
+        let s1_decls = vec![
+            Decl::VarDecl {
+                name: tc.x,
+                val: Expr::Literal {
+                    val: Value::Number { val: 1 },
+                },
+            },
+            Decl::DefDecl {
+                name: tc.y,
+                val: Expr::Binop {
+                    op: crate::ast::BinOp::Add,
+                    expr1: Box::new(Expr::Variable { name: tc.x }),
+                    expr2: Box::new(Expr::Literal {
+                        val: Value::Number { val: 1 },
+                    }),
+                },
+                is_pub: true,
+            },
+        ];
+        tc.manager.create_service(tc.s1, s1_decls).await.unwrap();
+
+        let s2_decls = vec![Decl::DefDecl {
+            name: z,
+            val: Expr::Binop {
+                op: crate::ast::BinOp::Add,
+                expr1: Box::new(Expr::MemberAccess {
+                    service_name: tc.s1,
+                    member_name: tc.y,
+                }),
+                expr2: Box::new(Expr::Literal {
+                    val: Value::Number { val: 2 },
+                }),
+            },
+            is_pub: true,
+        }];
+        tc.manager.create_service(tc.s2, s2_decls).await.unwrap();
+
+        let s2_id = tc.manager.services.get(&tc.s2).unwrap().id.0.clone();
+        let net_val =
+            codec::encode_value(&Value::Number { val: 10 }, &tc.manager.interner).unwrap();
+
+        // Simulate the router having buffered an Update (s1.y = 10) mid-wait.
+        tc.manager.pending_reactive.push(MeerkatMessage::Update {
+            listener_service: s2_id,
+            listener_def: "z".to_string(),
+            source_service: "s1".to_string(),
+            member: "y".to_string(),
+            value: net_val,
+        });
+
+        // Draining must apply it: z recomputes from the cached 10 -> 10 + 2 = 12.
+        tc.manager.drain_pending_reactive().await;
+
+        assert!(tc.manager.pending_reactive.is_empty());
+        assert_eq!(
+            tc.manager
+                .services
+                .get(&tc.s2)
+                .unwrap()
+                .vars
+                .get(&z)
+                .unwrap()
+                .value,
+            Value::Number { val: 12 }
         );
     }
 

--- a/meerkat-lib/src/runtime/manager/mod.rs
+++ b/meerkat-lib/src/runtime/manager/mod.rs
@@ -20,6 +20,13 @@ pub struct Service {
     pub vars: HashMap<Symbol, VarState>,
     pub defs: HashMap<Symbol, Expr>, // original def expressions for re-evaluation
     pub dep: DependAnalysis,         // dependency graph + topo order
+    /// #24: who depends on each member: member -> {(listener service id, def)}.
+    pub listeners: HashMap<Symbol, HashSet<(ServiceNetId, Symbol)>>,
+    /// #24: cached values of each def's cross-service deps:
+    /// def -> {(source service, member) -> value}.
+    pub dep_cache: HashMap<Symbol, HashMap<(Symbol, Symbol), Value>>,
+    /// #24: each def's direct cross-service deps as (service, member) symbols.
+    pub dep_remote: HashMap<Symbol, HashSet<(Symbol, Symbol)>>,
 }
 
 /// A remote request parked on a variable's wait queue because the requesting
@@ -212,6 +219,19 @@ impl Manager {
     ) -> Result<(), EvalError> {
         let dep = calc_dep_srv(&decls);
 
+        // #24: extract each def's direct cross-service deps now, while we still
+        // own `decls`. free_var drops MemberAccess, so this is the only place a
+        // reference like `s1.y` becomes visible to the runtime.
+        let mut dep_remote: HashMap<Symbol, HashSet<(Symbol, Symbol)>> = HashMap::new();
+        for decl in &decls {
+            if let Decl::DefDecl { name, val, .. } = decl {
+                let refs = val.cross_service_deps();
+                if !refs.is_empty() {
+                    dep_remote.insert(*name, refs);
+                }
+            }
+        }
+
         let id = self.compute_service_net_id(name);
         // Register the service (with its real `ServiceNetId`) before
         // evaluating any declarations, so action closures built during
@@ -225,6 +245,9 @@ impl Manager {
                 vars: HashMap::new(),
                 defs: HashMap::new(),
                 dep,
+                listeners: HashMap::new(),
+                dep_cache: HashMap::new(),
+                dep_remote,
             },
         );
 
@@ -296,12 +319,51 @@ impl Manager {
             }
         }
 
-        // code for handling transaction errors copied over from execute_action_with_txn
-
+        // #87: commit on success, abort and roll back on failure (pattern from
+        // execute_action_with_txn).
         if init_error.is_none() {
             self.apply_committed_writes(&txn).await;
             for addr in txn.participants.iter().cloned().collect::<Vec<_>>() {
                 let _ = self.send_commit(addr, &txn.id).await;
+            }
+
+            // #24: now that init succeeded, register listener edges so a change to
+            // a member notifies the defs that depend on it. Same-service deps come
+            // from dep_graph; cross-service deps come from dep_remote, where a local
+            // owner is wired in-process and a remote owner is subscribed over the
+            // wire. Only runs on the success path: a rolled-back service must not
+            // register listeners.
+            if let Some(this_id) = self.services.get(&svc_name).map(|s| s.id.clone()) {
+                let mut edges: Vec<(Symbol, Symbol, Symbol)> = Vec::new();
+                if let Some(s) = self.services.get(&svc_name) {
+                    for (def_name, deps) in &s.dep.dep_graph {
+                        if s.defs.contains_key(def_name) {
+                            for dep_member in deps {
+                                edges.push((svc_name, *dep_member, *def_name));
+                            }
+                        }
+                    }
+                    for (def_name, refs) in &s.dep_remote {
+                        for (owner, member) in refs {
+                            edges.push((*owner, *member, *def_name));
+                        }
+                    }
+                }
+                for (owner, member, listener_def) in edges {
+                    if self.services.contains_key(&owner) {
+                        if let Some(owner_svc) = self.services.get_mut(&owner) {
+                            owner_svc
+                                .listeners
+                                .entry(member)
+                                .or_default()
+                                .insert((this_id.clone(), listener_def));
+                        }
+                    } else {
+                        // remote owner: subscribe over the wire so future changes push.
+                        self.subscribe_remote(owner, member, this_id.clone(), listener_def)
+                            .await;
+                    }
+                }
             }
         } else {
             // Execution failed: discard buffered writes and abort participants.
@@ -493,71 +555,86 @@ impl Manager {
     }
 
     async fn propagate(&mut self, service_name: Symbol, changed_var: Symbol) {
-        // collect defs that need re-evaluation in topo order
-        let topo_order: Vec<Symbol> = self
-            .services
-            .get(&service_name)
-            .map(|s| s.dep.topo_order.clone())
-            .unwrap_or_default();
+        // #24: event-driven reactivity over the listener graph. A change to a
+        // member notifies its listeners; each local listener recomputes from
+        // current values and, if its value changes, cascades to its own
+        // listeners. The worklist is keyed by (service, member) so a cascade can
+        // cross local service boundaries. A listener resolving to another node is
+        // notified over the wire in a later stage.
+        let mut worklist: Vec<(Symbol, Symbol)> = vec![(service_name, changed_var)];
 
-        for def_name in topo_order {
-            let needs_update = self
+        while let Some((svc, member)) = worklist.pop() {
+            let listeners: Vec<(ServiceNetId, Symbol)> = self
                 .services
-                .get(&service_name)
-                .and_then(|s| s.dep.dep_vars.get(&def_name))
-                .map(|dep_vars| dep_vars.contains(&changed_var))
-                .unwrap_or(false);
+                .get(&svc)
+                .and_then(|s| s.listeners.get(&member))
+                .map(|set| set.iter().cloned().collect())
+                .unwrap_or_default();
 
-            let is_def = self
-                .services
-                .get(&service_name)
-                .map(|s| s.defs.contains_key(&def_name))
-                .unwrap_or(false);
-
-            if needs_update && is_def {
-                // build env from current var values
-                let expr = self
+            for (listener_id, listener_def) in listeners {
+                let listener_svc = match self
                     .services
-                    .get(&service_name)
-                    .and_then(|s| s.defs.get(&def_name))
-                    .cloned();
+                    .iter()
+                    .find(|(_, s)| s.id == listener_id)
+                    .map(|(name, _)| *name)
+                {
+                    Some(n) => n,
+                    None => continue,
+                };
 
-                if let Some(expr) = expr {
-                    let env: Vec<(Symbol, Value)> = self
-                        .services
-                        .get(&service_name)
-                        .map(|s| s.vars.iter().map(|(k, v)| (*k, v.value.clone())).collect())
-                        .unwrap_or_default();
+                let expr = match self
+                    .services
+                    .get(&listener_svc)
+                    .and_then(|s| s.defs.get(&listener_def))
+                    .cloned()
+                {
+                    Some(e) => e,
+                    None => continue,
+                };
 
-                    let value = match eval(
-                        &expr,
-                        &env,
-                        &mut EvalContext {
-                            manager: self,
-                            service_name,
-                            txn: None,
-                        },
-                    )
-                    .await
-                    {
-                        Ok(v) => v,
-                        Err(e) => {
-                            // Propagation is best-effort; durable retry of failed
-                            // updates is tracked under issue #24 (async updates).
-                            log::warn!(
-                                "propagation of def '{}' failed: {}",
-                                self.interner.get(def_name),
-                                e
-                            );
-                            continue;
-                        }
-                    };
+                let env: Vec<(Symbol, Value)> = self
+                    .services
+                    .get(&listener_svc)
+                    .map(|s| s.vars.iter().map(|(k, v)| (*k, v.value.clone())).collect())
+                    .unwrap_or_default();
 
-                    if let Some(service) = self.services.get_mut(&service_name) {
-                        if let Some(var_state) = service.vars.get_mut(&def_name) {
-                            var_state.value = value;
-                        }
+                let value = match eval(
+                    &expr,
+                    &env,
+                    &mut EvalContext {
+                        manager: self,
+                        service_name: listener_svc,
+                        txn: None,
+                    },
+                )
+                .await
+                {
+                    Ok(v) => v,
+                    Err(e) => {
+                        log::warn!(
+                            "propagation of def '{}' failed: {}",
+                            self.interner.get(listener_def),
+                            e
+                        );
+                        continue;
                     }
+                };
+
+                let changed = match self
+                    .services
+                    .get_mut(&listener_svc)
+                    .and_then(|s| s.vars.get_mut(&listener_def))
+                {
+                    Some(var_state) => {
+                        let differs = var_state.value != value;
+                        var_state.value = value;
+                        differs
+                    }
+                    None => false,
+                };
+
+                if changed {
+                    worklist.push((listener_svc, listener_def));
                 }
             }
         }
@@ -1453,6 +1530,131 @@ impl Default for Manager {
 mod tests {
     use super::*;
     use crate::ast::{Decl, Expr, Value};
+
+    // #24: cross_service_deps pulls out exactly the (service, member) symbols
+    // referenced via MemberAccess, and nothing for a purely local expression.
+    #[test]
+    fn test_cross_service_deps_extraction() {
+        let tc = TestContext::new();
+        // z = s1.y + 2  ->  {(s1, y)}
+        let z_expr = Expr::Binop {
+            op: crate::ast::BinOp::Add,
+            expr1: Box::new(Expr::MemberAccess {
+                service_name: tc.s1,
+                member_name: tc.y,
+            }),
+            expr2: Box::new(Expr::Literal {
+                val: Value::Number { val: 2 },
+            }),
+        };
+        assert_eq!(
+            z_expr.cross_service_deps(),
+            std::collections::HashSet::from([(tc.s1, tc.y)])
+        );
+        // y = x + 1  ->  {} (no cross-service references)
+        let y_expr = Expr::Binop {
+            op: crate::ast::BinOp::Add,
+            expr1: Box::new(Expr::Variable { name: tc.x }),
+            expr2: Box::new(Expr::Literal {
+                val: Value::Number { val: 1 },
+            }),
+        };
+        assert!(y_expr.cross_service_deps().is_empty());
+    }
+
+    // #24: a def in s2 that reads s1.y updates eagerly when s1.x changes,
+    // driven by the listener cascade rather than a lazy re-lookup.
+    #[tokio::test]
+    async fn test_cross_service_def_updates_eagerly() {
+        let mut tc = TestContext::new();
+        let z = tc.manager.interner.insert("z");
+
+        // service s1 { var x = 1; pub def y = x + 1; }
+        let s1_decls = vec![
+            Decl::VarDecl {
+                name: tc.x,
+                val: Expr::Literal {
+                    val: Value::Number { val: 1 },
+                },
+            },
+            Decl::DefDecl {
+                name: tc.y,
+                val: Expr::Binop {
+                    op: crate::ast::BinOp::Add,
+                    expr1: Box::new(Expr::Variable { name: tc.x }),
+                    expr2: Box::new(Expr::Literal {
+                        val: Value::Number { val: 1 },
+                    }),
+                },
+                is_pub: true,
+            },
+        ];
+        tc.manager.create_service(tc.s1, s1_decls).await.unwrap();
+
+        // service s2 { pub def z = s1.y + 2; }
+        let s2_decls = vec![Decl::DefDecl {
+            name: z,
+            val: Expr::Binop {
+                op: crate::ast::BinOp::Add,
+                expr1: Box::new(Expr::MemberAccess {
+                    service_name: tc.s1,
+                    member_name: tc.y,
+                }),
+                expr2: Box::new(Expr::Literal {
+                    val: Value::Number { val: 2 },
+                }),
+            },
+            is_pub: true,
+        }];
+        tc.manager.create_service(tc.s2, s2_decls).await.unwrap();
+
+        // initial z = (1 + 1) + 2 = 4
+        assert_eq!(
+            tc.manager
+                .services
+                .get(&tc.s2)
+                .unwrap()
+                .vars
+                .get(&z)
+                .unwrap()
+                .value,
+            Value::Number { val: 4 }
+        );
+
+        // s2.z is registered as a listener on s1.y
+        let on_y = tc
+            .manager
+            .services
+            .get(&tc.s1)
+            .unwrap()
+            .listeners
+            .get(&tc.y)
+            .cloned()
+            .unwrap_or_default();
+        assert!(
+            on_y.iter().any(|(_, d)| *d == z),
+            "s2.z should be registered as a listener on s1.y"
+        );
+
+        // s1.x = 4  ->  s1.y = 5  ->  s2.z = 7, eagerly via the cascade
+        tc.manager
+            .assign(tc.s1, tc.x, Value::Number { val: 4 }, None)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            tc.manager
+                .services
+                .get(&tc.s2)
+                .unwrap()
+                .vars
+                .get(&z)
+                .unwrap()
+                .value,
+            Value::Number { val: 7 },
+            "s2.z should update eagerly through the cross-service listener cascade"
+        );
+    }
 
     struct TestContext {
         manager: Manager,

--- a/meerkat-lib/src/runtime/manager/mod.rs
+++ b/meerkat-lib/src/runtime/manager/mod.rs
@@ -97,11 +97,6 @@ pub struct Manager {
     /// #24: reply address for each remote listener, keyed by the listener's
     /// ServiceNetId, so the owner can route Updates back to it.
     pub listener_addrs: HashMap<ServiceNetId, String>,
-    /// #24: RequestUpdates/Update messages seen by the sync reply-router
-    /// (dispatch_network_events) while awaiting a reply. They carry no
-    /// request_id, so they are buffered here and drained in async context so a
-    /// reactive update arriving mid-wait is applied, not dropped.
-    pub pending_reactive: Vec<MeerkatMessage>,
 }
 
 impl Manager {
@@ -119,7 +114,6 @@ impl Manager {
             interner,
             reactive_cache: None,
             listener_addrs: HashMap::new(),
-            pending_reactive: Vec::new(),
         }
     }
 
@@ -840,62 +834,18 @@ impl Manager {
 
     /// Drain all pending network events and dispatch each to the matching
     /// oneshot channel in pending_replies. Non-matching events are dropped.
-    pub fn dispatch_network_events(&mut self) {
-        while let Some(n) = self.network.as_mut() {
-            let event = n.try_recv_event();
-            match event {
-                Some(NetworkEvent::MessageReceived { msg, .. }) => {
-                    // #24: these carry no request_id and are not replies; buffer
-                    // them for async draining instead of dropping them here.
-                    if matches!(
-                        msg,
-                        MeerkatMessage::RequestUpdates { .. } | MeerkatMessage::Update { .. }
-                    ) {
-                        self.pending_reactive.push(msg);
-                        continue;
-                    }
-                    let rid = match &msg {
-                        MeerkatMessage::LookupResponse { request_id, .. } => Some(*request_id),
-                        MeerkatMessage::LookupError { request_id, .. } => Some(*request_id),
-                        MeerkatMessage::ActionResponse { request_id, .. } => Some(*request_id),
-                        MeerkatMessage::CommitResponse { request_id, .. } => Some(*request_id),
-                        MeerkatMessage::AbortResponse { request_id, .. } => Some(*request_id),
-                        MeerkatMessage::WaitParked { request_id, .. } => Some(*request_id),
-                        MeerkatMessage::Ping { .. }
-                        | MeerkatMessage::Pong { .. }
-                        | MeerkatMessage::Announce { .. }
-                        | MeerkatMessage::Transaction { .. }
-                        | MeerkatMessage::Propagation { .. }
-                        | MeerkatMessage::LookupRequest { .. }
-                        | MeerkatMessage::ActionRequest { .. }
-                        | MeerkatMessage::Commit { .. }
-                        | MeerkatMessage::Abort { .. }
-                        | MeerkatMessage::RequestUpdates { .. }
-                        | MeerkatMessage::Update { .. } => None,
-                    };
-                    if let Some(request_id) = rid {
-                        if let Some(tx) = self.pending_replies.remove(&request_id) {
-                            let _ = tx.send(msg);
-                        }
-                    }
-                }
-                Some(NetworkEvent::SendFailed { .. }) => {}
-                Some(NetworkEvent::PeerConnected { .. }) => {}
-                Some(NetworkEvent::PeerDisconnected { .. }) => {}
+    pub async fn dispatch_network_events(&mut self) {
+        loop {
+            // Scope the network borrow to just the receive so the rest of the
+            // loop body can take &mut self (the reactive handlers below).
+            let event = match self.network.as_mut() {
+                Some(n) => n.try_recv_event(),
                 None => break,
-            }
-        }
-    }
-
-    /// shared by remote_lookup and remote_action.
-    /// #24: handle any reactive messages the sync router buffered. Called in
-    /// async context (after each dispatch_network_events) so RequestUpdates and
-    /// Update arriving mid-wait are applied rather than lost.
-    async fn drain_pending_reactive(&mut self) {
-        while !self.pending_reactive.is_empty() {
-            let batch = std::mem::take(&mut self.pending_reactive);
-            for msg in batch {
-                match msg {
+            };
+            match event {
+                Some(NetworkEvent::MessageReceived { msg, .. }) => match msg {
+                    // #24: reactive messages are not replies; handle them inline
+                    // here in async context rather than buffering them.
                     MeerkatMessage::RequestUpdates {
                         service,
                         member,
@@ -929,12 +879,43 @@ impl Manager {
                         )
                         .await;
                     }
-                    _ => {}
-                }
+                    // Everything else is a reply: route it to its waiter.
+                    other => {
+                        let rid = match &other {
+                            MeerkatMessage::LookupResponse { request_id, .. } => Some(*request_id),
+                            MeerkatMessage::LookupError { request_id, .. } => Some(*request_id),
+                            MeerkatMessage::ActionResponse { request_id, .. } => Some(*request_id),
+                            MeerkatMessage::CommitResponse { request_id, .. } => Some(*request_id),
+                            MeerkatMessage::AbortResponse { request_id, .. } => Some(*request_id),
+                            MeerkatMessage::WaitParked { request_id, .. } => Some(*request_id),
+                            MeerkatMessage::Ping { .. }
+                            | MeerkatMessage::Pong { .. }
+                            | MeerkatMessage::Announce { .. }
+                            | MeerkatMessage::Transaction { .. }
+                            | MeerkatMessage::Propagation { .. }
+                            | MeerkatMessage::LookupRequest { .. }
+                            | MeerkatMessage::ActionRequest { .. }
+                            | MeerkatMessage::Commit { .. }
+                            | MeerkatMessage::Abort { .. }
+                            | MeerkatMessage::RequestUpdates { .. }
+                            | MeerkatMessage::Update { .. } => None,
+                        };
+                        if let Some(request_id) = rid {
+                            if let Some(tx) = self.pending_replies.remove(&request_id) {
+                                let _ = tx.send(other);
+                            }
+                        }
+                    }
+                },
+                Some(NetworkEvent::SendFailed { .. }) => {}
+                Some(NetworkEvent::PeerConnected { .. }) => {}
+                Some(NetworkEvent::PeerDisconnected { .. }) => {}
+                None => break,
             }
         }
     }
 
+    /// shared by remote_lookup and remote_action.
     async fn send_and_await_reply(
         &mut self,
         addr: Address,
@@ -961,8 +942,7 @@ impl Manager {
         tokio::pin!(timeout);
 
         loop {
-            self.dispatch_network_events();
-            self.drain_pending_reactive().await;
+            self.dispatch_network_events().await;
             tokio::select! {
                 biased;
                 result = &mut rx => {
@@ -2050,82 +2030,6 @@ mod tests {
             Some("/ip4/1.2.3.4/tcp/9")
         );
     }
-
-    // #24: an Update buffered by the sync reply-router (because it carries no
-    // request_id) must still be applied when drained, not dropped. This is the
-    // dual-role case Copilot flagged: a node awaiting a reply receives an Update.
-    #[tokio::test]
-    async fn test_buffered_update_is_applied_on_drain() {
-        let mut tc = TestContext::new();
-        let z = tc.manager.interner.insert("z");
-
-        let s1_decls = vec![
-            Decl::VarDecl {
-                name: tc.x,
-                val: Expr::Literal {
-                    val: Value::Number { val: 1 },
-                },
-            },
-            Decl::DefDecl {
-                name: tc.y,
-                val: Expr::Binop {
-                    op: crate::ast::BinOp::Add,
-                    expr1: Box::new(Expr::Variable { name: tc.x }),
-                    expr2: Box::new(Expr::Literal {
-                        val: Value::Number { val: 1 },
-                    }),
-                },
-                is_pub: true,
-            },
-        ];
-        tc.manager.create_service(tc.s1, s1_decls).await.unwrap();
-
-        let s2_decls = vec![Decl::DefDecl {
-            name: z,
-            val: Expr::Binop {
-                op: crate::ast::BinOp::Add,
-                expr1: Box::new(Expr::MemberAccess {
-                    service_name: tc.s1,
-                    member_name: tc.y,
-                }),
-                expr2: Box::new(Expr::Literal {
-                    val: Value::Number { val: 2 },
-                }),
-            },
-            is_pub: true,
-        }];
-        tc.manager.create_service(tc.s2, s2_decls).await.unwrap();
-
-        let s2_id = tc.manager.services.get(&tc.s2).unwrap().id.0.clone();
-        let net_val =
-            codec::encode_value(&Value::Number { val: 10 }, &tc.manager.interner).unwrap();
-
-        // Simulate the router having buffered an Update (s1.y = 10) mid-wait.
-        tc.manager.pending_reactive.push(MeerkatMessage::Update {
-            listener_service: s2_id,
-            listener_def: "z".to_string(),
-            source_service: "s1".to_string(),
-            member: "y".to_string(),
-            value: net_val,
-        });
-
-        // Draining must apply it: z recomputes from the cached 10 -> 10 + 2 = 12.
-        tc.manager.drain_pending_reactive().await;
-
-        assert!(tc.manager.pending_reactive.is_empty());
-        assert_eq!(
-            tc.manager
-                .services
-                .get(&tc.s2)
-                .unwrap()
-                .vars
-                .get(&z)
-                .unwrap()
-                .value,
-            Value::Number { val: 12 }
-        );
-    }
-
     struct TestContext {
         manager: Manager,
         foo: Symbol,

--- a/meerkat-lib/src/runtime/manager/mod.rs
+++ b/meerkat-lib/src/runtime/manager/mod.rs
@@ -751,6 +751,18 @@ impl Manager {
         let listener_def_sym = self.interner.insert(&listener_def);
         let listener_id = ServiceNetId(listener_service.clone());
 
+        // Only register a subscription for a member that actually exists on this
+        // service. Without this guard, an unknown member from untrusted network
+        // input would permanently grow listeners, listener_addrs, and the
+        // interner with no-op subscriptions.
+        let member_exists = self
+            .services
+            .get(&service_sym)
+            .map(|s| s.vars.contains_key(&member_sym))
+            .unwrap_or(false);
+        if !member_exists {
+            return;
+        }
         if let Some(svc) = self.services.get_mut(&service_sym) {
             svc.listeners
                 .entry(member_sym)

--- a/meerkat-lib/src/runtime/manager/mod.rs
+++ b/meerkat-lib/src/runtime/manager/mod.rs
@@ -90,6 +90,13 @@ pub struct Manager {
     pub local: bool,
     /// String interner
     pub interner: Interner,
+    /// #24: transient cache consulted during a reactive recompute. Holds the
+    /// (service, member) -> value map for the def currently being recomputed so
+    /// MemberAccess resolves from cache instead of a (possibly remote) lookup.
+    pub reactive_cache: Option<HashMap<(Symbol, Symbol), Value>>,
+    /// #24: reply address for each remote listener, keyed by the listener's
+    /// ServiceNetId, so the owner can route Updates back to it.
+    pub listener_addrs: HashMap<ServiceNetId, String>,
 }
 
 impl Manager {
@@ -105,6 +112,8 @@ impl Manager {
             local_address: None,
             local: false,
             interner,
+            reactive_cache: None,
+            listener_addrs: HashMap::new(),
         }
     }
 
@@ -557,10 +566,9 @@ impl Manager {
     async fn propagate(&mut self, service_name: Symbol, changed_var: Symbol) {
         // #24: event-driven reactivity over the listener graph. A change to a
         // member notifies its listeners; each local listener recomputes from
-        // current values and, if its value changes, cascades to its own
-        // listeners. The worklist is keyed by (service, member) so a cascade can
-        // cross local service boundaries. A listener resolving to another node is
-        // notified over the wire in a later stage.
+        // current values (and cached cross-service deps) and, if it changes,
+        // cascades to its own listeners. A listener resolving to another node is
+        // notified over the wire.
         let mut worklist: Vec<(Symbol, Symbol)> = vec![(service_name, changed_var)];
 
         while let Some((svc, member)) = worklist.pop() {
@@ -572,71 +580,243 @@ impl Manager {
                 .unwrap_or_default();
 
             for (listener_id, listener_def) in listeners {
-                let listener_svc = match self
+                let listener_svc = self
                     .services
                     .iter()
                     .find(|(_, s)| s.id == listener_id)
-                    .map(|(name, _)| *name)
-                {
-                    Some(n) => n,
-                    None => continue,
-                };
+                    .map(|(name, _)| *name);
 
-                let expr = match self
-                    .services
-                    .get(&listener_svc)
-                    .and_then(|s| s.defs.get(&listener_def))
-                    .cloned()
-                {
-                    Some(e) => e,
-                    None => continue,
-                };
-
-                let env: Vec<(Symbol, Value)> = self
-                    .services
-                    .get(&listener_svc)
-                    .map(|s| s.vars.iter().map(|(k, v)| (*k, v.value.clone())).collect())
-                    .unwrap_or_default();
-
-                let value = match eval(
-                    &expr,
-                    &env,
-                    &mut EvalContext {
-                        manager: self,
-                        service_name: listener_svc,
-                        txn: None,
-                    },
-                )
-                .await
-                {
-                    Ok(v) => v,
-                    Err(e) => {
-                        log::warn!(
-                            "propagation of def '{}' failed: {}",
-                            self.interner.get(listener_def),
-                            e
-                        );
-                        continue;
+                match listener_svc {
+                    Some(lsvc) => {
+                        if self.recompute_def(lsvc, listener_def).await {
+                            worklist.push((lsvc, listener_def));
+                        }
                     }
-                };
-
-                let changed = match self
-                    .services
-                    .get_mut(&listener_svc)
-                    .and_then(|s| s.vars.get_mut(&listener_def))
-                {
-                    Some(var_state) => {
-                        let differs = var_state.value != value;
-                        var_state.value = value;
-                        differs
+                    None => {
+                        self.emit_update(&listener_id, listener_def, svc, member)
+                            .await;
                     }
-                    None => false,
-                };
-
-                if changed {
-                    worklist.push((listener_svc, listener_def));
                 }
             }
+        }
+    }
+
+    /// #24: recompute `def` in `svc` from current values, seeding the reactive
+    /// cache with this def's cached cross-service deps so MemberAccess resolves
+    /// from cache instead of a (possibly remote) lookup. Returns whether the
+    /// stored value changed.
+    async fn recompute_def(&mut self, svc: Symbol, def: Symbol) -> bool {
+        let expr = match self
+            .services
+            .get(&svc)
+            .and_then(|s| s.defs.get(&def))
+            .cloned()
+        {
+            Some(e) => e,
+            None => return false,
+        };
+        let env: Vec<(Symbol, Value)> = self
+            .services
+            .get(&svc)
+            .map(|s| s.vars.iter().map(|(k, v)| (*k, v.value.clone())).collect())
+            .unwrap_or_default();
+        let cache = self
+            .services
+            .get(&svc)
+            .and_then(|s| s.dep_cache.get(&def))
+            .cloned()
+            .unwrap_or_default();
+
+        self.reactive_cache = Some(cache);
+        let result = eval(
+            &expr,
+            &env,
+            &mut EvalContext {
+                manager: self,
+                service_name: svc,
+                txn: None,
+            },
+        )
+        .await;
+        self.reactive_cache = None;
+
+        let value = match result {
+            Ok(v) => v,
+            Err(e) => {
+                log::warn!(
+                    "propagation of def '{}' failed: {}",
+                    self.interner.get(def),
+                    e
+                );
+                return false;
+            }
+        };
+
+        match self
+            .services
+            .get_mut(&svc)
+            .and_then(|s| s.vars.get_mut(&def))
+        {
+            Some(var_state) => {
+                let differs = var_state.value != value;
+                var_state.value = value;
+                differs
+            }
+            None => false,
+        }
+    }
+
+    /// #24: fire-and-forget send (no reply awaited).
+    async fn send_oneway(&mut self, addr: Address, msg: MeerkatMessage) {
+        if let Some(net) = self.network.as_mut() {
+            net.handle_command(NetworkCommand::SendMessage { addr, msg })
+                .await;
+        }
+    }
+
+    /// #24: send the current value of `svc.member` to a remote listener.
+    async fn emit_update(
+        &mut self,
+        listener_id: &ServiceNetId,
+        listener_def: Symbol,
+        svc: Symbol,
+        member: Symbol,
+    ) {
+        let reply_to = match self.listener_addrs.get(listener_id) {
+            Some(a) => a.clone(),
+            None => return,
+        };
+        let value = match self
+            .services
+            .get(&svc)
+            .and_then(|s| s.vars.get(&member))
+            .map(|vs| vs.value.clone())
+        {
+            Some(v) => v,
+            None => return,
+        };
+        let net_val = match codec::encode_value(&value, &self.interner) {
+            Ok(nv) => nv,
+            Err(_) => return,
+        };
+        let msg = MeerkatMessage::Update {
+            listener_service: listener_id.0.clone(),
+            listener_def: self.interner.get(listener_def).to_string(),
+            source_service: self.interner.get(svc).to_string(),
+            member: self.interner.get(member).to_string(),
+            value: net_val,
+        };
+        self.send_oneway(Address::new(&reply_to), msg).await;
+    }
+
+    /// #24: subscribe `this_id.listener_def` as a listener on remote `owner.member`.
+    async fn subscribe_remote(
+        &mut self,
+        owner: Symbol,
+        member: Symbol,
+        this_id: ServiceNetId,
+        listener_def: Symbol,
+    ) {
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static NEXT_SUB_ID: AtomicU64 = AtomicU64::new(1);
+        let addr = match self.remote_addr(owner) {
+            Ok(a) => a,
+            Err(_) => return,
+        };
+        let reply_to = self.local_reply_addr().await;
+        let request_id = NEXT_SUB_ID.fetch_add(1, Ordering::SeqCst);
+        let msg = MeerkatMessage::RequestUpdates {
+            request_id,
+            service: self.interner.get(owner).to_string(),
+            member: self.interner.get(member).to_string(),
+            listener_service: this_id.0,
+            listener_def: self.interner.get(listener_def).to_string(),
+            reply_to,
+        };
+        self.send_oneway(addr, msg).await;
+    }
+
+    /// #24 owner side: register a remote listener on `service.member` and reply
+    /// with the current value as an initial `Update` so it starts in sync.
+    pub async fn handle_request_updates(
+        &mut self,
+        service: String,
+        member: String,
+        listener_service: String,
+        listener_def: String,
+        reply_to: String,
+    ) {
+        let service_sym = self.interner.insert(&service);
+        let member_sym = self.interner.insert(&member);
+        let listener_def_sym = self.interner.insert(&listener_def);
+        let listener_id = ServiceNetId(listener_service.clone());
+
+        if let Some(svc) = self.services.get_mut(&service_sym) {
+            svc.listeners
+                .entry(member_sym)
+                .or_default()
+                .insert((listener_id.clone(), listener_def_sym));
+        } else {
+            return;
+        }
+        self.listener_addrs.insert(listener_id, reply_to.clone());
+
+        let current = self
+            .services
+            .get(&service_sym)
+            .and_then(|s| s.vars.get(&member_sym))
+            .map(|vs| vs.value.clone());
+        if let Some(value) = current {
+            if let Ok(net_val) = codec::encode_value(&value, &self.interner) {
+                let msg = MeerkatMessage::Update {
+                    listener_service,
+                    listener_def,
+                    source_service: service,
+                    member,
+                    value: net_val,
+                };
+                self.send_oneway(Address::new(&reply_to), msg).await;
+            }
+        }
+    }
+
+    /// #24 listener side: a remote member changed (or its initial value). Cache
+    /// it, recompute the dependent def from cache, and cascade to its listeners.
+    pub async fn handle_update(
+        &mut self,
+        listener_service: String,
+        listener_def: String,
+        source_service: String,
+        member: String,
+        value: crate::net::ast::NetValue,
+    ) {
+        let value = match codec::decode_value(value, &mut self.interner) {
+            Ok(v) => v,
+            Err(_) => return,
+        };
+        let listener_def_sym = self.interner.insert(&listener_def);
+        let source_sym = self.interner.insert(&source_service);
+        let member_sym = self.interner.insert(&member);
+
+        let listener_svc = self
+            .services
+            .iter()
+            .find(|(_, s)| s.id.0 == listener_service)
+            .map(|(name, _)| *name);
+        let listener_svc = match listener_svc {
+            Some(n) => n,
+            None => return,
+        };
+
+        if let Some(svc) = self.services.get_mut(&listener_svc) {
+            svc.dep_cache
+                .entry(listener_def_sym)
+                .or_default()
+                .insert((source_sym, member_sym), value);
+        }
+
+        if self.recompute_def(listener_svc, listener_def_sym).await {
+            self.propagate(listener_svc, listener_def_sym).await;
         }
     }
 
@@ -662,7 +842,9 @@ impl Manager {
                         | MeerkatMessage::LookupRequest { .. }
                         | MeerkatMessage::ActionRequest { .. }
                         | MeerkatMessage::Commit { .. }
-                        | MeerkatMessage::Abort { .. } => None,
+                        | MeerkatMessage::Abort { .. }
+                        | MeerkatMessage::RequestUpdates { .. }
+                        | MeerkatMessage::Update { .. } => None,
                     };
                     if let Some(request_id) = rid {
                         if let Some(tx) = self.pending_replies.remove(&request_id) {
@@ -907,6 +1089,8 @@ impl Manager {
             | MeerkatMessage::CommitResponse { .. }
             | MeerkatMessage::Abort { .. }
             | MeerkatMessage::AbortResponse { .. }
+            | MeerkatMessage::RequestUpdates { .. }
+            | MeerkatMessage::Update { .. }
             | MeerkatMessage::WaitParked { .. } => Err(EvalError::LocalDispatchFailed(
                 "Unexpected reply to lookup request".to_string(),
             )),
@@ -1040,6 +1224,8 @@ impl Manager {
             | MeerkatMessage::CommitResponse { .. }
             | MeerkatMessage::Abort { .. }
             | MeerkatMessage::AbortResponse { .. }
+            | MeerkatMessage::RequestUpdates { .. }
+            | MeerkatMessage::Update { .. }
             | MeerkatMessage::WaitParked { .. } => Err(EvalError::LocalDispatchFailed(
                 "Unexpected reply to action request".to_string(),
             )),
@@ -1469,6 +1655,8 @@ impl Manager {
             | MeerkatMessage::Commit { .. }
             | MeerkatMessage::Abort { .. }
             | MeerkatMessage::AbortResponse { .. }
+            | MeerkatMessage::RequestUpdates { .. }
+            | MeerkatMessage::Update { .. }
             | MeerkatMessage::WaitParked { .. } => Err(EvalError::LocalDispatchFailed(
                 "Unexpected reply to commit".to_string(),
             )),
@@ -1653,6 +1841,138 @@ mod tests {
                 .value,
             Value::Number { val: 7 },
             "s2.z should update eagerly through the cross-service listener cascade"
+        );
+    }
+
+    // #24: handle_update caches a pushed remote value and recomputes the
+    // dependent def FROM THE CACHE, not from a fresh lookup of the local value.
+    #[tokio::test]
+    async fn test_handle_update_recomputes_from_cache() {
+        let mut tc = TestContext::new();
+        let z = tc.manager.interner.insert("z");
+
+        let s1_decls = vec![
+            Decl::VarDecl {
+                name: tc.x,
+                val: Expr::Literal {
+                    val: Value::Number { val: 1 },
+                },
+            },
+            Decl::DefDecl {
+                name: tc.y,
+                val: Expr::Binop {
+                    op: crate::ast::BinOp::Add,
+                    expr1: Box::new(Expr::Variable { name: tc.x }),
+                    expr2: Box::new(Expr::Literal {
+                        val: Value::Number { val: 1 },
+                    }),
+                },
+                is_pub: true,
+            },
+        ];
+        tc.manager.create_service(tc.s1, s1_decls).await.unwrap();
+
+        let s2_decls = vec![Decl::DefDecl {
+            name: z,
+            val: Expr::Binop {
+                op: crate::ast::BinOp::Add,
+                expr1: Box::new(Expr::MemberAccess {
+                    service_name: tc.s1,
+                    member_name: tc.y,
+                }),
+                expr2: Box::new(Expr::Literal {
+                    val: Value::Number { val: 2 },
+                }),
+            },
+            is_pub: true,
+        }];
+        tc.manager.create_service(tc.s2, s2_decls).await.unwrap();
+
+        let s2_id = tc.manager.services.get(&tc.s2).unwrap().id.0.clone();
+        let net_val =
+            codec::encode_value(&Value::Number { val: 10 }, &tc.manager.interner).unwrap();
+
+        // simulate a remote Update saying s1.y = 10
+        tc.manager
+            .handle_update(
+                s2_id,
+                "z".to_string(),
+                "s1".to_string(),
+                "y".to_string(),
+                net_val,
+            )
+            .await;
+
+        // recomputed from the cached 10 (not s1's local y of 2): 10 + 2 = 12
+        assert_eq!(
+            tc.manager
+                .services
+                .get(&tc.s2)
+                .unwrap()
+                .vars
+                .get(&z)
+                .unwrap()
+                .value,
+            Value::Number { val: 12 }
+        );
+    }
+
+    // #24: handle_request_updates registers a remote listener and records its
+    // reply address (the initial Update send is a no-op without a network).
+    #[tokio::test]
+    async fn test_handle_request_updates_registers_listener() {
+        let mut tc = TestContext::new();
+        let s1_decls = vec![
+            Decl::VarDecl {
+                name: tc.x,
+                val: Expr::Literal {
+                    val: Value::Number { val: 1 },
+                },
+            },
+            Decl::DefDecl {
+                name: tc.y,
+                val: Expr::Binop {
+                    op: crate::ast::BinOp::Add,
+                    expr1: Box::new(Expr::Variable { name: tc.x }),
+                    expr2: Box::new(Expr::Literal {
+                        val: Value::Number { val: 1 },
+                    }),
+                },
+                is_pub: true,
+            },
+        ];
+        tc.manager.create_service(tc.s1, s1_decls).await.unwrap();
+
+        tc.manager
+            .handle_request_updates(
+                "s1".to_string(),
+                "y".to_string(),
+                "remote-s2-id".to_string(),
+                "z".to_string(),
+                "/ip4/1.2.3.4/tcp/9".to_string(),
+            )
+            .await;
+
+        let z = tc.manager.interner.insert("z");
+        let on_y = tc
+            .manager
+            .services
+            .get(&tc.s1)
+            .unwrap()
+            .listeners
+            .get(&tc.y)
+            .cloned()
+            .unwrap_or_default();
+        assert!(
+            on_y.iter().any(|(id, d)| id.0 == "remote-s2-id" && *d == z),
+            "remote s2.z should be registered as a listener on s1.y"
+        );
+        assert_eq!(
+            tc.manager
+                .listener_addrs
+                .get(&ServiceNetId("remote-s2-id".to_string()))
+                .map(|a| a.as_str()),
+            Some("/ip4/1.2.3.4/tcp/9")
         );
     }
 

--- a/meerkat-lib/src/runtime/manager/mod.rs
+++ b/meerkat-lib/src/runtime/manager/mod.rs
@@ -1810,7 +1810,7 @@ mod tests {
                 member_name: tc.y,
             }),
             expr2: Box::new(Expr::Literal {
-                val: Value::Number { val: 2 },
+                val: Value::Int { val: 2 },
             }),
         };
         assert_eq!(
@@ -1822,7 +1822,7 @@ mod tests {
             op: crate::ast::BinOp::Add,
             expr1: Box::new(Expr::Variable { name: tc.x }),
             expr2: Box::new(Expr::Literal {
-                val: Value::Number { val: 1 },
+                val: Value::Int { val: 1 },
             }),
         };
         assert!(y_expr.cross_service_deps().is_empty());
@@ -1839,17 +1839,19 @@ mod tests {
         let s1_decls = vec![
             Decl::VarDecl {
                 name: tc.x,
+                ty: None,
                 val: Expr::Literal {
-                    val: Value::Number { val: 1 },
+                    val: Value::Int { val: 1 },
                 },
             },
             Decl::DefDecl {
                 name: tc.y,
+                ty: None,
                 val: Expr::Binop {
                     op: crate::ast::BinOp::Add,
                     expr1: Box::new(Expr::Variable { name: tc.x }),
                     expr2: Box::new(Expr::Literal {
-                        val: Value::Number { val: 1 },
+                        val: Value::Int { val: 1 },
                     }),
                 },
                 is_pub: true,
@@ -1860,6 +1862,7 @@ mod tests {
         // service s2 { pub def z = s1.y + 2; }
         let s2_decls = vec![Decl::DefDecl {
             name: z,
+            ty: None,
             val: Expr::Binop {
                 op: crate::ast::BinOp::Add,
                 expr1: Box::new(Expr::MemberAccess {
@@ -1867,7 +1870,7 @@ mod tests {
                     member_name: tc.y,
                 }),
                 expr2: Box::new(Expr::Literal {
-                    val: Value::Number { val: 2 },
+                    val: Value::Int { val: 2 },
                 }),
             },
             is_pub: true,
@@ -1884,7 +1887,7 @@ mod tests {
                 .get(&z)
                 .unwrap()
                 .value,
-            Value::Number { val: 4 }
+            Value::Int { val: 4 }
         );
 
         // s2.z is registered as a listener on s1.y
@@ -1904,7 +1907,7 @@ mod tests {
 
         // s1.x = 4  ->  s1.y = 5  ->  s2.z = 7, eagerly via the cascade
         tc.manager
-            .assign(tc.s1, tc.x, Value::Number { val: 4 }, None)
+            .assign(tc.s1, tc.x, Value::Int { val: 4 }, None)
             .await
             .unwrap();
 
@@ -1917,7 +1920,7 @@ mod tests {
                 .get(&z)
                 .unwrap()
                 .value,
-            Value::Number { val: 7 },
+            Value::Int { val: 7 },
             "s2.z should update eagerly through the cross-service listener cascade"
         );
     }
@@ -1932,17 +1935,19 @@ mod tests {
         let s1_decls = vec![
             Decl::VarDecl {
                 name: tc.x,
+                ty: None,
                 val: Expr::Literal {
-                    val: Value::Number { val: 1 },
+                    val: Value::Int { val: 1 },
                 },
             },
             Decl::DefDecl {
                 name: tc.y,
+                ty: None,
                 val: Expr::Binop {
                     op: crate::ast::BinOp::Add,
                     expr1: Box::new(Expr::Variable { name: tc.x }),
                     expr2: Box::new(Expr::Literal {
-                        val: Value::Number { val: 1 },
+                        val: Value::Int { val: 1 },
                     }),
                 },
                 is_pub: true,
@@ -1952,6 +1957,7 @@ mod tests {
 
         let s2_decls = vec![Decl::DefDecl {
             name: z,
+            ty: None,
             val: Expr::Binop {
                 op: crate::ast::BinOp::Add,
                 expr1: Box::new(Expr::MemberAccess {
@@ -1959,7 +1965,7 @@ mod tests {
                     member_name: tc.y,
                 }),
                 expr2: Box::new(Expr::Literal {
-                    val: Value::Number { val: 2 },
+                    val: Value::Int { val: 2 },
                 }),
             },
             is_pub: true,
@@ -1967,8 +1973,7 @@ mod tests {
         tc.manager.create_service(tc.s2, s2_decls).await.unwrap();
 
         let s2_id = tc.manager.services.get(&tc.s2).unwrap().id.0.clone();
-        let net_val =
-            codec::encode_value(&Value::Number { val: 10 }, &tc.manager.interner).unwrap();
+        let net_val = codec::encode_value(&Value::Int { val: 10 }, &tc.manager.interner).unwrap();
 
         // simulate a remote Update saying s1.y = 10
         let z_sym = tc.manager.interner.insert("z");
@@ -1986,7 +1991,7 @@ mod tests {
                 .get(&z)
                 .unwrap()
                 .value,
-            Value::Number { val: 12 }
+            Value::Int { val: 12 }
         );
     }
 
@@ -1998,17 +2003,19 @@ mod tests {
         let s1_decls = vec![
             Decl::VarDecl {
                 name: tc.x,
+                ty: None,
                 val: Expr::Literal {
-                    val: Value::Number { val: 1 },
+                    val: Value::Int { val: 1 },
                 },
             },
             Decl::DefDecl {
                 name: tc.y,
+                ty: None,
                 val: Expr::Binop {
                     op: crate::ast::BinOp::Add,
                     expr1: Box::new(Expr::Variable { name: tc.x }),
                     expr2: Box::new(Expr::Literal {
-                        val: Value::Number { val: 1 },
+                        val: Value::Int { val: 1 },
                     }),
                 },
                 is_pub: true,

--- a/meerkat-lib/src/runtime/manager/mod.rs
+++ b/meerkat-lib/src/runtime/manager/mod.rs
@@ -25,8 +25,6 @@ pub struct Service {
     /// #24: cached values of each def's cross-service deps:
     /// def -> {(source service, member) -> value}.
     pub dep_cache: HashMap<Symbol, HashMap<(Symbol, Symbol), Value>>,
-    /// #24: each def's direct cross-service deps as (service, member) symbols.
-    pub dep_remote: HashMap<Symbol, HashSet<(Symbol, Symbol)>>,
 }
 
 /// A remote request parked on a variable's wait queue because the requesting
@@ -228,19 +226,6 @@ impl Manager {
     ) -> Result<(), EvalError> {
         let dep = calc_dep_srv(&decls);
 
-        // #24: extract each def's direct cross-service deps now, while we still
-        // own `decls`. free_var drops MemberAccess, so this is the only place a
-        // reference like `s1.y` becomes visible to the runtime.
-        let mut dep_remote: HashMap<Symbol, HashSet<(Symbol, Symbol)>> = HashMap::new();
-        for decl in &decls {
-            if let Decl::DefDecl { name, val, .. } = decl {
-                let refs = val.cross_service_deps();
-                if !refs.is_empty() {
-                    dep_remote.insert(*name, refs);
-                }
-            }
-        }
-
         let id = self.compute_service_net_id(name);
         // Register the service (with its real `ServiceNetId`) before
         // evaluating any declarations, so action closures built during
@@ -256,7 +241,6 @@ impl Manager {
                 dep,
                 listeners: HashMap::new(),
                 dep_cache: HashMap::new(),
-                dep_remote,
             },
         );
 
@@ -338,24 +322,26 @@ impl Manager {
 
             // #24: now that init succeeded, register listener edges so a change to
             // a member notifies the defs that depend on it. Same-service deps come
-            // from dep_graph; cross-service deps come from dep_remote, where a local
+            // from dep_graph; cross-service deps come from each def's MemberAccess refs, where a local
             // owner is wired in-process and a remote owner is subscribed over the
             // wire. Only runs on the success path: a rolled-back service must not
             // register listeners.
-            if let Some(this_id) = self.services.get(&svc_name).map(|s| s.id.clone()) {
+            if let Some(s) = self.services.get(&svc_name) {
+                let this_id = s.id.clone();
                 let mut edges: Vec<(Symbol, Symbol, Symbol)> = Vec::new();
-                if let Some(s) = self.services.get(&svc_name) {
-                    for (def_name, deps) in &s.dep.dep_graph {
-                        if s.defs.contains_key(def_name) {
-                            for dep_member in deps {
-                                edges.push((svc_name, *dep_member, *def_name));
-                            }
+                for (def_name, deps) in &s.dep.dep_graph {
+                    if s.defs.contains_key(def_name) {
+                        for dep_member in deps {
+                            edges.push((svc_name, *dep_member, *def_name));
                         }
                     }
-                    for (def_name, refs) in &s.dep_remote {
-                        for (owner, member) in refs {
-                            edges.push((*owner, *member, *def_name));
-                        }
+                }
+                // #24: cross-service deps, derived from each stored def
+                // expression (dep_remote removed: these are just the keys of
+                // dep_cache, recomputed here from the def's MemberAccess refs).
+                for (def_name, expr) in &s.defs {
+                    for (owner, member) in expr.cross_service_deps() {
+                        edges.push((owner, member, *def_name));
                     }
                 }
                 for (owner, member, listener_def) in edges {
@@ -565,10 +551,12 @@ impl Manager {
 
     async fn propagate(&mut self, service_name: Symbol, changed_var: Symbol) {
         // #24: event-driven reactivity over the listener graph. A change to a
-        // member notifies its listeners; each local listener recomputes from
-        // current values (and cached cross-service deps) and, if it changes,
-        // cascades to its own listeners. A listener resolving to another node is
-        // notified over the wire.
+        // member notifies its listeners. For each listener we resolve its
+        // service id to a local service: Some means a local listener, which we
+        // recompute from current values (and cached cross-service deps) and, if
+        // it changes, push back onto the worklist to cascade; None means the
+        // listener lives on another node, which we notify over the wire via
+        // emit_update.
         let mut worklist: Vec<(Symbol, Symbol)> = vec![(service_name, changed_var)];
 
         while let Some((svc, member)) = worklist.pop() {
@@ -613,7 +601,14 @@ impl Manager {
             .cloned()
         {
             Some(e) => e,
-            None => return false,
+            None => {
+                log::warn!(
+                    "recompute_def: def '{}' not found in service '{}'",
+                    self.interner.get(def),
+                    self.interner.get(svc)
+                );
+                return false;
+            }
         };
         let env: Vec<(Symbol, Value)> = self
             .services
@@ -638,6 +633,9 @@ impl Manager {
             },
         )
         .await;
+        // The reactive cache is only valid for the single recompute above (its
+        // entries are this def's cached cross-service deps), so clear it before
+        // returning to avoid leaking stale entries into later evaluations.
         self.reactive_cache = None;
 
         let value = match result {
@@ -662,7 +660,14 @@ impl Manager {
                 var_state.value = value;
                 differs
             }
-            None => false,
+            None => {
+                log::warn!(
+                    "recompute_def: def '{}' in service '{}' disappeared after recompute",
+                    self.interner.get(def),
+                    self.interner.get(svc)
+                );
+                false
+            }
         }
     }
 
@@ -684,7 +689,13 @@ impl Manager {
     ) {
         let reply_to = match self.listener_addrs.get(listener_id) {
             Some(a) => a.clone(),
-            None => return,
+            None => {
+                log::warn!(
+                    "emit_update: no reply address for listener '{}'",
+                    listener_id.0
+                );
+                return;
+            }
         };
         let value = match self
             .services
@@ -693,11 +704,26 @@ impl Manager {
             .map(|vs| vs.value.clone())
         {
             Some(v) => v,
-            None => return,
+            None => {
+                log::warn!(
+                    "emit_update: member '{}' not found in service '{}'",
+                    self.interner.get(member),
+                    self.interner.get(svc)
+                );
+                return;
+            }
         };
         let net_val = match codec::encode_value(&value, &self.interner) {
             Ok(nv) => nv,
-            Err(_) => return,
+            Err(e) => {
+                log::warn!(
+                    "emit_update: failed to encode value for '{}.{}': {}",
+                    self.interner.get(svc),
+                    self.interner.get(member),
+                    e
+                );
+                return;
+            }
         };
         let msg = MeerkatMessage::Update {
             listener_service: listener_id.0.clone(),
@@ -740,17 +766,12 @@ impl Manager {
     /// with the current value as an initial `Update` so it starts in sync.
     pub async fn handle_request_updates(
         &mut self,
-        service: String,
-        member: String,
-        listener_service: String,
-        listener_def: String,
+        service_sym: Symbol,
+        member_sym: Symbol,
+        listener_id: ServiceNetId,
+        listener_def_sym: Symbol,
         reply_to: String,
     ) {
-        let service_sym = self.interner.insert(&service);
-        let member_sym = self.interner.insert(&member);
-        let listener_def_sym = self.interner.insert(&listener_def);
-        let listener_id = ServiceNetId(listener_service.clone());
-
         // Only register a subscription for a member that actually exists on this
         // service. Without this guard, an unknown member from untrusted network
         // input would permanently grow listeners, listener_addrs, and the
@@ -771,7 +792,8 @@ impl Manager {
         } else {
             return;
         }
-        self.listener_addrs.insert(listener_id, reply_to.clone());
+        self.listener_addrs
+            .insert(listener_id.clone(), reply_to.clone());
 
         let current = self
             .services
@@ -781,10 +803,10 @@ impl Manager {
         if let Some(value) = current {
             if let Ok(net_val) = codec::encode_value(&value, &self.interner) {
                 let msg = MeerkatMessage::Update {
-                    listener_service,
-                    listener_def,
-                    source_service: service,
-                    member,
+                    listener_service: listener_id.0.clone(),
+                    listener_def: self.interner.get(listener_def_sym).to_string(),
+                    source_service: self.interner.get(service_sym).to_string(),
+                    member: self.interner.get(member_sym).to_string(),
                     value: net_val,
                 };
                 self.send_oneway(Address::new(&reply_to), msg).await;
@@ -796,24 +818,21 @@ impl Manager {
     /// it, recompute the dependent def from cache, and cascade to its listeners.
     pub async fn handle_update(
         &mut self,
-        listener_service: String,
-        listener_def: String,
-        source_service: String,
-        member: String,
+        listener_id: ServiceNetId,
+        listener_def_sym: Symbol,
+        source_sym: Symbol,
+        member_sym: Symbol,
         value: crate::net::ast::NetValue,
     ) {
         let value = match codec::decode_value(value, &mut self.interner) {
             Ok(v) => v,
             Err(_) => return,
         };
-        let listener_def_sym = self.interner.insert(&listener_def);
-        let source_sym = self.interner.insert(&source_service);
-        let member_sym = self.interner.insert(&member);
 
         let listener_svc = self
             .services
             .iter()
-            .find(|(_, s)| s.id.0 == listener_service)
+            .find(|(_, s)| s.id == listener_id)
             .map(|(name, _)| *name);
         let listener_svc = match listener_svc {
             Some(n) => n,
@@ -835,15 +854,14 @@ impl Manager {
     /// Drain all pending network events and dispatch each to the matching
     /// oneshot channel in pending_replies. Non-matching events are dropped.
     pub async fn dispatch_network_events(&mut self) {
-        loop {
-            // Scope the network borrow to just the receive so the rest of the
-            // loop body can take &mut self (the reactive handlers below).
-            let event = match self.network.as_mut() {
-                Some(n) => n.try_recv_event(),
-                None => break,
-            };
+        // Scope the network borrow to just the receive (via the inner match) so
+        // the rest of the loop body can take &mut self for the reactive handlers.
+        while let Some(event) = match self.network.as_mut() {
+            Some(n) => n.try_recv_event(),
+            None => None,
+        } {
             match event {
-                Some(NetworkEvent::MessageReceived { msg, .. }) => match msg {
+                NetworkEvent::MessageReceived { msg, .. } => match msg {
                     // #24: reactive messages are not replies; handle them inline
                     // here in async context rather than buffering them.
                     MeerkatMessage::RequestUpdates {
@@ -854,11 +872,14 @@ impl Manager {
                         reply_to,
                         ..
                     } => {
+                        let service_sym = self.interner.insert(&service);
+                        let member_sym = self.interner.insert(&member);
+                        let listener_def_sym = self.interner.insert(&listener_def);
                         self.handle_request_updates(
-                            service,
-                            member,
-                            listener_service,
-                            listener_def,
+                            service_sym,
+                            member_sym,
+                            ServiceNetId(listener_service),
+                            listener_def_sym,
                             reply_to,
                         )
                         .await;
@@ -870,11 +891,14 @@ impl Manager {
                         member,
                         value,
                     } => {
+                        let listener_def_sym = self.interner.insert(&listener_def);
+                        let source_sym = self.interner.insert(&source_service);
+                        let member_sym = self.interner.insert(&member);
                         self.handle_update(
-                            listener_service,
-                            listener_def,
-                            source_service,
-                            member,
+                            ServiceNetId(listener_service),
+                            listener_def_sym,
+                            source_sym,
+                            member_sym,
                             value,
                         )
                         .await;
@@ -907,10 +931,9 @@ impl Manager {
                         }
                     }
                 },
-                Some(NetworkEvent::SendFailed { .. }) => {}
-                Some(NetworkEvent::PeerConnected { .. }) => {}
-                Some(NetworkEvent::PeerDisconnected { .. }) => {}
-                None => break,
+                NetworkEvent::SendFailed { .. } => {}
+                NetworkEvent::PeerConnected { .. } => {}
+                NetworkEvent::PeerDisconnected { .. } => {}
             }
         }
     }
@@ -1948,14 +1971,9 @@ mod tests {
             codec::encode_value(&Value::Number { val: 10 }, &tc.manager.interner).unwrap();
 
         // simulate a remote Update saying s1.y = 10
+        let z_sym = tc.manager.interner.insert("z");
         tc.manager
-            .handle_update(
-                s2_id,
-                "z".to_string(),
-                "s1".to_string(),
-                "y".to_string(),
-                net_val,
-            )
+            .handle_update(ServiceNetId(s2_id), z_sym, tc.s1, tc.y, net_val)
             .await;
 
         // recomputed from the cached 10 (not s1's local y of 2): 10 + 2 = 12
@@ -1998,17 +2016,16 @@ mod tests {
         ];
         tc.manager.create_service(tc.s1, s1_decls).await.unwrap();
 
+        let z = tc.manager.interner.insert("z");
         tc.manager
             .handle_request_updates(
-                "s1".to_string(),
-                "y".to_string(),
-                "remote-s2-id".to_string(),
-                "z".to_string(),
+                tc.s1,
+                tc.y,
+                ServiceNetId("remote-s2-id".to_string()),
+                z,
                 "/ip4/1.2.3.4/tcp/9".to_string(),
             )
             .await;
-
-        let z = tc.manager.interner.insert("z");
         let on_y = tc
             .manager
             .services

--- a/meerkat-lib/src/runtime/manager/mod.rs
+++ b/meerkat-lib/src/runtime/manager/mod.rs
@@ -872,9 +872,19 @@ impl Manager {
                         reply_to,
                         ..
                     } => {
-                        let service_sym = self.interner.insert(&service);
-                        let member_sym = self.interner.insert(&member);
-                        let listener_def_sym = self.interner.insert(&listener_def);
+                        // #24: validate + intern wire names through codec (the
+                        // sole interning authority for network data); skip the
+                        // message if any identifier fails validation.
+                        let (service_sym, member_sym, listener_def_sym) =
+                            match codec::decode_request_updates(
+                                &service,
+                                &member,
+                                &listener_def,
+                                &mut self.interner,
+                            ) {
+                                Ok(syms) => syms,
+                                Err(_) => continue,
+                            };
                         self.handle_request_updates(
                             service_sym,
                             member_sym,
@@ -891,9 +901,17 @@ impl Manager {
                         member,
                         value,
                     } => {
-                        let listener_def_sym = self.interner.insert(&listener_def);
-                        let source_sym = self.interner.insert(&source_service);
-                        let member_sym = self.interner.insert(&member);
+                        // #24: validate + intern wire names through codec; skip
+                        // the message if any identifier fails validation.
+                        let (listener_def_sym, source_sym, member_sym) = match codec::decode_update(
+                            &listener_def,
+                            &source_service,
+                            &member,
+                            &mut self.interner,
+                        ) {
+                            Ok(syms) => syms,
+                            Err(_) => continue,
+                        };
                         self.handle_update(
                             ServiceNetId(listener_service),
                             listener_def_sym,

--- a/meerkat-lib/src/runtime/parser/mod.rs
+++ b/meerkat-lib/src/runtime/parser/mod.rs
@@ -36,13 +36,11 @@ pub fn parse_string(input: &str, interner: &mut Interner) -> Result<Vec<Stmt>, S
     let mut lex_stream = Vec::new();
     for (t, span) in lex::Token::lexer(input).spanned() {
         match t {
-            lex::Token::Ident(name) => {
-                if name.len() > MAX_IDENTIFIER_LENGTH {
-                    return Err(format!(
-                        "Parse error: identifier exceeds maximum length of {} characters",
-                        MAX_IDENTIFIER_LENGTH
-                    ));
-                }
+            lex::Token::Ident(name) if name.len() > MAX_IDENTIFIER_LENGTH => {
+                return Err(format!(
+                    "Parse error: identifier exceeds maximum length of {} characters",
+                    MAX_IDENTIFIER_LENGTH
+                ));
             }
             lex::Token::StrLit(val) if val.len() > MAX_STRING_LITERAL_LENGTH => {
                 return Err(format!(
@@ -95,13 +93,11 @@ pub fn parse_repl(input: &str, interner: &mut Interner) -> ReplParseResult {
     let mut lex_stream = Vec::new();
     for (t, span) in lex::Token::lexer(input).spanned() {
         match t {
-            lex::Token::Ident(name) => {
-                if name.len() > MAX_IDENTIFIER_LENGTH {
-                    return ReplParseResult::Error(format!(
-                        "Parse error: identifier exceeds maximum length of {} characters",
-                        MAX_IDENTIFIER_LENGTH
-                    ));
-                }
+            lex::Token::Ident(name) if name.len() > MAX_IDENTIFIER_LENGTH => {
+                return ReplParseResult::Error(format!(
+                    "Parse error: identifier exceeds maximum length of {} characters",
+                    MAX_IDENTIFIER_LENGTH
+                ));
             }
             lex::Token::StrLit(val) if val.len() > MAX_STRING_LITERAL_LENGTH => {
                 return ReplParseResult::Error(format!(

--- a/meerkat-lib/src/runtime/semantic_analysis/var_analysis/read_write.rs
+++ b/meerkat-lib/src/runtime/semantic_analysis/var_analysis/read_write.rs
@@ -3,6 +3,73 @@ use crate::runtime::interner::Symbol;
 use std::collections::HashSet;
 
 impl Expr {
+    /// Collect every cross-service reference `(service, member)` appearing
+    /// anywhere in this expression. Counterpart to `free_var`, which drops
+    /// `MemberAccess`; issue #24 needs these to know which remote members a
+    /// def must subscribe to. Symbols are interner-local, resolved to strings
+    /// only at the network boundary.
+    pub fn cross_service_deps(&self) -> HashSet<(Symbol, Symbol)> {
+        match self {
+            Expr::Literal { .. } | Expr::Table { .. } | Expr::Variable { .. } => HashSet::new(),
+            Expr::MemberAccess {
+                service_name,
+                member_name,
+            } => HashSet::from([(*service_name, *member_name)]),
+            Expr::KeyVal { value, .. } => value.cross_service_deps(),
+            Expr::Tuple { val } => {
+                let mut deps = HashSet::new();
+                for item in val {
+                    deps.extend(item.cross_service_deps());
+                }
+                deps
+            }
+            Expr::Unop { expr, .. } => expr.cross_service_deps(),
+            Expr::Binop { expr1, expr2, .. } => {
+                let mut deps = expr1.cross_service_deps();
+                deps.extend(expr2.cross_service_deps());
+                deps
+            }
+            Expr::If { cond, expr1, expr2 } => {
+                let mut deps = cond.cross_service_deps();
+                deps.extend(expr1.cross_service_deps());
+                deps.extend(expr2.cross_service_deps());
+                deps
+            }
+            Expr::Func { body, .. } => body.cross_service_deps(),
+            Expr::Call { func, args } => {
+                let mut deps = func.cross_service_deps();
+                for arg in args {
+                    deps.extend(arg.cross_service_deps());
+                }
+                deps
+            }
+            Expr::Action(stmts) => {
+                let mut deps = HashSet::new();
+                for stmt in stmts {
+                    match stmt {
+                        ActionStmt::Let { expr, .. } => deps.extend(expr.cross_service_deps()),
+                        ActionStmt::Expr(expr) => deps.extend(expr.cross_service_deps()),
+                        ActionStmt::Do(expr) => deps.extend(expr.cross_service_deps()),
+                        ActionStmt::Assert(expr, _) => deps.extend(expr.cross_service_deps()),
+                        ActionStmt::Assign { expr, .. } => deps.extend(expr.cross_service_deps()),
+                        ActionStmt::Insert { row, .. } => deps.extend(row.cross_service_deps()),
+                    }
+                }
+                deps
+            }
+            Expr::Select { where_clause, .. } => where_clause.cross_service_deps(),
+            Expr::Fold {
+                operation,
+                identity,
+                ..
+            } => {
+                let mut deps = operation.cross_service_deps();
+                deps.extend(identity.cross_service_deps());
+                deps
+            }
+        }
+    }
+
     /// Returns the free variables in `self` with respect to `var_binded`
     ///
     /// This is used for:

--- a/meerkat-lib/src/runtime/semantic_analysis/var_analysis/read_write.rs
+++ b/meerkat-lib/src/runtime/semantic_analysis/var_analysis/read_write.rs
@@ -10,7 +10,10 @@ impl Expr {
     /// only at the network boundary.
     pub fn cross_service_deps(&self) -> HashSet<(Symbol, Symbol)> {
         match self {
-            Expr::Literal { .. } | Expr::Table { .. } | Expr::Variable { .. } => HashSet::new(),
+            Expr::Literal { .. } | Expr::Variable { .. } => HashSet::new(),
+            // Tables are not yet supported in cross-service dependency analysis;
+            // they carry no MemberAccess today, so an empty set is correct for now.
+            Expr::Table { .. } => HashSet::new(),
             Expr::MemberAccess {
                 service_name,
                 member_name,

--- a/meerkat/src/main.rs
+++ b/meerkat/src/main.rs
@@ -603,6 +603,8 @@ async fn run_watch(
             .replace("0.0.0.0", &node_ip)
             .replace("127.0.0.1", &node_ip);
         manager.set_local_address(format!("{}/p2p/{}", addr_str, peer_id));
+    } else {
+        return Err("Failed to start network listener in watch mode".into());
     }
     manager.network = Some(net);
 

--- a/meerkat/src/main.rs
+++ b/meerkat/src/main.rs
@@ -515,6 +515,41 @@ async fn run_server(
                     // abort just released.
                     wake_ready(&mut manager, freed).await;
                 }
+                MeerkatMessage::RequestUpdates {
+                    service,
+                    member,
+                    listener_service,
+                    listener_def,
+                    reply_to,
+                    ..
+                } => {
+                    manager
+                        .handle_request_updates(
+                            service,
+                            member,
+                            listener_service,
+                            listener_def,
+                            reply_to,
+                        )
+                        .await;
+                }
+                MeerkatMessage::Update {
+                    listener_service,
+                    listener_def,
+                    source_service,
+                    member,
+                    value,
+                } => {
+                    manager
+                        .handle_update(
+                            listener_service,
+                            listener_def,
+                            source_service,
+                            member,
+                            value,
+                        )
+                        .await;
+                }
                 MeerkatMessage::Ping { .. }
                 | MeerkatMessage::Pong { .. }
                 | MeerkatMessage::Announce { .. }

--- a/meerkat/src/main.rs
+++ b/meerkat/src/main.rs
@@ -529,9 +529,18 @@ async fn run_server(
                     reply_to,
                     ..
                 } => {
-                    let service_sym = manager.interner.insert(&service);
-                    let member_sym = manager.interner.insert(&member);
-                    let listener_def_sym = manager.interner.insert(&listener_def);
+                    // #24: validate + intern wire names through codec (the sole
+                    // interning authority for network data); skip on bad input.
+                    let (service_sym, member_sym, listener_def_sym) =
+                        match codec::decode_request_updates(
+                            &service,
+                            &member,
+                            &listener_def,
+                            &mut manager.interner,
+                        ) {
+                            Ok(syms) => syms,
+                            Err(_) => continue,
+                        };
                     manager
                         .handle_request_updates(
                             service_sym,
@@ -549,9 +558,16 @@ async fn run_server(
                     member,
                     value,
                 } => {
-                    let listener_def_sym = manager.interner.insert(&listener_def);
-                    let source_sym = manager.interner.insert(&source_service);
-                    let member_sym = manager.interner.insert(&member);
+                    // #24: validate + intern wire names through codec; skip on bad input.
+                    let (listener_def_sym, source_sym, member_sym) = match codec::decode_update(
+                        &listener_def,
+                        &source_service,
+                        &member,
+                        &mut manager.interner,
+                    ) {
+                        Ok(syms) => syms,
+                        Err(_) => continue,
+                    };
                     manager
                         .handle_update(
                             ServiceNetId(listener_service),
@@ -713,9 +729,16 @@ async fn run_client(
                     println!("[update] {}.{} = {:?}", source_service, member, parsed);
                 }
                 let lid = ServiceNetId(listener_service);
-                let def_sym = manager.interner.insert(&listener_def);
-                let source_sym = manager.interner.insert(&source_service);
-                let member_sym = manager.interner.insert(&member);
+                // #24: validate + intern wire names through codec; skip on bad input.
+                let (def_sym, source_sym, member_sym) = match codec::decode_update(
+                    &listener_def,
+                    &source_service,
+                    &member,
+                    &mut manager.interner,
+                ) {
+                    Ok(syms) => syms,
+                    Err(_) => continue,
+                };
                 manager
                     .handle_update(lid.clone(), def_sym, source_sym, member_sym, value)
                     .await;

--- a/meerkat/src/main.rs
+++ b/meerkat/src/main.rs
@@ -107,10 +107,8 @@ pub async fn main() -> Result<(), Box<dyn Error>> {
 
             if args.server {
                 run_server(prog, remote_url_map, args.port, args.local, interner).await
-            } else if args.watch {
-                run_watch(prog, file, remote_url_map, args.local, interner).await
             } else {
-                run_client(prog, file, remote_url_map, args.local, interner).await
+                run_client(prog, file, remote_url_map, args.local, args.watch, interner).await
             }
         }
         None => {
@@ -531,12 +529,15 @@ async fn run_server(
                     reply_to,
                     ..
                 } => {
+                    let service_sym = manager.interner.insert(&service);
+                    let member_sym = manager.interner.insert(&member);
+                    let listener_def_sym = manager.interner.insert(&listener_def);
                     manager
                         .handle_request_updates(
-                            service,
-                            member,
-                            listener_service,
-                            listener_def,
+                            service_sym,
+                            member_sym,
+                            ServiceNetId(listener_service),
+                            listener_def_sym,
                             reply_to,
                         )
                         .await;
@@ -548,12 +549,15 @@ async fn run_server(
                     member,
                     value,
                 } => {
+                    let listener_def_sym = manager.interner.insert(&listener_def);
+                    let source_sym = manager.interner.insert(&source_service);
+                    let member_sym = manager.interner.insert(&member);
                     manager
                         .handle_update(
-                            listener_service,
-                            listener_def,
-                            source_service,
-                            member,
+                            ServiceNetId(listener_service),
+                            listener_def_sym,
+                            source_sym,
+                            member_sym,
                             value,
                         )
                         .await;
@@ -576,140 +580,22 @@ async fn run_server(
     }
 }
 
-async fn run_watch(
-    prog: Vec<Stmt>,
-    input_file: &str,
-    remote_url_map: std::collections::HashMap<String, String>,
-    local: bool,
-    interner: Interner,
-) -> Result<(), Box<dyn Error>> {
-    let mut manager = Manager::new(interner);
-    manager.local = local;
-
-    // Watch mode always needs the network to receive notifications.
-    let mut net = NetworkActor::new(NodeType::Server)
-        .await
-        .map_err(|e| format!("Network error: {}", e))?;
-    let listen_ip = if local { "127.0.0.1" } else { "0.0.0.0" };
-    let listen_addr = Address::new(format!("/ip4/{}/tcp/0", listen_ip));
-    let reply = net
-        .handle_command(NetworkCommand::Listen { addr: listen_addr })
-        .await;
-    if let NetworkReply::ListenSuccess { addr } = reply {
-        let node_ip = manager.get_node_ip();
-        let peer_id = net.local_peer_id();
-        let addr_str = addr
-            .0
-            .replace("0.0.0.0", &node_ip)
-            .replace("127.0.0.1", &node_ip);
-        manager.set_local_address(format!("{}/p2p/{}", addr_str, peer_id));
-    } else {
-        return Err("Failed to start network listener in watch mode".into());
-    }
-    manager.network = Some(net);
-
-    // Set up services: Import registers remotes, Service create_service subscribes
-    // to its cross-service deps.
-    for stmt in &prog {
-        match *stmt {
-            Stmt::Import {
-                ref path,
-                service_name,
-            } => {
-                if let Some(url) = remote_url_map.get(manager.interner.get(service_name)) {
-                    manager
-                        .remote_services
-                        .insert(service_name, Address::new(url.as_str()));
-                    println!(
-                        "Remote service '{}' registered at {}",
-                        manager.interner.get(service_name),
-                        url
-                    );
-                } else {
-                    let base_dir = std::path::Path::new(input_file)
-                        .parent()
-                        .unwrap_or(std::path::Path::new("."));
-                    let import_path = base_dir.join(path);
-                    let import_stmts =
-                        parser::parse_file(import_path.to_str().unwrap(), &mut manager.interner)
-                            .map_err(|e| format!("Import parse error: {}", e))?;
-                    for import_stmt in &import_stmts {
-                        if let Stmt::Service { name, ref decls } = *import_stmt {
-                            manager
-                                .create_service(name, decls.clone())
-                                .await
-                                .map_err(|e| format!("Import service error: {}", e))?;
-                        }
-                    }
-                }
-            }
-            Stmt::Service { name, ref decls } => {
-                manager
-                    .create_service(name, decls.clone())
-                    .await
-                    .map_err(|e| format!("Service error: {}", e))?;
-                println!("Service '{}' loaded", manager.interner.get(name));
-            }
-            _ => {}
-        }
-    }
-
-    println!("Watching for changes, press Ctrl+C to stop...");
-    loop {
-        let msg = manager
-            .network
-            .as_mut()
-            .and_then(|n| n.try_recv_event())
-            .and_then(|ev| match ev {
-                NetworkEvent::MessageReceived { msg, .. } => Some(msg),
-                _ => None,
-            });
-        if let Some(MeerkatMessage::Update {
-            listener_service,
-            listener_def,
-            source_service,
-            member,
-            value,
-        }) = msg
-        {
-            if let Ok(parsed) = codec::decode_value(value.clone(), &mut manager.interner) {
-                println!("[update] {}.{} = {:?}", source_service, member, parsed);
-            }
-            manager
-                .handle_update(
-                    listener_service.clone(),
-                    listener_def.clone(),
-                    source_service,
-                    member,
-                    value,
-                )
-                .await;
-            let lid = ServiceNetId(listener_service);
-            let def_sym = manager.interner.insert(&listener_def);
-            if let Some((_, svc)) = manager.services.iter().find(|(_, s)| s.id == lid) {
-                if let Some(vs) = svc.vars.get(&def_sym) {
-                    println!("          -> {} = {:?}", listener_def, vs.value);
-                }
-            }
-        }
-        tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
-    }
-}
-
 async fn run_client(
     prog: Vec<Stmt>,
     input_file: &str,
     remote_url_map: std::collections::HashMap<String, String>,
     local: bool,
+    watch: bool,
     interner: Interner,
 ) -> Result<(), Box<dyn Error>> {
     let mut manager = Manager::new(interner);
     manager.local = local;
 
-    // Start network if we have remote imports
+    // Start the network if we have remote imports, or always in watch mode
+    // (watch needs the network to receive change notifications).
     let mut net: Option<NetworkActor> = None;
     let mut local_full_addr: Option<String> = None;
-    if !remote_url_map.is_empty() {
+    if watch || !remote_url_map.is_empty() {
         let mut n = NetworkActor::new(NodeType::Server)
             .await
             .map_err(|e| format!("Network error: {}", e))?;
@@ -752,17 +638,20 @@ async fn run_client(
                 service_name,
                 ref stmts,
             } => {
-                manager
-                    .execute_action(service_name, stmts)
-                    .await
-                    .map_err(|e| {
-                        format!(
-                            "Test failed in '{}': {}",
-                            manager.interner.get(service_name),
-                            e
-                        )
-                    })?;
-                println!("@test({}) passed", manager.interner.get(service_name));
+                // Watch mode only observes; it does not run @test actions.
+                if !watch {
+                    manager
+                        .execute_action(service_name, stmts)
+                        .await
+                        .map_err(|e| {
+                            format!(
+                                "Test failed in '{}': {}",
+                                manager.interner.get(service_name),
+                                e
+                            )
+                        })?;
+                    println!("@test({}) passed", manager.interner.get(service_name));
+                }
             }
             &Stmt::Import {
                 ref path,
@@ -798,6 +687,45 @@ async fn run_client(
             }
             &Stmt::ActionStmt(_) => {}
             &Stmt::Update { .. } | &Stmt::Connect { .. } | &Stmt::Watch { .. } => {}
+        }
+    }
+
+    if watch {
+        println!("Watching for changes, press Ctrl+C to stop...");
+        loop {
+            let msg = manager
+                .network
+                .as_mut()
+                .and_then(|n| n.try_recv_event())
+                .and_then(|ev| match ev {
+                    NetworkEvent::MessageReceived { msg, .. } => Some(msg),
+                    _ => None,
+                });
+            if let Some(MeerkatMessage::Update {
+                listener_service,
+                listener_def,
+                source_service,
+                member,
+                value,
+            }) = msg
+            {
+                if let Ok(parsed) = codec::decode_value(value.clone(), &mut manager.interner) {
+                    println!("[update] {}.{} = {:?}", source_service, member, parsed);
+                }
+                let lid = ServiceNetId(listener_service);
+                let def_sym = manager.interner.insert(&listener_def);
+                let source_sym = manager.interner.insert(&source_service);
+                let member_sym = manager.interner.insert(&member);
+                manager
+                    .handle_update(lid.clone(), def_sym, source_sym, member_sym, value)
+                    .await;
+                if let Some((_, svc)) = manager.services.iter().find(|(_, s)| s.id == lid) {
+                    if let Some(vs) = svc.vars.get(&def_sym) {
+                        println!("          -> {} = {:?}", listener_def, vs.value);
+                    }
+                }
+            }
+            tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
         }
     }
 

--- a/meerkat/src/main.rs
+++ b/meerkat/src/main.rs
@@ -48,6 +48,11 @@ struct Args {
     /// Emit AST to `stdout`
     #[arg(long = "ast", default_value_t = false)]
     ast: bool,
+
+    /// Watch mode: subscribe to cross-service dependencies and print change
+    /// notifications asynchronously as they arrive (issue #24)
+    #[arg(long = "watch", default_value_t = false)]
+    watch: bool,
 }
 
 #[tokio::main]
@@ -102,14 +107,17 @@ pub async fn main() -> Result<(), Box<dyn Error>> {
 
             if args.server {
                 run_server(prog, remote_url_map, args.port, args.local, interner).await
+            } else if args.watch {
+                run_watch(prog, file, remote_url_map, args.local, interner).await
             } else {
                 run_client(prog, file, remote_url_map, args.local, interner).await
             }
         }
         None => {
-            if args.server || args.check_only || args.ast {
+            if args.server || args.check_only || args.ast || args.watch {
                 return Err(
-                    "Expected a .mkt file (-f) for --server, --check, or --ast mode.".into(),
+                    "Expected a .mkt file (-f) for --server, --check, --ast, or --watch mode."
+                        .into(),
                 );
             }
             let mut manager = Manager::new(interner);
@@ -564,6 +572,124 @@ async fn run_server(
             }
         }
 
+        tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
+    }
+}
+
+async fn run_watch(
+    prog: Vec<Stmt>,
+    input_file: &str,
+    remote_url_map: std::collections::HashMap<String, String>,
+    local: bool,
+    interner: Interner,
+) -> Result<(), Box<dyn Error>> {
+    let mut manager = Manager::new(interner);
+    manager.local = local;
+
+    // Watch mode always needs the network to receive notifications.
+    let mut net = NetworkActor::new(NodeType::Server)
+        .await
+        .map_err(|e| format!("Network error: {}", e))?;
+    let listen_ip = if local { "127.0.0.1" } else { "0.0.0.0" };
+    let listen_addr = Address::new(format!("/ip4/{}/tcp/0", listen_ip));
+    let reply = net
+        .handle_command(NetworkCommand::Listen { addr: listen_addr })
+        .await;
+    if let NetworkReply::ListenSuccess { addr } = reply {
+        let node_ip = manager.get_node_ip();
+        let peer_id = net.local_peer_id();
+        let addr_str = addr
+            .0
+            .replace("0.0.0.0", &node_ip)
+            .replace("127.0.0.1", &node_ip);
+        manager.set_local_address(format!("{}/p2p/{}", addr_str, peer_id));
+    }
+    manager.network = Some(net);
+
+    // Set up services: Import registers remotes, Service create_service subscribes
+    // to its cross-service deps.
+    for stmt in &prog {
+        match *stmt {
+            Stmt::Import {
+                ref path,
+                service_name,
+            } => {
+                if let Some(url) = remote_url_map.get(manager.interner.get(service_name)) {
+                    manager
+                        .remote_services
+                        .insert(service_name, Address::new(url.as_str()));
+                    println!(
+                        "Remote service '{}' registered at {}",
+                        manager.interner.get(service_name),
+                        url
+                    );
+                } else {
+                    let base_dir = std::path::Path::new(input_file)
+                        .parent()
+                        .unwrap_or(std::path::Path::new("."));
+                    let import_path = base_dir.join(path);
+                    let import_stmts =
+                        parser::parse_file(import_path.to_str().unwrap(), &mut manager.interner)
+                            .map_err(|e| format!("Import parse error: {}", e))?;
+                    for import_stmt in &import_stmts {
+                        if let Stmt::Service { name, ref decls } = *import_stmt {
+                            manager
+                                .create_service(name, decls.clone())
+                                .await
+                                .map_err(|e| format!("Import service error: {}", e))?;
+                        }
+                    }
+                }
+            }
+            Stmt::Service { name, ref decls } => {
+                manager
+                    .create_service(name, decls.clone())
+                    .await
+                    .map_err(|e| format!("Service error: {}", e))?;
+                println!("Service '{}' loaded", manager.interner.get(name));
+            }
+            _ => {}
+        }
+    }
+
+    println!("Watching for changes, press Ctrl+C to stop...");
+    loop {
+        let msg = manager
+            .network
+            .as_mut()
+            .and_then(|n| n.try_recv_event())
+            .and_then(|ev| match ev {
+                NetworkEvent::MessageReceived { msg, .. } => Some(msg),
+                _ => None,
+            });
+        if let Some(MeerkatMessage::Update {
+            listener_service,
+            listener_def,
+            source_service,
+            member,
+            value,
+        }) = msg
+        {
+            if let Ok(parsed) = codec::decode_value(value.clone(), &mut manager.interner) {
+                println!("[update] {}.{} = {:?}", source_service, member, parsed);
+            }
+            manager
+                .handle_update(
+                    listener_service.clone(),
+                    listener_def.clone(),
+                    source_service,
+                    member,
+                    value,
+                )
+                .await;
+            let lid = ServiceNetId(listener_service);
+            let def_sym = manager.interner.insert(&listener_def);
+            if let Some((_, svc)) = manager.services.iter().find(|(_, s)| s.id == lid) {
+                if let Some(vs) = svc.vars.get(&def_sym) {
+                    println!("          -> {} = {:?}", listener_def, vs.value);
+                }
+            }
+        }
         tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
     }
 }


### PR DESCRIPTION
Replaces the polling Manager::propagate with push-based change notifications, per the Historiographer "Simple protocol", closing #24. When a def initializes, it registers as a listener on the members it depends on; when a member changes, the manager notifies each listener (local in-process, remote over the wire); the listener recomputes from cached dependency values without a round-trip.

**Changes made**
- Expr::cross_service_deps extracts the (service, member) references a def depends on (the counterpart to free_var, which drops MemberAccess).
- Service gains listeners, dep_cache, and dep_remote; create_service registers same-service listeners (dep_graph) and cross-service ones (local owners in-process, remote owners via subscribe).
- propagate is rewritten as a (service, member) worklist over the listener graph, replacing the topo-scan recompute.
- New RequestUpdates / Update messages, with handle_request_updates (owner registers a listener and replies with the current value) and handle_update (listener caches the value and recomputes).
- A transient reactive cache on Manager: MemberAccess resolves from cache during a recompute, so a change does not trigger a fresh lookup.
- A --watch CLI flag that prints change notifications as they arrive, for every dependency, without a REPL.

**Design notes**
Symbols are interner-local, so the wire carries names as strings (interned on receipt) and values via the existing NetValue codec. A listener identifies itself by its globally-unique ServiceNetId, which the owner echoes back so the listener can match it to a local service.

**Testing**
- Unit tests (75 lib, 10 integration green): cross-service dep extraction, eager cross-service cascade, handle_update recompute-from-cache (asserts 12 from the cached push rather than 4 from a local lookup, proving no round-trip), and listener registration.
- Manual three-terminal demo with s1.mkt / test_client.mkt: an s1 server, a --watch client on s2, and a trigger client invoking s1.inc_x. The watcher prints the s1.y change and the recomputed z over the wire.
- Honest gap: the wire path is covered by the manual demo plus manager-level unit tests, not yet by an automated two-node integration test in CI. Happy to add one if preferred.

**Follow-ups**

- A def that references a remote action member (here inc_delegate references s1.inc_x) also subscribes to that action member, so the watcher prints one extra initial notification for it. An action closure never changes, so this is noise rather than a correctness issue; filtering action members at registration would remove it.
- A one-shot client that subscribes and then exits leaves a stale listener address on the owner. Dropping listeners on send failure or disconnect is a reasonable follow-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `--watch` mode to monitor distributed reactive changes and continuously print updated listener values.
  * Introduced subscription-style cross-service listener updates to enable eager recomputation and remote propagation when members change.

* **Performance**
  * Improved member-access evaluation during reactive recomputation by using a short-lived cache to reduce redundant resolutions.

* **Behavior/UX**
  * Updated networking to support listener subscription requests and pushed update delivery, while keeping watched listener values current.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->