### PR TITLE
feat: type annotations, representation, and serialization

### DIFF
--- a/meerkat-lib/src/net/ast.rs
+++ b/meerkat-lib/src/net/ast.rs
@@ -10,38 +10,64 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct NetField {
     pub name: String,
-    pub ty: NetDataType,
+    pub ty: NetTableType,
+}
+
+/// Network representation of a type in the Meerkat language
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub enum NetType {
+    Int,
+    String,
+    Bool,
+    Unit,
+    Tuple(Vec<NetType>),
+    Func(Box<NetType>, Box<NetType>),
+}
+
+/// Network representation of a function parameter
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub struct NetParam {
+    pub name: String,
+    pub ty: Option<NetType>,
 }
 
 /// Network representation of an action statement
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum NetActionStmt {
-    /// Bind a value to a local name using `let`
-    Let { name: String, expr: NetExpr },
-    /// A standalone expression statement
+    Let {
+        name: String,
+        ty: Option<NetType>,
+        expr: NetExpr,
+    },
     Expr(NetExpr),
-    /// A `do` statement to evaluate an expression for side effects
     Do(NetExpr),
     /// An `assert` statement to check invariants
     ///
     /// The `String` parameter captures the exact raw source
     /// string of the assertion condition for error reporting
     Assert(NetExpr, String),
-    /// Re-assign a value to an existing variable
-    Assign { name: String, expr: NetExpr },
-    /// Insert a record into a table
-    Insert { row: NetExpr, table_name: String },
+    Assign {
+        name: String,
+        expr: NetExpr,
+    },
+    Insert {
+        row: NetExpr,
+        table_name: String,
+    },
 }
 
 /// Network representation of a value
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum NetValue {
-    /// A numeric integer value
-    Number { val: i32 },
-    /// A boolean value
-    Bool { val: bool },
-    /// A `String` literal value
-    String { val: String },
+    Int {
+        val: i32,
+    },
+    Bool {
+        val: bool,
+    },
+    String {
+        val: String,
+    },
     /// A standard closure value with environment
     Closure {
         params: Vec<String>,
@@ -60,57 +86,55 @@ pub enum NetValue {
 /// Network representation of an expression
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum NetExpr {
-    /// Literal constant value
-    Literal { val: NetValue },
-    /// Variable reference
-    Variable { name: String },
-    /// Tuple construct containing elements
-    Tuple { val: Vec<NetExpr> },
-    /// Key-value attribute binding
-    KeyVal { name: String, value: Box<NetExpr> },
-    /// Unary operator application
-    Unop { op: NetUnOp, expr: Box<NetExpr> },
-    /// Binary operator application
+    Literal {
+        val: NetValue,
+    },
+    Variable {
+        name: String,
+    },
+    Tuple {
+        val: Vec<NetExpr>,
+    },
+    KeyVal {
+        name: String,
+        value: Box<NetExpr>,
+    },
+    Unop {
+        op: NetUnOp,
+        expr: Box<NetExpr>,
+    },
     Binop {
         op: NetBinOp,
         expr1: Box<NetExpr>,
         expr2: Box<NetExpr>,
     },
-    /// Conditional branching expression
     If {
         cond: Box<NetExpr>,
         expr1: Box<NetExpr>,
         expr2: Box<NetExpr>,
     },
-    /// Anonymous function construct
     Func {
-        params: Vec<String>,
+        params: Vec<NetParam>,
         body: Box<NetExpr>,
     },
-    /// Function call expression
     Call {
         func: Box<NetExpr>,
         args: Vec<NetExpr>,
     },
-    /// Embedded action statement block
     Action(Vec<NetActionStmt>),
-    /// Accessing a remote service member
     MemberAccess {
         service_name: String,
         member_name: String,
     },
-    /// Data selection query
     Select {
         table_name: String,
         column_names: Vec<String>,
         where_clause: Box<NetExpr>,
     },
-    /// Inline table structure
     Table {
         schema: Vec<NetField>,
         records: Vec<NetExpr>,
     },
-    /// Fold aggregation construct
     Fold {
         table_name: String,
         column_name: String,
@@ -122,51 +146,34 @@ pub enum NetExpr {
 /// Network representation of a unary operator
 ///
 /// This enum defines the serialized unary operators mapped from the
-/// runtime counterparts for transmission over the network
+/// counterparts for transmission over the network
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 pub enum NetUnOp {
-    /// Negation operator
     Neg,
-    /// Logical negation operator
     Not,
 }
 
 /// Network representation of a binary operator
 ///
 /// This enum defines the serialized binary operators mapped from the
-/// runtime counterparts for transmission over the network
+/// counterparts for transmission over the network
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 pub enum NetBinOp {
-    /// Addition operator
     Add,
-    /// Subtraction operator
     Sub,
-    /// Multiplication operator
     Mul,
-    /// Division operator
     Div,
-    /// Equality comparison operator
     Eq,
-    /// Less-than comparison operator
     Lt,
-    /// Greater-than comparison operator
     Gt,
-    /// Logical conjunction operator
     And,
-    /// Logical disjunction operator
     Or,
 }
 
-/// Network representation of a data type
-///
-/// This enum defines the serialized data types mapped from the
-/// runtime counterparts for transmission over the network
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub enum NetDataType {
-    /// String data type representation
+/// Network representation of a table field data type
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub enum NetTableType {
+    Int,
     String,
-    /// Number data type representation
-    Number,
-    /// Boolean data type representation
     Bool,
 }

--- a/meerkat-lib/src/net/ast.rs
+++ b/meerkat-lib/src/net/ast.rs
@@ -70,10 +70,15 @@ pub enum NetValue {
     },
     /// A standard closure value with environment
     Closure {
-        params: Vec<String>,
+        params: Vec<NetParam>,
         body: Box<NetExpr>,
         env: Vec<(String, NetValue)>,
         service_name: String,
+        /// Important: `None` indicates missing type information, not the
+        /// `unit` type. In practice, the return types for closures should
+        /// generally be `Some` type; however, this was left as an `Option`
+        /// for now for maximum flexibility as development continues.
+        return_ty: Option<NetType>,
     },
     /// An action closure value with environment and network ID
     ActionClosure {
@@ -116,6 +121,7 @@ pub enum NetExpr {
     Func {
         params: Vec<NetParam>,
         body: Box<NetExpr>,
+        return_ty: Option<NetType>,
     },
     Call {
         func: Box<NetExpr>,

--- a/meerkat-lib/src/net/codec.rs
+++ b/meerkat-lib/src/net/codec.rs
@@ -57,9 +57,7 @@ fn encode_type_internal(ty: &Type, depth: usize) -> Result<NetType> {
         Type::Bool => Ok(NetType::Bool),
         Type::Unit => Ok(NetType::Unit),
         Type::Tuple(ts) => {
-            if ts.len() < 2 {
-                return Err(Error::Message(format!("invalid tuple arity: {}", ts.len())));
-            }
+            debug_assert!(ts.len() >= 2);
             let mut encoded_ts = Vec::new();
             for t in ts.iter() {
                 encoded_ts.push(encode_type_internal(t, depth + 1)?);
@@ -167,10 +165,7 @@ pub fn decode_type(ty: NetType) -> Result<Type> {
 pub fn encode_param(param: &Param, interner: &Interner) -> Result<NetParam> {
     let name_str = interner.get(param.name);
     validate_identifier(name_str)?;
-    let ty = match &param.ty {
-        Some(t) => Some(encode_type(t)?),
-        None => None,
-    };
+    let ty = param.ty.as_ref().map(encode_type).transpose()?;
     Ok(NetParam {
         name: name_str.to_string(),
         ty,
@@ -188,10 +183,7 @@ pub fn encode_param(param: &Param, interner: &Interner) -> Result<NetParam> {
 ///     `Result<Param>`: The decoded runtime parameter
 pub fn decode_param(param: NetParam, interner: &mut Interner) -> Result<Param> {
     validate_identifier(&param.name)?;
-    let ty = match param.ty {
-        Some(t) => Some(decode_type(t)?),
-        None => None,
-    };
+    let ty = param.ty.map(decode_type).transpose()?;
     Ok(Param {
         name: interner.insert(&param.name),
         ty,
@@ -234,10 +226,7 @@ pub fn encode_value(val: &Value, interner: &Interner) -> Result<NetValue> {
             }
             let service_str = interner.get(*service_name);
             validate_identifier(service_str)?;
-            let encoded_return_ty = match return_ty {
-                Some(t) => Some(encode_type(t)?),
-                None => None,
-            };
+            let encoded_return_ty = return_ty.as_ref().map(encode_type).transpose()?;
             Ok(NetValue::Closure {
                 params: encoded_params,
                 body: encoded_body,
@@ -305,10 +294,7 @@ pub fn decode_value(val: NetValue, interner: &mut Interner) -> Result<Value> {
             }
             validate_identifier(&service_name)?;
             let decoded_service = interner.insert(&service_name);
-            let decoded_return_ty = match return_ty {
-                Some(t) => Some(decode_type(t)?),
-                None => None,
-            };
+            let decoded_return_ty = return_ty.map(decode_type).transpose()?;
             Ok(Value::Closure {
                 params: decoded_params,
                 body: decoded_body,
@@ -399,10 +385,7 @@ pub fn encode_expr(expr: &Expr, interner: &Interner) -> Result<NetExpr> {
                 encoded_params.push(encode_param(p, interner)?);
             }
             let encoded_body = Box::new(encode_expr(body, interner)?);
-            let encoded_return_ty = match return_ty {
-                Some(t) => Some(encode_type(t)?),
-                None => None,
-            };
+            let encoded_return_ty = return_ty.as_ref().map(encode_type).transpose()?;
             Ok(NetExpr::Func {
                 params: encoded_params,
                 body: encoded_body,
@@ -550,10 +533,7 @@ pub fn decode_expr(expr: NetExpr, interner: &mut Interner) -> Result<Expr> {
                 decoded_params.push(decode_param(p, interner)?);
             }
             let decoded_body = Box::new(decode_expr(*body, interner)?);
-            let decoded_return_ty = match return_ty {
-                Some(t) => Some(decode_type(t)?),
-                None => None,
-            };
+            let decoded_return_ty = return_ty.map(decode_type).transpose()?;
             Ok(Expr::Func {
                 params: decoded_params,
                 body: decoded_body,
@@ -654,10 +634,7 @@ pub fn encode_action_stmt(stmt: &ActionStmt, interner: &Interner) -> Result<NetA
         ActionStmt::Let { name, ty, expr } => {
             let name_str = interner.get(*name);
             validate_identifier(name_str)?;
-            let encoded_ty = match ty {
-                Some(t) => Some(encode_type(t)?),
-                None => None,
-            };
+            let encoded_ty = ty.as_ref().map(encode_type).transpose()?;
             Ok(NetActionStmt::Let {
                 name: name_str.to_string(),
                 ty: encoded_ty,
@@ -704,10 +681,7 @@ pub fn decode_action_stmt(stmt: NetActionStmt, interner: &mut Interner) -> Resul
     match stmt {
         NetActionStmt::Let { name, ty, expr } => {
             validate_identifier(&name)?;
-            let decoded_ty = match ty {
-                Some(t) => Some(decode_type(t)?),
-                None => None,
-            };
+            let decoded_ty = ty.map(decode_type).transpose()?;
             Ok(ActionStmt::Let {
                 name: interner.insert(&name),
                 ty: decoded_ty,

--- a/meerkat-lib/src/net/codec.rs
+++ b/meerkat-lib/src/net/codec.rs
@@ -875,7 +875,7 @@ mod tests {
 
         let stmt1 = ActionStmt::Let {
             name: var_x,
-            ty: None,
+            ty: Some(Type::Int),
             expr: Expr::Literal {
                 val: Value::Int { val: 42 },
             },
@@ -927,12 +927,12 @@ mod tests {
         let original_value = Value::Closure {
             params: vec![Param {
                 name: param_name,
-                ty: None,
+                ty: Some(Type::String),
             }],
             body: Box::new(body),
             env: vec![(env_key, env_val)],
             service_name: service,
-            return_ty: None,
+            return_ty: Some(Type::String),
         };
 
         let encoded = encode_value(&original_value, &interner_orig).unwrap();
@@ -1049,12 +1049,12 @@ mod tests {
         let func_expr = Expr::Func {
             params: vec![Param {
                 name: param_name,
-                ty: None,
+                ty: Some(Type::Int),
             }],
             body: Box::new(Expr::Literal {
                 val: Value::Int { val: 9 },
             }),
-            return_ty: None,
+            return_ty: Some(Type::Int),
         };
         run_expr_test(&func_expr, &interner);
 
@@ -1064,12 +1064,12 @@ mod tests {
         let func_expr = Expr::Func {
             params: vec![Param {
                 name: param_name,
-                ty: None,
+                ty: Some(Type::Int),
             }],
             body: Box::new(Expr::Literal {
                 val: Value::Int { val: 9 },
             }),
-            return_ty: None,
+            return_ty: Some(Type::Int),
         };
         let call_expr = Expr::Call {
             func: Box::new(func_expr),

--- a/meerkat-lib/src/net/codec.rs
+++ b/meerkat-lib/src/net/codec.rs
@@ -10,7 +10,7 @@ use crate::net::ast::{
 use crate::runtime::ast::{ActionStmt, BinOp, Expr, Field, TableType, UnOp, Value};
 use crate::runtime::interner::Interner;
 use crate::runtime::limits::{MAX_IDENTIFIER_LENGTH, MAX_STRING_LITERAL_LENGTH, MAX_TYPE_DEPTH};
-use crate::runtime::tt::{Param, Type};
+use crate::runtime::tt::{Param, TupleType, Type};
 
 fn validate_identifier(s: &str) -> Result<()> {
     if s.len() > MAX_IDENTIFIER_LENGTH {
@@ -57,8 +57,11 @@ fn encode_type_internal(ty: &Type, depth: usize) -> Result<NetType> {
         Type::Bool => Ok(NetType::Bool),
         Type::Unit => Ok(NetType::Unit),
         Type::Tuple(ts) => {
+            if ts.len() < 2 {
+                return Err(Error::Message(format!("invalid tuple arity: {}", ts.len())));
+            }
             let mut encoded_ts = Vec::new();
-            for t in ts {
+            for t in ts.iter() {
                 encoded_ts.push(encode_type_internal(t, depth + 1)?);
             }
             Ok(NetType::Tuple(encoded_ts))
@@ -113,11 +116,19 @@ fn decode_type_internal(ty: NetType, depth: usize) -> Result<Type> {
         NetType::Bool => Ok(Type::Bool),
         NetType::Unit => Ok(Type::Unit),
         NetType::Tuple(ts) => {
+            if ts.len() < 2 {
+                return Err(Error::Message(format!(
+                    "invalid network tuple arity: {}",
+                    ts.len()
+                )));
+            }
             let mut decoded_ts = Vec::new();
             for t in ts {
                 decoded_ts.push(decode_type_internal(t, depth + 1)?);
             }
-            Ok(Type::Tuple(decoded_ts))
+            let tuple_type =
+                TupleType::new(decoded_ts).map_err(|e| Error::Message(e.to_string()))?;
+            Ok(Type::Tuple(tuple_type))
         }
         NetType::Func(t1, t2) => {
             let dt1 = decode_type_internal(*t1, depth + 1)?;
@@ -1401,5 +1412,36 @@ mod tests {
         let res = encode_type(&current_type);
         assert!(res.is_err());
         assert!(matches!(res.unwrap_err(), Error::LimitExceeded(_)));
+    }
+
+    /// Verify that `decode_type` rejects invalid network tuple arities
+    #[test]
+    fn test_codec_tuple_invalid_arity_decode() {
+        // Zero elements tuple
+        let zero_tuple = NetType::Tuple(vec![]);
+        let res_zero = decode_type(zero_tuple);
+        assert!(res_zero.is_err());
+        assert!(matches!(res_zero.unwrap_err(), Error::Message(_)));
+
+        // Singleton tuple
+        let singleton_tuple = NetType::Tuple(vec![NetType::Int]);
+        let res_single = decode_type(singleton_tuple);
+        assert!(res_single.is_err());
+        assert!(matches!(res_single.unwrap_err(), Error::Message(_)));
+    }
+
+    /// Verify round-trip encoding and decoding for a valid tuple type
+    #[test]
+    fn test_codec_tuple_valid_roundtrip() {
+        let original_type = Type::Tuple(TupleType::new(vec![Type::Int, Type::String]).unwrap());
+
+        let encoded_type = encode_type(&original_type).unwrap();
+        assert_eq!(
+            encoded_type,
+            NetType::Tuple(vec![NetType::Int, NetType::String])
+        );
+
+        let decoded_type = decode_type(encoded_type).unwrap();
+        assert_eq!(original_type, decoded_type);
     }
 }

--- a/meerkat-lib/src/net/codec.rs
+++ b/meerkat-lib/src/net/codec.rs
@@ -34,12 +34,25 @@ fn validate_string_literal(s: &str) -> Result<()> {
 
 /// Encode a runtime `Type` into a network representation
 ///
+/// Enforces type depth limit to prevent stack-overflow DoS attacks
+///
 /// Args:
 ///     `ty` (`&Type`): The runtime type to encode
+///     `depth` (`usize`): The current recursion depth
 ///
 /// Returns:
 ///     `Result<NetType>`: The encoded network type representation
-pub fn encode_type(ty: &Type) -> Result<NetType> {
+///
+/// Raises:
+///     `Error::LimitExceeded`: The type nesting depth exceeds
+///     maximum limit
+pub fn encode_type(ty: &Type, depth: usize) -> Result<NetType> {
+    if depth > MAX_TYPE_DEPTH {
+        return Err(Error::LimitExceeded(format!(
+            "Type nesting depth exceeds maximum limit of {}",
+            MAX_TYPE_DEPTH
+        )));
+    }
     match ty {
         Type::Int => Ok(NetType::Int),
         Type::String => Ok(NetType::String),
@@ -48,13 +61,13 @@ pub fn encode_type(ty: &Type) -> Result<NetType> {
         Type::Tuple(ts) => {
             let mut encoded_ts = Vec::new();
             for t in ts {
-                encoded_ts.push(encode_type(t)?);
+                encoded_ts.push(encode_type(t, depth + 1)?);
             }
             Ok(NetType::Tuple(encoded_ts))
         }
         Type::Func(t1, t2) => {
-            let et1 = encode_type(t1)?;
-            let et2 = encode_type(t2)?;
+            let et1 = encode_type(t1, depth + 1)?;
+            let et2 = encode_type(t2, depth + 1)?;
             Ok(NetType::Func(Box::new(et1), Box::new(et2)))
         }
     }
@@ -114,7 +127,7 @@ pub fn encode_param(param: &Param, interner: &Interner) -> Result<NetParam> {
     let name_str = interner.get(param.name);
     validate_identifier(name_str)?;
     let ty = match &param.ty {
-        Some(t) => Some(encode_type(t)?),
+        Some(t) => Some(encode_type(t, 0)?),
         None => None,
     };
     Ok(NetParam {
@@ -572,7 +585,7 @@ pub fn encode_action_stmt(stmt: &ActionStmt, interner: &Interner) -> Result<NetA
             let name_str = interner.get(*name);
             validate_identifier(name_str)?;
             let encoded_ty = match ty {
-                Some(t) => Some(encode_type(t)?),
+                Some(t) => Some(encode_type(t, 0)?),
                 None => None,
             };
             Ok(NetActionStmt::Let {
@@ -1279,7 +1292,7 @@ mod tests {
             ty: Some(original_type.clone()),
         };
 
-        let encoded_type = encode_type(&original_type).unwrap();
+        let encoded_type = encode_type(&original_type, 0).unwrap();
         let encoded_param = encode_param(&original_param, &interner_orig).unwrap();
 
         let mut interner_new = Interner::new();
@@ -1301,6 +1314,21 @@ mod tests {
         }
 
         let res = decode_type(current_type, 0);
+        assert!(res.is_err());
+        assert!(matches!(res.unwrap_err(), Error::LimitExceeded(_)));
+    }
+
+    /// Verify that encoding a Type exceeding MAX_TYPE_DEPTH returns
+    /// a limit exceeded error
+    #[test]
+    fn test_codec_encode_type_depth_overflow() {
+        // Construct a Type that exceeds MAX_TYPE_DEPTH (16)
+        let mut current_type = Type::Int;
+        for _ in 0..(MAX_TYPE_DEPTH + 1) {
+            current_type = Type::Func(Box::new(Type::Bool), Box::new(current_type));
+        }
+
+        let res = encode_type(&current_type, 0);
         assert!(res.is_err());
         assert!(matches!(res.unwrap_err(), Error::LimitExceeded(_)));
     }

--- a/meerkat-lib/src/net/codec.rs
+++ b/meerkat-lib/src/net/codec.rs
@@ -4,11 +4,13 @@
 //! `AST` types and the serialized network representation variants
 
 use crate::error::{Error, Result};
-use crate::net::ast::{NetActionStmt, NetBinOp, NetDataType, NetExpr, NetField, NetUnOp, NetValue};
-use crate::runtime::ast::{ActionStmt, BinOp, DataType, Expr, Field, UnOp, Value};
+use crate::net::ast::{
+    NetActionStmt, NetBinOp, NetExpr, NetField, NetParam, NetTableType, NetType, NetUnOp, NetValue,
+};
+use crate::runtime::ast::{ActionStmt, BinOp, Expr, Field, TableType, UnOp, Value};
 use crate::runtime::interner::Interner;
-use crate::runtime::limits::{MAX_IDENTIFIER_LENGTH, MAX_STRING_LITERAL_LENGTH};
-use crate::runtime::tt::Param;
+use crate::runtime::limits::{MAX_IDENTIFIER_LENGTH, MAX_STRING_LITERAL_LENGTH, MAX_TYPE_DEPTH};
+use crate::runtime::tt::{Param, Type};
 
 fn validate_identifier(s: &str) -> Result<()> {
     if s.len() > MAX_IDENTIFIER_LENGTH {
@@ -30,6 +32,118 @@ fn validate_string_literal(s: &str) -> Result<()> {
     Ok(())
 }
 
+/// Encode a runtime `Type` into a network representation
+///
+/// Args:
+///     `ty` (`&Type`): The runtime type to encode
+///
+/// Returns:
+///     `Result<NetType>`: The encoded network type representation
+pub fn encode_type(ty: &Type) -> Result<NetType> {
+    match ty {
+        Type::Int => Ok(NetType::Int),
+        Type::String => Ok(NetType::String),
+        Type::Bool => Ok(NetType::Bool),
+        Type::Unit => Ok(NetType::Unit),
+        Type::Tuple(ts) => {
+            let mut encoded_ts = Vec::new();
+            for t in ts {
+                encoded_ts.push(encode_type(t)?);
+            }
+            Ok(NetType::Tuple(encoded_ts))
+        }
+        Type::Func(t1, t2) => {
+            let et1 = encode_type(t1)?;
+            let et2 = encode_type(t2)?;
+            Ok(NetType::Func(Box::new(et1), Box::new(et2)))
+        }
+    }
+}
+
+/// Decode a network `NetType` representation into a runtime `Type`
+///
+/// Enforces type depth limit to prevent stack-overflow DoS attacks
+///
+/// Args:
+///     `ty` (`NetType`): The network type to decode
+///     `depth` (`usize`): The current recursion depth
+///
+/// Returns:
+///     `Result<Type>`: The decoded runtime type
+///
+/// Raises:
+///     `Error::LimitExceeded`: The type nesting depth exceeds
+///     maximum limit
+pub fn decode_type(ty: NetType, depth: usize) -> Result<Type> {
+    if depth > MAX_TYPE_DEPTH {
+        return Err(Error::LimitExceeded(format!(
+            "Type nesting depth exceeds maximum limit of {}",
+            MAX_TYPE_DEPTH
+        )));
+    }
+    match ty {
+        NetType::Int => Ok(Type::Int),
+        NetType::String => Ok(Type::String),
+        NetType::Bool => Ok(Type::Bool),
+        NetType::Unit => Ok(Type::Unit),
+        NetType::Tuple(ts) => {
+            let mut decoded_ts = Vec::new();
+            for t in ts {
+                decoded_ts.push(decode_type(t, depth + 1)?);
+            }
+            Ok(Type::Tuple(decoded_ts))
+        }
+        NetType::Func(t1, t2) => {
+            let dt1 = decode_type(*t1, depth + 1)?;
+            let dt2 = decode_type(*t2, depth + 1)?;
+            Ok(Type::Func(Box::new(dt1), Box::new(dt2)))
+        }
+    }
+}
+
+/// Encode a runtime `Param` into a network representation
+///
+/// Args:
+///     `param` (`&Param`): The runtime parameter to encode
+///     `interner` (`&Interner`): The interner for symbol lookup
+///
+/// Returns:
+///     `Result<NetParam>`: The encoded network parameter
+///     representation
+pub fn encode_param(param: &Param, interner: &Interner) -> Result<NetParam> {
+    let name_str = interner.get(param.name);
+    validate_identifier(name_str)?;
+    let ty = match &param.ty {
+        Some(t) => Some(encode_type(t)?),
+        None => None,
+    };
+    Ok(NetParam {
+        name: name_str.to_string(),
+        ty,
+    })
+}
+
+/// Decode a network `NetParam` representation into a runtime `Param`
+///
+/// Args:
+///     `param` (`NetParam`): The network parameter to decode
+///     `interner` (`&mut Interner`): The interner for symbol
+///     creation
+///
+/// Returns:
+///     `Result<Param>`: The decoded runtime parameter
+pub fn decode_param(param: NetParam, interner: &mut Interner) -> Result<Param> {
+    validate_identifier(&param.name)?;
+    let ty = match param.ty {
+        Some(t) => Some(decode_type(t, 0)?),
+        None => None,
+    };
+    Ok(Param {
+        name: interner.insert(&param.name),
+        ty,
+    })
+}
+
 /// Encode a runtime `Value` into a network representation
 ///
 /// Args:
@@ -40,7 +154,7 @@ fn validate_string_literal(s: &str) -> Result<()> {
 ///     `Result<NetValue>`: The encoded `NetValue` network representation
 pub fn encode_value(val: &Value, interner: &Interner) -> Result<NetValue> {
     match val {
-        Value::Number { val } => Ok(NetValue::Number { val: *val }),
+        Value::Int { val } => Ok(NetValue::Int { val: *val }),
         Value::Bool { val } => Ok(NetValue::Bool { val: *val }),
         Value::String { val } => {
             validate_string_literal(val)?;
@@ -108,7 +222,7 @@ pub fn encode_value(val: &Value, interner: &Interner) -> Result<NetValue> {
 ///     `Result<Value>`: The decoded runtime `Value`
 pub fn decode_value(val: NetValue, interner: &mut Interner) -> Result<Value> {
     match val {
-        NetValue::Number { val } => Ok(Value::Number { val }),
+        NetValue::Int { val } => Ok(Value::Int { val }),
         NetValue::Bool { val } => Ok(Value::Bool { val }),
         NetValue::String { val } => {
             validate_string_literal(&val)?;
@@ -214,9 +328,7 @@ pub fn encode_expr(expr: &Expr, interner: &Interner) -> Result<NetExpr> {
         Expr::Func { params, body } => {
             let mut encoded_params = Vec::new();
             for p in params {
-                let p_str = interner.get(p.name);
-                validate_identifier(p_str)?;
-                encoded_params.push(p_str.to_string());
+                encoded_params.push(encode_param(p, interner)?);
             }
             let encoded_body = Box::new(encode_expr(body, interner)?);
             Ok(NetExpr::Func {
@@ -356,16 +468,10 @@ pub fn decode_expr(expr: NetExpr, interner: &mut Interner) -> Result<Expr> {
             expr2: Box::new(decode_expr(*expr2, interner)?),
         }),
         NetExpr::Func { params, body } => {
-            for p in &params {
-                validate_identifier(p)?;
+            let mut decoded_params = Vec::new();
+            for p in params {
+                decoded_params.push(decode_param(p, interner)?);
             }
-            let decoded_params = params
-                .into_iter()
-                .map(|p| Param {
-                    name: interner.insert(&p),
-                    ty: None,
-                })
-                .collect();
             let decoded_body = Box::new(decode_expr(*body, interner)?);
             Ok(Expr::Func {
                 params: decoded_params,
@@ -462,11 +568,16 @@ pub fn decode_expr(expr: NetExpr, interner: &mut Interner) -> Result<Expr> {
 ///     `Result<NetActionStmt>`: The encoded `NetActionStmt` network representation
 pub fn encode_action_stmt(stmt: &ActionStmt, interner: &Interner) -> Result<NetActionStmt> {
     match stmt {
-        ActionStmt::Let { name, ty: _, expr } => {
+        ActionStmt::Let { name, ty, expr } => {
             let name_str = interner.get(*name);
             validate_identifier(name_str)?;
+            let encoded_ty = match ty {
+                Some(t) => Some(encode_type(t)?),
+                None => None,
+            };
             Ok(NetActionStmt::Let {
                 name: name_str.to_string(),
+                ty: encoded_ty,
                 expr: encode_expr(expr, interner)?,
             })
         }
@@ -508,11 +619,15 @@ pub fn encode_action_stmt(stmt: &ActionStmt, interner: &Interner) -> Result<NetA
 ///     `Result<ActionStmt>`: The decoded runtime `ActionStmt`
 pub fn decode_action_stmt(stmt: NetActionStmt, interner: &mut Interner) -> Result<ActionStmt> {
     match stmt {
-        NetActionStmt::Let { name, expr } => {
+        NetActionStmt::Let { name, ty, expr } => {
             validate_identifier(&name)?;
+            let decoded_ty = match ty {
+                Some(t) => Some(decode_type(t, 0)?),
+                None => None,
+            };
             Ok(ActionStmt::Let {
                 name: interner.insert(&name),
-                ty: None,
+                ty: decoded_ty,
                 expr: decode_expr(expr, interner)?,
             })
         }
@@ -552,7 +667,7 @@ pub fn encode_field(field: &Field, interner: &Interner) -> Result<NetField> {
     validate_identifier(name_str)?;
     Ok(NetField {
         name: name_str.to_string(),
-        ty: encode_datatype(&field.ty),
+        ty: encode_tabletype(&field.ty),
     })
 }
 
@@ -568,7 +683,7 @@ pub fn decode_field(field: NetField, interner: &mut Interner) -> Result<Field> {
     validate_identifier(&field.name)?;
     Ok(Field {
         name: interner.insert(&field.name),
-        ty: decode_datatype(field.ty),
+        ty: decode_tabletype(field.ty),
     })
 }
 
@@ -642,33 +757,33 @@ pub fn decode_binop(op: NetBinOp) -> BinOp {
     }
 }
 
-/// Encode a runtime `DataType` into its network equivalent
+/// Encode a runtime `TableType` into its network equivalent
 ///
 /// Args:
-///     t (`&DataType`): The runtime data type to encode
+///     t (`&TableType`): The runtime table type to encode
 ///
 /// Returns:
-///     `NetDataType`: The encoded network data type representation
-pub fn encode_datatype(t: &DataType) -> NetDataType {
+///     `NetTableType`: The encoded network table type representation
+pub fn encode_tabletype(t: &TableType) -> NetTableType {
     match t {
-        DataType::String => NetDataType::String,
-        DataType::Number => NetDataType::Number,
-        DataType::Bool => NetDataType::Bool,
+        TableType::String => NetTableType::String,
+        TableType::Int => NetTableType::Int,
+        TableType::Bool => NetTableType::Bool,
     }
 }
 
-/// Decode a network `NetDataType` into its runtime equivalent
+/// Decode a network `NetTableType` into its runtime equivalent
 ///
 /// Args:
-///     t (`NetDataType`): The network data type to decode
+///     t (`NetTableType`): The network table type to decode
 ///
 /// Returns:
-///     `DataType`: The decoded runtime data type representation
-pub fn decode_datatype(t: NetDataType) -> DataType {
+///     `TableType`: The decoded runtime table type representation
+pub fn decode_tabletype(t: NetTableType) -> TableType {
     match t {
-        NetDataType::String => DataType::String,
-        NetDataType::Number => DataType::Number,
-        NetDataType::Bool => DataType::Bool,
+        NetTableType::String => TableType::String,
+        NetTableType::Int => TableType::Int,
+        NetTableType::Bool => TableType::Bool,
     }
 }
 
@@ -690,7 +805,7 @@ mod tests {
             name: var_x,
             ty: None,
             expr: Expr::Literal {
-                val: Value::Number { val: 42 },
+                val: Value::Int { val: 42 },
             },
         };
         let stmt2 = ActionStmt::Insert {
@@ -734,7 +849,7 @@ mod tests {
             },
         };
         let env_key = interner_orig.insert("y");
-        let env_val = Value::Number { val: 123 };
+        let env_val = Value::Int { val: 123 };
         let service = interner_orig.insert("my_service");
 
         let original_value = Value::Closure {
@@ -767,10 +882,10 @@ mod tests {
         let tuple_expr = Expr::Tuple {
             val: vec![
                 Expr::Literal {
-                    val: Value::Number { val: 1 },
+                    val: Value::Int { val: 1 },
                 },
                 Expr::Literal {
-                    val: Value::Number { val: 2 },
+                    val: Value::Int { val: 2 },
                 },
             ],
         };
@@ -782,7 +897,7 @@ mod tests {
         let key_val_expr = Expr::KeyVal {
             name: name_kv,
             value: Box::new(Expr::Literal {
-                val: Value::Number { val: 3 },
+                val: Value::Int { val: 3 },
             }),
         };
         run_expr_test(&key_val_expr, &interner);
@@ -816,10 +931,10 @@ mod tests {
             let binop_expr = Expr::Binop {
                 op: *op,
                 expr1: Box::new(Expr::Literal {
-                    val: Value::Number { val: 5 },
+                    val: Value::Int { val: 5 },
                 }),
                 expr2: Box::new(Expr::Literal {
-                    val: Value::Number { val: 6 },
+                    val: Value::Int { val: 6 },
                 }),
             };
             run_expr_test(&binop_expr, &interner);
@@ -832,10 +947,10 @@ mod tests {
                 val: Value::Bool { val: true },
             }),
             expr1: Box::new(Expr::Literal {
-                val: Value::Number { val: 7 },
+                val: Value::Int { val: 7 },
             }),
             expr2: Box::new(Expr::Literal {
-                val: Value::Number { val: 8 },
+                val: Value::Int { val: 8 },
             }),
         };
         run_expr_test(&if_expr, &interner);
@@ -861,7 +976,7 @@ mod tests {
                 ty: None,
             }],
             body: Box::new(Expr::Literal {
-                val: Value::Number { val: 9 },
+                val: Value::Int { val: 9 },
             }),
         };
         run_expr_test(&func_expr, &interner);
@@ -875,13 +990,13 @@ mod tests {
                 ty: None,
             }],
             body: Box::new(Expr::Literal {
-                val: Value::Number { val: 9 },
+                val: Value::Int { val: 9 },
             }),
         };
         let call_expr = Expr::Call {
             func: Box::new(func_expr),
             args: vec![Expr::Literal {
-                val: Value::Number { val: 10 },
+                val: Value::Int { val: 10 },
             }],
         };
         run_expr_test(&call_expr, &interner);
@@ -899,7 +1014,7 @@ mod tests {
         // 4. Action
         let interner = Interner::new();
         let action_expr = Expr::Action(vec![ActionStmt::Do(Expr::Literal {
-            val: Value::Number { val: 11 },
+            val: Value::Int { val: 11 },
         })]);
         run_expr_test(&action_expr, &interner);
     }
@@ -935,15 +1050,15 @@ mod tests {
         let col2 = interner.insert("col2");
         let f1 = Field {
             name: col1,
-            ty: DataType::String,
+            ty: TableType::String,
         };
         let f2 = Field {
             name: col2,
-            ty: DataType::Number,
+            ty: TableType::Int,
         };
         let f3 = Field {
             name: col2,
-            ty: DataType::Bool,
+            ty: TableType::Bool,
         };
         let table_expr = Expr::Table {
             schema: vec![f1, f2, f3],
@@ -963,10 +1078,10 @@ mod tests {
             table_name,
             column_name: col1,
             operation: Box::new(Expr::Literal {
-                val: Value::Number { val: 42 },
+                val: Value::Int { val: 42 },
             }),
             identity: Box::new(Expr::Literal {
-                val: Value::Number { val: 0 },
+                val: Value::Int { val: 0 },
             }),
         };
         run_expr_test(&fold_expr, &interner);
@@ -986,14 +1101,14 @@ mod tests {
         // 1. Expr
         let interner = Interner::new();
         let stmt_expr = ActionStmt::Expr(Expr::Literal {
-            val: Value::Number { val: 100 },
+            val: Value::Int { val: 100 },
         });
         run_stmt_test(&stmt_expr, &interner);
 
         // 2. Do
         let interner = Interner::new();
         let stmt_do = ActionStmt::Do(Expr::Literal {
-            val: Value::Number { val: 200 },
+            val: Value::Int { val: 200 },
         });
         run_stmt_test(&stmt_do, &interner);
 
@@ -1013,7 +1128,7 @@ mod tests {
         let stmt_assign = ActionStmt::Assign {
             name: name_var,
             expr: Expr::Literal {
-                val: Value::Number { val: 300 },
+                val: Value::Int { val: 300 },
             },
         };
         run_stmt_test(&stmt_assign, &interner);
@@ -1042,7 +1157,7 @@ mod tests {
     #[test]
     fn test_codec_deeply_nested_structure() {
         let mut expr = Expr::Literal {
-            val: Value::Number { val: 0 },
+            val: Value::Int { val: 0 },
         };
         let mut interner = Interner::new();
         for _ in 0..20 {
@@ -1050,7 +1165,7 @@ mod tests {
                 op: BinOp::Add,
                 expr1: Box::new(expr),
                 expr2: Box::new(Expr::Literal {
-                    val: Value::Number { val: 1 },
+                    val: Value::Int { val: 1 },
                 }),
             };
         }
@@ -1083,7 +1198,7 @@ mod tests {
         let net_val = NetValue::Closure {
             params: vec![long_ident],
             body: Box::new(NetExpr::Literal {
-                val: NetValue::Number { val: 0 },
+                val: NetValue::Int { val: 0 },
             }),
             env: vec![],
             service_name: "test".to_string(),
@@ -1143,6 +1258,49 @@ mod tests {
         );
         let mut interner = Interner::new();
         let res = decode_action_stmt(net_stmt, &mut interner);
+        assert!(res.is_err());
+        assert!(matches!(res.unwrap_err(), Error::LimitExceeded(_)));
+    }
+
+    /// Verify round-trip encoding and decoding for NetType and NetParam structures
+    #[test]
+    fn test_codec_type_and_param_roundtrip() {
+        let mut interner_orig = Interner::new();
+        let param_name = interner_orig.insert("param_x");
+
+        // Construct Type::Func(Int -> String, Bool -> Unit)
+        let original_type = Type::Func(
+            Box::new(Type::Func(Box::new(Type::Int), Box::new(Type::String))),
+            Box::new(Type::Func(Box::new(Type::Bool), Box::new(Type::Unit))),
+        );
+
+        let original_param = Param {
+            name: param_name,
+            ty: Some(original_type.clone()),
+        };
+
+        let encoded_type = encode_type(&original_type).unwrap();
+        let encoded_param = encode_param(&original_param, &interner_orig).unwrap();
+
+        let mut interner_new = Interner::new();
+        let decoded_type = decode_type(encoded_type, 0).unwrap();
+        let decoded_param = decode_param(encoded_param, &mut interner_new).unwrap();
+
+        assert_eq!(original_type, decoded_type);
+        assert_eq!(original_param.ty, decoded_param.ty);
+    }
+
+    /// Verify that deserializing a NetType exceeding MAX_TYPE_DEPTH
+    /// returns a limit exceeded error
+    #[test]
+    fn test_codec_type_depth_overflow() {
+        // Construct a NetType that exceeds MAX_TYPE_DEPTH (16)
+        let mut current_type = NetType::Int;
+        for _ in 0..(MAX_TYPE_DEPTH + 1) {
+            current_type = NetType::Func(Box::new(NetType::Bool), Box::new(current_type));
+        }
+
+        let res = decode_type(current_type, 0);
         assert!(res.is_err());
         assert!(matches!(res.unwrap_err(), Error::LimitExceeded(_)));
     }

--- a/meerkat-lib/src/net/codec.rs
+++ b/meerkat-lib/src/net/codec.rs
@@ -8,6 +8,7 @@ use crate::net::ast::{NetActionStmt, NetBinOp, NetDataType, NetExpr, NetField, N
 use crate::runtime::ast::{ActionStmt, BinOp, DataType, Expr, Field, UnOp, Value};
 use crate::runtime::interner::Interner;
 use crate::runtime::limits::{MAX_IDENTIFIER_LENGTH, MAX_STRING_LITERAL_LENGTH};
+use crate::runtime::tt::Param;
 
 fn validate_identifier(s: &str) -> Result<()> {
     if s.len() > MAX_IDENTIFIER_LENGTH {
@@ -213,7 +214,7 @@ pub fn encode_expr(expr: &Expr, interner: &Interner) -> Result<NetExpr> {
         Expr::Func { params, body } => {
             let mut encoded_params = Vec::new();
             for p in params {
-                let p_str = interner.get(*p);
+                let p_str = interner.get(p.name);
                 validate_identifier(p_str)?;
                 encoded_params.push(p_str.to_string());
             }
@@ -358,7 +359,13 @@ pub fn decode_expr(expr: NetExpr, interner: &mut Interner) -> Result<Expr> {
             for p in &params {
                 validate_identifier(p)?;
             }
-            let decoded_params = params.into_iter().map(|p| interner.insert(&p)).collect();
+            let decoded_params = params
+                .into_iter()
+                .map(|p| Param {
+                    name: interner.insert(&p),
+                    ty: None,
+                })
+                .collect();
             let decoded_body = Box::new(decode_expr(*body, interner)?);
             Ok(Expr::Func {
                 params: decoded_params,
@@ -455,7 +462,7 @@ pub fn decode_expr(expr: NetExpr, interner: &mut Interner) -> Result<Expr> {
 ///     `Result<NetActionStmt>`: The encoded `NetActionStmt` network representation
 pub fn encode_action_stmt(stmt: &ActionStmt, interner: &Interner) -> Result<NetActionStmt> {
     match stmt {
-        ActionStmt::Let { name, expr } => {
+        ActionStmt::Let { name, ty: _, expr } => {
             let name_str = interner.get(*name);
             validate_identifier(name_str)?;
             Ok(NetActionStmt::Let {
@@ -505,6 +512,7 @@ pub fn decode_action_stmt(stmt: NetActionStmt, interner: &mut Interner) -> Resul
             validate_identifier(&name)?;
             Ok(ActionStmt::Let {
                 name: interner.insert(&name),
+                ty: None,
                 expr: decode_expr(expr, interner)?,
             })
         }
@@ -680,6 +688,7 @@ mod tests {
 
         let stmt1 = ActionStmt::Let {
             name: var_x,
+            ty: None,
             expr: Expr::Literal {
                 val: Value::Number { val: 42 },
             },
@@ -847,7 +856,10 @@ mod tests {
         let mut interner = Interner::new();
         let param_name = interner.insert("p");
         let func_expr = Expr::Func {
-            params: vec![param_name],
+            params: vec![Param {
+                name: param_name,
+                ty: None,
+            }],
             body: Box::new(Expr::Literal {
                 val: Value::Number { val: 9 },
             }),
@@ -858,7 +870,10 @@ mod tests {
         let mut interner = Interner::new();
         let param_name = interner.insert("p");
         let func_expr = Expr::Func {
-            params: vec![param_name],
+            params: vec![Param {
+                name: param_name,
+                ty: None,
+            }],
             body: Box::new(Expr::Literal {
                 val: Value::Number { val: 9 },
             }),

--- a/meerkat-lib/src/net/codec.rs
+++ b/meerkat-lib/src/net/codec.rs
@@ -32,13 +32,11 @@ fn validate_string_literal(s: &str) -> Result<()> {
     Ok(())
 }
 
-/// Encode a runtime `Type` into a network representation
-///
-/// Enforces type depth limit to prevent stack-overflow DoS attacks
+/// Encode a runtime `Type` using recursion depth accumulator
 ///
 /// Args:
-///     `ty` (`&Type`): The runtime type to encode
-///     `depth` (`usize`): The current recursion depth
+///     ty (`&Type`): The runtime type to encode
+///     depth (`usize`): The current recursion depth
 ///
 /// Returns:
 ///     `Result<NetType>`: The encoded network type representation
@@ -46,7 +44,7 @@ fn validate_string_literal(s: &str) -> Result<()> {
 /// Raises:
 ///     `Error::LimitExceeded`: The type nesting depth exceeds
 ///     maximum limit
-pub fn encode_type(ty: &Type, depth: usize) -> Result<NetType> {
+fn encode_type_internal(ty: &Type, depth: usize) -> Result<NetType> {
     if depth > MAX_TYPE_DEPTH {
         return Err(Error::LimitExceeded(format!(
             "Type nesting depth exceeds maximum limit of {}",
@@ -61,25 +59,40 @@ pub fn encode_type(ty: &Type, depth: usize) -> Result<NetType> {
         Type::Tuple(ts) => {
             let mut encoded_ts = Vec::new();
             for t in ts {
-                encoded_ts.push(encode_type(t, depth + 1)?);
+                encoded_ts.push(encode_type_internal(t, depth + 1)?);
             }
             Ok(NetType::Tuple(encoded_ts))
         }
         Type::Func(t1, t2) => {
-            let et1 = encode_type(t1, depth + 1)?;
-            let et2 = encode_type(t2, depth + 1)?;
+            let et1 = encode_type_internal(t1, depth + 1)?;
+            let et2 = encode_type_internal(t2, depth + 1)?;
             Ok(NetType::Func(Box::new(et1), Box::new(et2)))
         }
     }
 }
 
-/// Decode a network `NetType` representation into a runtime `Type`
+/// Encode a runtime `Type` into a network representation
 ///
 /// Enforces type depth limit to prevent stack-overflow DoS attacks
 ///
 /// Args:
-///     `ty` (`NetType`): The network type to decode
-///     `depth` (`usize`): The current recursion depth
+///     ty (`&Type`): The runtime type to encode
+///
+/// Returns:
+///     `Result<NetType>`: The encoded network type representation
+///
+/// Raises:
+///     `Error::LimitExceeded`: The type nesting depth exceeds
+///     maximum limit
+pub fn encode_type(ty: &Type) -> Result<NetType> {
+    encode_type_internal(ty, 0)
+}
+
+/// Decode a network `NetType` with recursion depth accumulator
+///
+/// Args:
+///     ty (`NetType`): The network type to decode
+///     depth (`usize`): The current recursion depth
 ///
 /// Returns:
 ///     `Result<Type>`: The decoded runtime type
@@ -87,7 +100,7 @@ pub fn encode_type(ty: &Type, depth: usize) -> Result<NetType> {
 /// Raises:
 ///     `Error::LimitExceeded`: The type nesting depth exceeds
 ///     maximum limit
-pub fn decode_type(ty: NetType, depth: usize) -> Result<Type> {
+fn decode_type_internal(ty: NetType, depth: usize) -> Result<Type> {
     if depth > MAX_TYPE_DEPTH {
         return Err(Error::LimitExceeded(format!(
             "Type nesting depth exceeds maximum limit of {}",
@@ -102,16 +115,33 @@ pub fn decode_type(ty: NetType, depth: usize) -> Result<Type> {
         NetType::Tuple(ts) => {
             let mut decoded_ts = Vec::new();
             for t in ts {
-                decoded_ts.push(decode_type(t, depth + 1)?);
+                decoded_ts.push(decode_type_internal(t, depth + 1)?);
             }
             Ok(Type::Tuple(decoded_ts))
         }
         NetType::Func(t1, t2) => {
-            let dt1 = decode_type(*t1, depth + 1)?;
-            let dt2 = decode_type(*t2, depth + 1)?;
+            let dt1 = decode_type_internal(*t1, depth + 1)?;
+            let dt2 = decode_type_internal(*t2, depth + 1)?;
             Ok(Type::Func(Box::new(dt1), Box::new(dt2)))
         }
     }
+}
+
+/// Decode a network `NetType` representation into a runtime `Type`
+///
+/// Enforces type depth limit to prevent stack-overflow DoS attacks
+///
+/// Args:
+///     ty (`NetType`): The network type to decode
+///
+/// Returns:
+///     `Result<Type>`: The decoded runtime type
+///
+/// Raises:
+///     `Error::LimitExceeded`: The type nesting depth exceeds
+///     maximum limit
+pub fn decode_type(ty: NetType) -> Result<Type> {
+    decode_type_internal(ty, 0)
 }
 
 /// Encode a runtime `Param` into a network representation
@@ -127,7 +157,7 @@ pub fn encode_param(param: &Param, interner: &Interner) -> Result<NetParam> {
     let name_str = interner.get(param.name);
     validate_identifier(name_str)?;
     let ty = match &param.ty {
-        Some(t) => Some(encode_type(t, 0)?),
+        Some(t) => Some(encode_type(t)?),
         None => None,
     };
     Ok(NetParam {
@@ -148,7 +178,7 @@ pub fn encode_param(param: &Param, interner: &Interner) -> Result<NetParam> {
 pub fn decode_param(param: NetParam, interner: &mut Interner) -> Result<Param> {
     validate_identifier(&param.name)?;
     let ty = match param.ty {
-        Some(t) => Some(decode_type(t, 0)?),
+        Some(t) => Some(decode_type(t)?),
         None => None,
     };
     Ok(Param {
@@ -578,14 +608,15 @@ pub fn decode_expr(expr: NetExpr, interner: &mut Interner) -> Result<Expr> {
 ///     interner (`&Interner`): The `Interner` for symbol lookup
 ///
 /// Returns:
-///     `Result<NetActionStmt>`: The encoded `NetActionStmt` network representation
+///     `Result<NetActionStmt>`: The encoded `NetActionStmt` network
+///     representation
 pub fn encode_action_stmt(stmt: &ActionStmt, interner: &Interner) -> Result<NetActionStmt> {
     match stmt {
         ActionStmt::Let { name, ty, expr } => {
             let name_str = interner.get(*name);
             validate_identifier(name_str)?;
             let encoded_ty = match ty {
-                Some(t) => Some(encode_type(t, 0)?),
+                Some(t) => Some(encode_type(t)?),
                 None => None,
             };
             Ok(NetActionStmt::Let {
@@ -635,7 +666,7 @@ pub fn decode_action_stmt(stmt: NetActionStmt, interner: &mut Interner) -> Resul
         NetActionStmt::Let { name, ty, expr } => {
             validate_identifier(&name)?;
             let decoded_ty = match ty {
-                Some(t) => Some(decode_type(t, 0)?),
+                Some(t) => Some(decode_type(t)?),
                 None => None,
             };
             Ok(ActionStmt::Let {
@@ -1275,13 +1306,14 @@ mod tests {
         assert!(matches!(res.unwrap_err(), Error::LimitExceeded(_)));
     }
 
-    /// Verify round-trip encoding and decoding for NetType and NetParam structures
+    /// Verify round-trip encoding and decoding for `NetType` and
+    /// `NetParam` structures
     #[test]
     fn test_codec_type_and_param_roundtrip() {
         let mut interner_orig = Interner::new();
         let param_name = interner_orig.insert("param_x");
 
-        // Construct Type::Func(Int -> String, Bool -> Unit)
+        // Construct `Type::Func(Int -> String, Bool -> Unit)`
         let original_type = Type::Func(
             Box::new(Type::Func(Box::new(Type::Int), Box::new(Type::String))),
             Box::new(Type::Func(Box::new(Type::Bool), Box::new(Type::Unit))),
@@ -1292,43 +1324,43 @@ mod tests {
             ty: Some(original_type.clone()),
         };
 
-        let encoded_type = encode_type(&original_type, 0).unwrap();
+        let encoded_type = encode_type(&original_type).unwrap();
         let encoded_param = encode_param(&original_param, &interner_orig).unwrap();
 
         let mut interner_new = Interner::new();
-        let decoded_type = decode_type(encoded_type, 0).unwrap();
+        let decoded_type = decode_type(encoded_type).unwrap();
         let decoded_param = decode_param(encoded_param, &mut interner_new).unwrap();
 
         assert_eq!(original_type, decoded_type);
         assert_eq!(original_param.ty, decoded_param.ty);
     }
 
-    /// Verify that deserializing a NetType exceeding MAX_TYPE_DEPTH
-    /// returns a limit exceeded error
+    /// Verify that deserializing a `NetType` exceeding
+    /// `MAX_TYPE_DEPTH` returns a limit exceeded error
     #[test]
     fn test_codec_type_depth_overflow() {
-        // Construct a NetType that exceeds MAX_TYPE_DEPTH (16)
+        // Construct a `NetType` that exceeds `MAX_TYPE_DEPTH` (16)
         let mut current_type = NetType::Int;
         for _ in 0..(MAX_TYPE_DEPTH + 1) {
             current_type = NetType::Func(Box::new(NetType::Bool), Box::new(current_type));
         }
 
-        let res = decode_type(current_type, 0);
+        let res = decode_type(current_type);
         assert!(res.is_err());
         assert!(matches!(res.unwrap_err(), Error::LimitExceeded(_)));
     }
 
-    /// Verify that encoding a Type exceeding MAX_TYPE_DEPTH returns
-    /// a limit exceeded error
+    /// Verify that encoding a `Type` exceeding `MAX_TYPE_DEPTH`
+    /// returns a limit exceeded error
     #[test]
     fn test_codec_encode_type_depth_overflow() {
-        // Construct a Type that exceeds MAX_TYPE_DEPTH (16)
+        // Construct a `Type` that exceeds `MAX_TYPE_DEPTH` (16)
         let mut current_type = Type::Int;
         for _ in 0..(MAX_TYPE_DEPTH + 1) {
             current_type = Type::Func(Box::new(Type::Bool), Box::new(current_type));
         }
 
-        let res = encode_type(&current_type, 0);
+        let res = encode_type(&current_type);
         assert!(res.is_err());
         assert!(matches!(res.unwrap_err(), Error::LimitExceeded(_)));
     }

--- a/meerkat-lib/src/net/codec.rs
+++ b/meerkat-lib/src/net/codec.rs
@@ -208,12 +208,11 @@ pub fn encode_value(val: &Value, interner: &Interner) -> Result<NetValue> {
             body,
             env,
             service_name,
+            return_ty,
         } => {
             let mut encoded_params = Vec::new();
             for p in params {
-                let p_str = interner.get(*p);
-                validate_identifier(p_str)?;
-                encoded_params.push(p_str.to_string());
+                encoded_params.push(encode_param(p, interner)?);
             }
             let encoded_body = Box::new(encode_expr(body, interner)?);
             let mut encoded_env = Vec::new();
@@ -224,11 +223,16 @@ pub fn encode_value(val: &Value, interner: &Interner) -> Result<NetValue> {
             }
             let service_str = interner.get(*service_name);
             validate_identifier(service_str)?;
+            let encoded_return_ty = match return_ty {
+                Some(t) => Some(encode_type(t)?),
+                None => None,
+            };
             Ok(NetValue::Closure {
                 params: encoded_params,
                 body: encoded_body,
                 env: encoded_env,
                 service_name: service_str.to_string(),
+                return_ty: encoded_return_ty,
             })
         }
         Value::ActionClosure {
@@ -276,11 +280,12 @@ pub fn decode_value(val: NetValue, interner: &mut Interner) -> Result<Value> {
             body,
             env,
             service_name,
+            return_ty,
         } => {
-            for p in &params {
-                validate_identifier(p)?;
+            let mut decoded_params = Vec::new();
+            for p in params {
+                decoded_params.push(decode_param(p, interner)?);
             }
-            let decoded_params = params.into_iter().map(|p| interner.insert(&p)).collect();
             let decoded_body = Box::new(decode_expr(*body, interner)?);
             let mut decoded_env = Vec::new();
             for (k, v) in env {
@@ -289,11 +294,16 @@ pub fn decode_value(val: NetValue, interner: &mut Interner) -> Result<Value> {
             }
             validate_identifier(&service_name)?;
             let decoded_service = interner.insert(&service_name);
+            let decoded_return_ty = match return_ty {
+                Some(t) => Some(decode_type(t)?),
+                None => None,
+            };
             Ok(Value::Closure {
                 params: decoded_params,
                 body: decoded_body,
                 env: decoded_env,
                 service_name: decoded_service,
+                return_ty: decoded_return_ty,
             })
         }
         NetValue::ActionClosure {
@@ -368,15 +378,24 @@ pub fn encode_expr(expr: &Expr, interner: &Interner) -> Result<NetExpr> {
             expr1: Box::new(encode_expr(expr1, interner)?),
             expr2: Box::new(encode_expr(expr2, interner)?),
         }),
-        Expr::Func { params, body } => {
+        Expr::Func {
+            params,
+            body,
+            return_ty,
+        } => {
             let mut encoded_params = Vec::new();
             for p in params {
                 encoded_params.push(encode_param(p, interner)?);
             }
             let encoded_body = Box::new(encode_expr(body, interner)?);
+            let encoded_return_ty = match return_ty {
+                Some(t) => Some(encode_type(t)?),
+                None => None,
+            };
             Ok(NetExpr::Func {
                 params: encoded_params,
                 body: encoded_body,
+                return_ty: encoded_return_ty,
             })
         }
         Expr::Call { func, args } => {
@@ -510,15 +529,24 @@ pub fn decode_expr(expr: NetExpr, interner: &mut Interner) -> Result<Expr> {
             expr1: Box::new(decode_expr(*expr1, interner)?),
             expr2: Box::new(decode_expr(*expr2, interner)?),
         }),
-        NetExpr::Func { params, body } => {
+        NetExpr::Func {
+            params,
+            body,
+            return_ty,
+        } => {
             let mut decoded_params = Vec::new();
             for p in params {
                 decoded_params.push(decode_param(p, interner)?);
             }
             let decoded_body = Box::new(decode_expr(*body, interner)?);
+            let decoded_return_ty = match return_ty {
+                Some(t) => Some(decode_type(t)?),
+                None => None,
+            };
             Ok(Expr::Func {
                 params: decoded_params,
                 body: decoded_body,
+                return_ty: decoded_return_ty,
             })
         }
         NetExpr::Call { func, args } => {
@@ -897,10 +925,14 @@ mod tests {
         let service = interner_orig.insert("my_service");
 
         let original_value = Value::Closure {
-            params: vec![param_name],
+            params: vec![Param {
+                name: param_name,
+                ty: None,
+            }],
             body: Box::new(body),
             env: vec![(env_key, env_val)],
             service_name: service,
+            return_ty: None,
         };
 
         let encoded = encode_value(&original_value, &interner_orig).unwrap();
@@ -1022,6 +1054,7 @@ mod tests {
             body: Box::new(Expr::Literal {
                 val: Value::Int { val: 9 },
             }),
+            return_ty: None,
         };
         run_expr_test(&func_expr, &interner);
 
@@ -1036,6 +1069,7 @@ mod tests {
             body: Box::new(Expr::Literal {
                 val: Value::Int { val: 9 },
             }),
+            return_ty: None,
         };
         let call_expr = Expr::Call {
             func: Box::new(func_expr),
@@ -1240,12 +1274,16 @@ mod tests {
     fn test_codec_decode_oversized_identifier() {
         let long_ident = "a".repeat(MAX_IDENTIFIER_LENGTH + 1);
         let net_val = NetValue::Closure {
-            params: vec![long_ident],
+            params: vec![NetParam {
+                name: long_ident,
+                ty: None,
+            }],
             body: Box::new(NetExpr::Literal {
                 val: NetValue::Int { val: 0 },
             }),
             env: vec![],
             service_name: "test".to_string(),
+            return_ty: None,
         };
         let mut interner = Interner::new();
         let res = decode_value(net_val, &mut interner);

--- a/meerkat-lib/src/runtime/ast/mod.rs
+++ b/meerkat-lib/src/runtime/ast/mod.rs
@@ -95,6 +95,11 @@ pub enum Value {
         body: Box<Expr>,
         env: Vec<(Symbol, Value)>,
         service_name: Symbol,
+        /// Important: `None` indicates missing type info, not the
+        /// `unit` type. In practice, return types for closures should
+        /// generally be `Some` type; however, this was left as an
+        /// `Option` for now for maximum flexibility as development
+        /// continues
         return_ty: Option<Type>,
     },
     ActionClosure {
@@ -145,6 +150,11 @@ pub enum Expr {
     Func {
         params: Vec<Param>,
         body: Box<Expr>,
+        /// Important: `None` indicates missing type info, not the
+        /// `unit` type. In practice, return types for closures should
+        /// generally be `Some` type; however, this was left as an
+        /// `Option` for now for maximum flexibility as development
+        /// continues
         return_ty: Option<Type>,
     },
     Call {

--- a/meerkat-lib/src/runtime/ast/mod.rs
+++ b/meerkat-lib/src/runtime/ast/mod.rs
@@ -81,7 +81,7 @@ pub enum Stmt {
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum Value {
-    Number {
+    Int {
         val: i32,
     },
     Bool {
@@ -203,13 +203,13 @@ pub enum Decl {
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Field {
     pub name: Symbol,
-    pub ty: DataType,
+    pub ty: TableType,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub enum DataType {
+pub enum TableType {
     String,
-    Number,
+    Int,
     Bool,
 }
 
@@ -251,7 +251,7 @@ impl Display for Value {
     ///     `std::fmt::Result`: The result of the formatting operation
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Value::Number { val } => write!(f, "{}", val),
+            Value::Int { val } => write!(f, "{}", val),
             Value::Bool { val } => write!(f, "{}", val),
             Value::String { val } => write!(f, "\"{}\"", val),
             Value::Closure {

--- a/meerkat-lib/src/runtime/ast/mod.rs
+++ b/meerkat-lib/src/runtime/ast/mod.rs
@@ -91,10 +91,11 @@ pub enum Value {
         val: String,
     },
     Closure {
-        params: Vec<Symbol>,
+        params: Vec<Param>,
         body: Box<Expr>,
         env: Vec<(Symbol, Value)>,
         service_name: Symbol,
+        return_ty: Option<Type>,
     },
     ActionClosure {
         stmts: Vec<ActionStmt>,
@@ -144,6 +145,7 @@ pub enum Expr {
     Func {
         params: Vec<Param>,
         body: Box<Expr>,
+        return_ty: Option<Type>,
     },
     Call {
         func: Box<Expr>,
@@ -255,12 +257,27 @@ impl Display for Value {
             Value::Bool { val } => write!(f, "{}", val),
             Value::String { val } => write!(f, "\"{}\"", val),
             Value::Closure {
-                params, body, env, ..
+                params,
+                body,
+                env,
+                return_ty,
+                ..
             } => {
                 let params_str: Vec<String> = params.iter().map(|p| p.to_string()).collect();
                 let env_str: Vec<String> =
                     env.iter().map(|(k, v)| format!("{}: {}", k, v)).collect();
-                write!(f, "fn({})[{:?}]{{{}}}", params_str.join(","), env_str, body)
+                if let Some(ref ty) = return_ty {
+                    write!(
+                        f,
+                        "fn({}) -> {}[{:?}]{{{}}}",
+                        params_str.join(","),
+                        ty,
+                        env_str,
+                        body
+                    )
+                } else {
+                    write!(f, "fn({})[{:?}]{{{}}}", params_str.join(","), env_str, body)
+                }
             }
             Value::ActionClosure {
                 stmts,
@@ -302,9 +319,17 @@ impl Display for Expr {
             Expr::If { cond, expr1, expr2 } => {
                 write!(f, "if {} then {} else {}", cond, expr1, expr2)
             }
-            Expr::Func { params, body } => {
+            Expr::Func {
+                params,
+                body,
+                return_ty,
+            } => {
                 let params_str: Vec<String> = params.iter().map(|p| p.to_string()).collect();
-                write!(f, "fn({})[{}]", params_str.join(","), body)
+                if let Some(ref ty) = return_ty {
+                    write!(f, "fn({}) -> {}[{}]", params_str.join(","), ty, body)
+                } else {
+                    write!(f, "fn({})[{}]", params_str.join(","), body)
+                }
             }
             Expr::Call { func, args } => write!(
                 f,

--- a/meerkat-lib/src/runtime/ast/mod.rs
+++ b/meerkat-lib/src/runtime/ast/mod.rs
@@ -1,6 +1,8 @@
 use crate::net::ServiceNetId;
 use crate::runtime::interner::Symbol;
+use crate::runtime::tt::{Param, Type};
 use std::fmt::Display;
+
 pub mod printer;
 pub use printer::AstPrinter;
 
@@ -29,6 +31,7 @@ pub enum BinOp {
 pub enum ActionStmt {
     Let {
         name: Symbol,
+        ty: Option<Type>,
         expr: Expr,
     },
     Expr(Expr),
@@ -139,7 +142,7 @@ pub enum Expr {
     },
 
     Func {
-        params: Vec<Symbol>,
+        params: Vec<Param>,
         body: Box<Expr>,
     },
     Call {
@@ -182,10 +185,12 @@ pub enum Expr {
 pub enum Decl {
     VarDecl {
         name: Symbol,
+        ty: Option<Type>,
         val: Expr,
     },
     DefDecl {
         name: Symbol,
+        ty: Option<Type>,
         val: Expr,
         is_pub: bool,
     },
@@ -366,7 +371,13 @@ impl Display for ActionStmt {
     ///     `std::fmt::Result`: The result of the formatting operation
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            ActionStmt::Let { name, expr } => write!(f, "let {} = {}", name, expr),
+            ActionStmt::Let { name, ty, expr } => {
+                if let Some(t) = ty {
+                    write!(f, "let {}: {} = {}", name, t, expr)
+                } else {
+                    write!(f, "let {} = {}", name, expr)
+                }
+            }
             ActionStmt::Expr(expr) => write!(f, "{}", expr),
             ActionStmt::Do(expr) => write!(f, "do {}", expr),
             ActionStmt::Assert(expr, _) => write!(f, "assert {}", expr),
@@ -391,14 +402,24 @@ impl Display for Decl {
     ///     `std::fmt::Result`: The result of the formatting operation
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Decl::VarDecl { name, val } => {
-                write!(f, "var {} = {}", name, val)
-            }
-            Decl::DefDecl { name, val, is_pub } => {
-                if *is_pub {
-                    write!(f, "pub def {} = {}", name, val)
+            Decl::VarDecl { name, ty, val } => {
+                if let Some(t) = ty {
+                    write!(f, "var {}: {} = {}", name, t, val)
                 } else {
-                    write!(f, "def {} = {}", name, val)
+                    write!(f, "var {} = {}", name, val)
+                }
+            }
+            Decl::DefDecl {
+                name,
+                ty,
+                val,
+                is_pub,
+            } => {
+                let prefix = if *is_pub { "pub " } else { "" };
+                if let Some(t) = ty {
+                    write!(f, "{}def {}: {} = {}", prefix, name, t, val)
+                } else {
+                    write!(f, "{}def {} = {}", prefix, name, val)
                 }
             }
             Decl::TableDecl { name, .. } => {

--- a/meerkat-lib/src/runtime/ast/printer.rs
+++ b/meerkat-lib/src/runtime/ast/printer.rs
@@ -6,6 +6,7 @@
 
 use crate::runtime::ast::{ActionStmt, Decl, Expr, Field, Stmt, Value};
 use crate::runtime::interner::{Interner, Symbol};
+use crate::runtime::tt::Type;
 
 const INDENTATION: usize = 2;
 
@@ -38,6 +39,20 @@ impl<'a> AstPrinter<'a> {
     ///     `String`: The formatted symbol string representation
     pub fn format_symbol(&self, sym: Symbol) -> String {
         format!("{} (\"{}\")", sym, self.interner.get(sym))
+    }
+
+    /// Helper function to format an optional type using `Display` representation
+    ///
+    /// Args:
+    ///     `ty` (`&Option<Type>`): The optional type to format
+    ///
+    /// Returns:
+    ///     `String`: The formatted type string representation
+    pub fn format_type_opt(&self, ty: &Option<Type>) -> String {
+        match ty {
+            Some(t) => format!("Some({})", t),
+            None => "None".to_string(),
+        }
     }
 
     /// Prints spaces corresponding to the current indentation level
@@ -118,9 +133,9 @@ impl<'a> AstPrinter<'a> {
             Decl::VarDecl { name, ty, val } => {
                 let name = *name;
                 println!(
-                    "VarDecl: {{ name: {}, ty: {:?} }}",
+                    "VarDecl: {{ name: {}, ty: {} }}",
                     self.format_symbol(name),
-                    ty
+                    self.format_type_opt(ty)
                 );
                 self.print_expr(val, indent + 1);
             }
@@ -133,9 +148,9 @@ impl<'a> AstPrinter<'a> {
                 let name = *name;
                 let is_pub = *is_pub;
                 println!(
-                    "DefDecl: {{ name: {}, ty: {:?}, is_pub: {} }}",
+                    "DefDecl: {{ name: {}, ty: {}, is_pub: {} }}",
                     self.format_symbol(name),
-                    ty,
+                    self.format_type_opt(ty),
                     is_pub
                 );
                 self.print_expr(val, indent + 1);
@@ -167,9 +182,9 @@ impl<'a> AstPrinter<'a> {
             ActionStmt::Let { name, ty, expr } => {
                 let name = *name;
                 println!(
-                    "Let: {{ name: {}, ty: {:?} }}",
+                    "Let: {{ name: {}, ty: {} }}",
                     self.format_symbol(name),
-                    ty
+                    self.format_type_opt(ty)
                 );
                 self.print_expr(expr, indent + 1);
             }
@@ -246,7 +261,7 @@ impl<'a> AstPrinter<'a> {
                     .iter()
                     .map(|p| {
                         if let Some(ref t) = p.ty {
-                            format!("{}: {:?}", self.format_symbol(p.name), t)
+                            format!("{}: {}", self.format_symbol(p.name), t)
                         } else {
                             self.format_symbol(p.name)
                         }
@@ -329,9 +344,9 @@ impl<'a> AstPrinter<'a> {
     pub fn print_value(&self, val: &Value, indent: usize) {
         self.print_indent(indent);
         match val {
-            Value::Number { val } => {
+            Value::Int { val } => {
                 let val = *val;
-                println!("Number: {}", val);
+                println!("Int: {}", val);
             }
             Value::Bool { val } => {
                 let val = *val;

--- a/meerkat-lib/src/runtime/ast/printer.rs
+++ b/meerkat-lib/src/runtime/ast/printer.rs
@@ -256,7 +256,11 @@ impl<'a> AstPrinter<'a> {
                 self.print_expr(expr1, indent + 1);
                 self.print_expr(expr2, indent + 1);
             }
-            Expr::Func { params, body } => {
+            Expr::Func {
+                params,
+                body,
+                return_ty,
+            } => {
                 let params_str: Vec<String> = params
                     .iter()
                     .map(|p| {
@@ -267,7 +271,11 @@ impl<'a> AstPrinter<'a> {
                         }
                     })
                     .collect();
-                println!("Func: {{ params: {:?} }}", params_str);
+                println!(
+                    "Func: {{ params: {:?}, return_ty: {} }}",
+                    params_str,
+                    self.format_type_opt(return_ty)
+                );
                 self.print_expr(body, indent + 1);
             }
             Expr::Call { func, args } => {
@@ -359,14 +367,24 @@ impl<'a> AstPrinter<'a> {
                 params,
                 body,
                 service_name,
+                return_ty,
                 ..
             } => {
                 let service_name = *service_name;
-                let params_str: Vec<String> =
-                    params.iter().map(|p| self.format_symbol(*p)).collect();
+                let params_str: Vec<String> = params
+                    .iter()
+                    .map(|p| {
+                        if let Some(ref t) = p.ty {
+                            format!("{}: {}", self.format_symbol(p.name), t)
+                        } else {
+                            self.format_symbol(p.name)
+                        }
+                    })
+                    .collect();
                 println!(
-                    "Closure: {{ params: {:?}, service_name: {} }}",
+                    "Closure: {{ params: {:?}, return_ty: {}, service_name: {} }}",
                     params_str,
+                    self.format_type_opt(return_ty),
                     self.format_symbol(service_name)
                 );
                 self.print_expr(body, indent + 1);

--- a/meerkat-lib/src/runtime/ast/printer.rs
+++ b/meerkat-lib/src/runtime/ast/printer.rs
@@ -115,17 +115,27 @@ impl<'a> AstPrinter<'a> {
     pub fn print_decl(&self, decl: &Decl, indent: usize) {
         self.print_indent(indent);
         match decl {
-            Decl::VarDecl { name, val } => {
+            Decl::VarDecl { name, ty, val } => {
                 let name = *name;
-                println!("VarDecl: {{ name: {} }}", self.format_symbol(name));
+                println!(
+                    "VarDecl: {{ name: {}, ty: {:?} }}",
+                    self.format_symbol(name),
+                    ty
+                );
                 self.print_expr(val, indent + 1);
             }
-            Decl::DefDecl { name, val, is_pub } => {
+            Decl::DefDecl {
+                name,
+                ty,
+                val,
+                is_pub,
+            } => {
                 let name = *name;
                 let is_pub = *is_pub;
                 println!(
-                    "DefDecl: {{ name: {}, is_pub: {} }}",
+                    "DefDecl: {{ name: {}, ty: {:?}, is_pub: {} }}",
                     self.format_symbol(name),
+                    ty,
                     is_pub
                 );
                 self.print_expr(val, indent + 1);
@@ -154,9 +164,13 @@ impl<'a> AstPrinter<'a> {
     pub fn print_action_stmt(&self, stmt: &ActionStmt, indent: usize) {
         self.print_indent(indent);
         match stmt {
-            ActionStmt::Let { name, expr } => {
+            ActionStmt::Let { name, ty, expr } => {
                 let name = *name;
-                println!("Let: {{ name: {} }}", self.format_symbol(name));
+                println!(
+                    "Let: {{ name: {}, ty: {:?} }}",
+                    self.format_symbol(name),
+                    ty
+                );
                 self.print_expr(expr, indent + 1);
             }
             ActionStmt::Expr(expr) => {
@@ -228,8 +242,16 @@ impl<'a> AstPrinter<'a> {
                 self.print_expr(expr2, indent + 1);
             }
             Expr::Func { params, body } => {
-                let params_str: Vec<String> =
-                    params.iter().map(|p| self.format_symbol(*p)).collect();
+                let params_str: Vec<String> = params
+                    .iter()
+                    .map(|p| {
+                        if let Some(ref t) = p.ty {
+                            format!("{}: {:?}", self.format_symbol(p.name), t)
+                        } else {
+                            self.format_symbol(p.name)
+                        }
+                    })
+                    .collect();
                 println!("Func: {{ params: {:?} }}", params_str);
                 self.print_expr(body, indent + 1);
             }

--- a/meerkat-lib/src/runtime/interpreter/evaluator.rs
+++ b/meerkat-lib/src/runtime/interpreter/evaluator.rs
@@ -119,25 +119,25 @@ pub async fn eval(
             let val1 = eval(expr1, env, ctx).await?;
             let val2 = eval(expr2, env, ctx).await?;
             match (op, val1, val2) {
-                (BinOp::Add, Value::Number { val: v1 }, Value::Number { val: v2 }) => {
-                    Ok(Value::Number { val: v1 + v2 })
+                (BinOp::Add, Value::Int { val: v1 }, Value::Int { val: v2 }) => {
+                    Ok(Value::Int { val: v1 + v2 })
                 }
-                (BinOp::Sub, Value::Number { val: v1 }, Value::Number { val: v2 }) => {
-                    Ok(Value::Number { val: v1 - v2 })
+                (BinOp::Sub, Value::Int { val: v1 }, Value::Int { val: v2 }) => {
+                    Ok(Value::Int { val: v1 - v2 })
                 }
-                (BinOp::Mul, Value::Number { val: v1 }, Value::Number { val: v2 }) => {
-                    Ok(Value::Number { val: v1 * v2 })
+                (BinOp::Mul, Value::Int { val: v1 }, Value::Int { val: v2 }) => {
+                    Ok(Value::Int { val: v1 * v2 })
                 }
-                (BinOp::Div, Value::Number { val: v1 }, Value::Number { val: v2 }) => {
-                    Ok(Value::Number { val: v1 / v2 })
+                (BinOp::Div, Value::Int { val: v1 }, Value::Int { val: v2 }) => {
+                    Ok(Value::Int { val: v1 / v2 })
                 }
-                (BinOp::Eq, Value::Number { val: v1 }, Value::Number { val: v2 }) => {
+                (BinOp::Eq, Value::Int { val: v1 }, Value::Int { val: v2 }) => {
                     Ok(Value::Bool { val: v1 == v2 })
                 }
-                (BinOp::Lt, Value::Number { val: v1 }, Value::Number { val: v2 }) => {
+                (BinOp::Lt, Value::Int { val: v1 }, Value::Int { val: v2 }) => {
                     Ok(Value::Bool { val: v1 < v2 })
                 }
-                (BinOp::Gt, Value::Number { val: v1 }, Value::Number { val: v2 }) => {
+                (BinOp::Gt, Value::Int { val: v1 }, Value::Int { val: v2 }) => {
                     Ok(Value::Bool { val: v1 > v2 })
                 }
                 (BinOp::And, Value::Bool { val: v1 }, Value::Bool { val: v2 }) => {
@@ -155,7 +155,7 @@ pub async fn eval(
         Expr::Unop { op, expr } => {
             let val = eval(expr, env, ctx).await?;
             match (op, val) {
-                (UnOp::Neg, Value::Number { val: v }) => Ok(Value::Number { val: -v }),
+                (UnOp::Neg, Value::Int { val: v }) => Ok(Value::Int { val: -v }),
                 (UnOp::Not, Value::Bool { val: v }) => Ok(Value::Bool { val: !v }),
                 _ => Err(EvalError::TypeError(
                     "Type error in unary operation".to_string(),
@@ -268,10 +268,10 @@ mod tests {
             txn: None,
         };
         let expr = Expr::Literal {
-            val: Value::Number { val: 42 },
+            val: Value::Int { val: 42 },
         };
         let result = eval(&expr, &[], &mut ctx).await.unwrap();
-        assert_eq!(result, Value::Number { val: 42 });
+        assert_eq!(result, Value::Int { val: 42 });
     }
 
     /// Verify that evaluating a binary add operation returns the sum of the numbers
@@ -286,14 +286,14 @@ mod tests {
         let expr = Expr::Binop {
             op: BinOp::Add,
             expr1: Box::new(Expr::Literal {
-                val: Value::Number { val: 2 },
+                val: Value::Int { val: 2 },
             }),
             expr2: Box::new(Expr::Literal {
-                val: Value::Number { val: 3 },
+                val: Value::Int { val: 3 },
             }),
         };
         let result = eval(&expr, &[], &mut ctx).await.unwrap();
-        assert_eq!(result, Value::Number { val: 5 });
+        assert_eq!(result, Value::Int { val: 5 });
     }
 
     /// Verify that defining a function and calling it yields the expected computed `Value`
@@ -312,18 +312,18 @@ mod tests {
                 op: BinOp::Add,
                 expr1: Box::new(Expr::Variable { name: x }),
                 expr2: Box::new(Expr::Literal {
-                    val: Value::Number { val: 10 },
+                    val: Value::Int { val: 10 },
                 }),
             }),
         };
         let call_expr = Expr::Call {
             func: Box::new(func_expr),
             args: vec![Expr::Literal {
-                val: Value::Number { val: 5 },
+                val: Value::Int { val: 5 },
             }],
         };
         let result = eval(&call_expr, &[], &mut ctx).await.unwrap();
-        assert_eq!(result, Value::Number { val: 15 });
+        assert_eq!(result, Value::Int { val: 15 });
     }
 
     /// Verify that evaluating an action statement block produces an action `Value::ActionClosure`
@@ -339,7 +339,7 @@ mod tests {
         let action_expr = Expr::Action(vec![ActionStmt::Assign {
             name: var_name,
             expr: Expr::Literal {
-                val: Value::Number { val: 5 },
+                val: Value::Int { val: 5 },
             },
         }]);
         let result = eval(&action_expr, &[], &mut ctx).await.unwrap();
@@ -363,9 +363,9 @@ mod tests {
             txn: None,
         };
         let env = vec![
-            (v1, Value::Number { val: 1 }),
-            (v2, Value::Number { val: 2 }),
-            (v3, Value::Number { val: 3 }),
+            (v1, Value::Int { val: 1 }),
+            (v2, Value::Int { val: 2 }),
+            (v3, Value::Int { val: 3 }),
         ];
         let func_expr = Expr::Func {
             params: vec![Param { name: v4, ty: None }],
@@ -386,7 +386,7 @@ mod tests {
                 assert_eq!(params.len(), 1);
                 assert_eq!(captured_env.len(), 1);
                 assert_eq!(captured_env[0].0, v1);
-                assert_eq!(captured_env[0].1, Value::Number { val: 1 });
+                assert_eq!(captured_env[0].1, Value::Int { val: 1 });
             }
             _ => panic!("Expected Closure"),
         }

--- a/meerkat-lib/src/runtime/interpreter/evaluator.rs
+++ b/meerkat-lib/src/runtime/interpreter/evaluator.rs
@@ -82,10 +82,11 @@ pub async fn eval(
                     body,
                     env: closure_env,
                     service_name: closure_svc,
+                    ..
                 } => {
                     let mut new_env = closure_env.clone();
                     for (param, arg_val) in params.iter().zip(arg_vals) {
-                        new_env.push((*param, arg_val));
+                        new_env.push((param.name, arg_val));
                     }
                     eval(
                         &body,
@@ -174,7 +175,11 @@ pub async fn eval(
             }
         }
 
-        Expr::Func { params, body } => {
+        Expr::Func {
+            params,
+            body,
+            return_ty,
+        } => {
             let var_binded: HashSet<Symbol> = params.iter().map(|p| p.name).collect();
             let free_vars = body.free_var(&HashSet::new(), &var_binded);
             let captured_env: Vec<(Symbol, Value)> = env
@@ -191,10 +196,11 @@ pub async fn eval(
                 .cloned()
                 .collect();
             Ok(Value::Closure {
-                params: params.iter().map(|p| p.name).collect(),
+                params: params.clone(),
                 body: body.clone(),
                 env: captured_env,
                 service_name: ctx.service_name,
+                return_ty: return_ty.clone(),
             })
         }
 
@@ -315,6 +321,7 @@ mod tests {
                     val: Value::Int { val: 10 },
                 }),
             }),
+            return_ty: None,
         };
         let call_expr = Expr::Call {
             func: Box::new(func_expr),
@@ -374,6 +381,7 @@ mod tests {
                 expr1: Box::new(Expr::Variable { name: v4 }),
                 expr2: Box::new(Expr::Variable { name: v1 }),
             }),
+            return_ty: None,
         };
         let result = eval(&func_expr, &env, &mut ctx).await.unwrap();
         match result {

--- a/meerkat-lib/src/runtime/interpreter/evaluator.rs
+++ b/meerkat-lib/src/runtime/interpreter/evaluator.rs
@@ -175,7 +175,7 @@ pub async fn eval(
         }
 
         Expr::Func { params, body } => {
-            let var_binded: HashSet<Symbol> = params.iter().cloned().collect();
+            let var_binded: HashSet<Symbol> = params.iter().map(|p| p.name).collect();
             let free_vars = body.free_var(&HashSet::new(), &var_binded);
             let captured_env: Vec<(Symbol, Value)> = env
                 .iter()
@@ -191,7 +191,7 @@ pub async fn eval(
                 .cloned()
                 .collect();
             Ok(Value::Closure {
-                params: params.clone(),
+                params: params.iter().map(|p| p.name).collect(),
                 body: body.clone(),
                 env: captured_env,
                 service_name: ctx.service_name,
@@ -255,6 +255,7 @@ mod tests {
     use super::*;
     use crate::ast::{ActionStmt, BinOp, Expr, Value};
     use crate::runtime::interner::Interner;
+    use crate::runtime::tt::Param;
     use crate::runtime::Manager;
 
     /// Verify that evaluating a literal expression returns the expected runtime `Value`
@@ -306,7 +307,7 @@ mod tests {
             txn: None,
         };
         let func_expr = Expr::Func {
-            params: vec![x],
+            params: vec![Param { name: x, ty: None }],
             body: Box::new(Expr::Binop {
                 op: BinOp::Add,
                 expr1: Box::new(Expr::Variable { name: x }),
@@ -367,7 +368,7 @@ mod tests {
             (v3, Value::Number { val: 3 }),
         ];
         let func_expr = Expr::Func {
-            params: vec![v4],
+            params: vec![Param { name: v4, ty: None }],
             body: Box::new(Expr::Binop {
                 op: BinOp::Add,
                 expr1: Box::new(Expr::Variable { name: v4 }),

--- a/meerkat-lib/src/runtime/interpreter/executor.rs
+++ b/meerkat-lib/src/runtime/interpreter/executor.rs
@@ -105,7 +105,7 @@ pub async fn execute(
             match val {
                 Value::Bool { val: true } => Ok(ExecuteEffect::None),
                 Value::Bool { val: false } => Err(EvalError::AssertionError(text.clone())),
-                Value::Number { .. }
+                Value::Int { .. }
                 | Value::String { .. }
                 | Value::Closure { .. }
                 | Value::ActionClosure { .. } => {

--- a/meerkat-lib/src/runtime/interpreter/executor.rs
+++ b/meerkat-lib/src/runtime/interpreter/executor.rs
@@ -113,7 +113,7 @@ pub async fn execute(
                 }
             }
         }
-        ActionStmt::Let { name, expr } => {
+        ActionStmt::Let { name, ty: _, expr } => {
             let val = eval(
                 expr,
                 env,

--- a/meerkat-lib/src/runtime/limits.rs
+++ b/meerkat-lib/src/runtime/limits.rs
@@ -5,3 +5,6 @@ pub const MAX_IDENTIFIER_LENGTH: usize = 64;
 
 /// Maximum allowed length of a string literal in characters
 pub const MAX_STRING_LITERAL_LENGTH: usize = 8192;
+
+/// Maximum allowed nesting depth of a type structure during deserialization
+pub const MAX_TYPE_DEPTH: usize = 16;

--- a/meerkat-lib/src/runtime/manager/mod.rs
+++ b/meerkat-lib/src/runtime/manager/mod.rs
@@ -2332,18 +2332,21 @@ mod tests {
         let decls = vec![
             Decl::VarDecl {
                 name: tc.x,
+                ty: None,
                 val: Expr::Literal {
-                    val: Value::Number { val: 1 },
+                    val: Value::Int { val: 1 },
                 },
             },
             Decl::VarDecl {
                 name: tc.y,
+                ty: None,
                 val: Expr::Literal {
-                    val: Value::Number { val: 2 },
+                    val: Value::Int { val: 2 },
                 },
             },
             Decl::DefDecl {
                 name: tc.f,
+                ty: None,
                 val: Expr::Binop {
                     op: crate::ast::BinOp::Add,
                     expr1: Box::new(Expr::Variable { name: tc.x }),
@@ -2371,20 +2374,22 @@ mod tests {
         let decls = vec![
             Decl::VarDecl {
                 name: tc.x,
+                ty: None,
                 val: Expr::Literal {
-                    val: Value::Number { val: 1 },
+                    val: Value::Int { val: 1 },
                 },
             },
             // adding a bool and number should be a type error
             Decl::VarDecl {
                 name: tc.y,
+                ty: None,
                 val: Expr::Binop {
                     op: crate::ast::BinOp::Add,
                     expr1: Box::new(Expr::Literal {
                         val: Value::Bool { val: true },
                     }),
                     expr2: Box::new(Expr::Literal {
-                        val: Value::Number { val: 1 },
+                        val: Value::Int { val: 1 },
                     }),
                 },
             },
@@ -2407,8 +2412,9 @@ mod tests {
                 tc.s1,
                 vec![Decl::VarDecl {
                     name: tc.x,
+                    ty: None,
                     val: Expr::Literal {
-                        val: Value::Number { val: 7 },
+                        val: Value::Int { val: 7 },
                     },
                 }],
             )
@@ -2436,6 +2442,7 @@ mod tests {
                 tc.s2,
                 vec![Decl::DefDecl {
                     name: tc.f,
+                    ty: None,
                     val: Expr::MemberAccess {
                         service_name: tc.s1,
                         member_name: tc.x,

--- a/meerkat-lib/src/runtime/manager/mod.rs
+++ b/meerkat-lib/src/runtime/manager/mod.rs
@@ -1501,12 +1501,12 @@ mod tests {
             name: tc.x,
             ty: None,
             val: Expr::Literal {
-                val: Value::Number { val: 1 },
+                val: Value::Int { val: 1 },
             },
         }];
         tc.manager.create_service(tc.foo, decls).await.unwrap();
         let result = tc.manager.lookup(tc.x, tc.foo, None).await.unwrap();
-        assert_eq!(result, Value::Number { val: 1 });
+        assert_eq!(result, Value::Int { val: 1 });
     }
 
     #[tokio::test]
@@ -1517,7 +1517,7 @@ mod tests {
                 name: tc.x,
                 ty: None,
                 val: Expr::Literal {
-                    val: Value::Number { val: 2 },
+                    val: Value::Int { val: 2 },
                 },
             },
             Decl::DefDecl {
@@ -1527,7 +1527,7 @@ mod tests {
                     op: crate::ast::BinOp::Add,
                     expr1: Box::new(Expr::Variable { name: tc.x }),
                     expr2: Box::new(Expr::Literal {
-                        val: Value::Number { val: 3 },
+                        val: Value::Int { val: 3 },
                     }),
                 },
                 is_pub: true,
@@ -1535,7 +1535,7 @@ mod tests {
         ];
         tc.manager.create_service(tc.foo, decls).await.unwrap();
         let result = tc.manager.lookup(tc.f, tc.foo, None).await.unwrap();
-        assert_eq!(result, Value::Number { val: 5 });
+        assert_eq!(result, Value::Int { val: 5 });
     }
 
     #[tokio::test]
@@ -1554,7 +1554,7 @@ mod tests {
                 name: tc.x,
                 ty: None,
                 val: Expr::Literal {
-                    val: Value::Number { val: 1 },
+                    val: Value::Int { val: 1 },
                 },
             },
             Decl::DefDecl {
@@ -1564,7 +1564,7 @@ mod tests {
                     op: crate::ast::BinOp::Add,
                     expr1: Box::new(Expr::Variable { name: tc.x }),
                     expr2: Box::new(Expr::Literal {
-                        val: Value::Number { val: 10 },
+                        val: Value::Int { val: 10 },
                     }),
                 },
                 is_pub: true,
@@ -1574,15 +1574,15 @@ mod tests {
 
         // f should be 11 initially
         let result = tc.manager.lookup(tc.f, tc.foo, None).await.unwrap();
-        assert_eq!(result, Value::Number { val: 11 });
+        assert_eq!(result, Value::Int { val: 11 });
 
         // update x to 5, f should become 15
         tc.manager
-            .assign(tc.foo, tc.x, Value::Number { val: 5 }, None)
+            .assign(tc.foo, tc.x, Value::Int { val: 5 }, None)
             .await
             .unwrap();
         let result = tc.manager.lookup(tc.f, tc.foo, None).await.unwrap();
-        assert_eq!(result, Value::Number { val: 15 });
+        assert_eq!(result, Value::Int { val: 15 });
     }
 
     // Helper: service with a single var x = 0
@@ -1592,7 +1592,7 @@ mod tests {
             name: tc.x,
             ty: None,
             val: Expr::Literal {
-                val: Value::Number { val: 0 },
+                val: Value::Int { val: 0 },
             },
         }];
         tc.manager.create_service(tc.foo, decls).await.unwrap();
@@ -1629,13 +1629,13 @@ mod tests {
                 op: crate::ast::BinOp::Add,
                 expr1: Box::new(Expr::Variable { name: tc.x }),
                 expr2: Box::new(Expr::Literal {
-                    val: Value::Number { val: 1 },
+                    val: Value::Int { val: 1 },
                 }),
             },
         }];
         tc.manager.execute_action(tc.foo, &stmts).await.unwrap();
         let result = tc.manager.lookup(tc.x, tc.foo, None).await.unwrap();
-        assert_eq!(result, Value::Number { val: 1 });
+        assert_eq!(result, Value::Int { val: 1 });
     }
 
     #[tokio::test]
@@ -1650,14 +1650,14 @@ mod tests {
                 op: crate::ast::BinOp::Add,
                 expr1: Box::new(Expr::Variable { name: tc.x }),
                 expr2: Box::new(Expr::Literal {
-                    val: Value::Number { val: 1 },
+                    val: Value::Int { val: 1 },
                 }),
             },
         }];
         tc.manager.execute_action(tc.foo, &stmts).await.unwrap();
         tc.manager.execute_action(tc.foo, &stmts).await.unwrap();
         let result = tc.manager.lookup(tc.x, tc.foo, None).await.unwrap();
-        assert_eq!(result, Value::Number { val: 2 });
+        assert_eq!(result, Value::Int { val: 2 });
     }
 
     #[tokio::test]
@@ -1668,7 +1668,7 @@ mod tests {
         let stmts = vec![ActionStmt::Assign {
             name: tc.x,
             expr: Expr::Literal {
-                val: Value::Number { val: 42 },
+                val: Value::Int { val: 42 },
             },
         }];
         tc.manager.execute_action(tc.foo, &stmts).await.unwrap();
@@ -1683,14 +1683,14 @@ mod tests {
         let stmts = vec![ActionStmt::Assign {
             name: tc.x,
             expr: Expr::Literal {
-                val: Value::Number { val: 42 },
+                val: Value::Int { val: 42 },
             },
         }];
 
         tc.manager.execute_action(tc.foo, &stmts).await.unwrap();
 
         let state = x_state(&tc);
-        assert_eq!(state.value, Value::Number { val: 42 });
+        assert_eq!(state.value, Value::Int { val: 42 });
         assert!(state.latest_write_txn.is_some());
     }
 
@@ -1709,7 +1709,7 @@ mod tests {
                 op: crate::ast::BinOp::Add,
                 expr1: Box::new(Expr::Variable { name: tc.x }),
                 expr2: Box::new(Expr::Literal {
-                    val: Value::Number { val: 1 },
+                    val: Value::Int { val: 1 },
                 }),
             },
         }]);
@@ -1719,7 +1719,7 @@ mod tests {
         // inner write took effect
         let result = tc.manager.lookup(tc.x, tc.foo, None).await.unwrap();
         // and the lock was released
-        assert_eq!(result, Value::Number { val: 1 });
+        assert_eq!(result, Value::Int { val: 1 });
         assert_x_unlocked(&tc);
     }
 
@@ -1734,7 +1734,7 @@ mod tests {
             ActionStmt::Assign {
                 name: tc.x,
                 expr: Expr::Literal {
-                    val: Value::Number { val: 99 },
+                    val: Value::Int { val: 99 },
                 },
             },
             ActionStmt::Assert(
@@ -1749,7 +1749,7 @@ mod tests {
         // `x` must remain 0 — the buffered write to 99 was never committed
         let x = tc.manager.lookup(tc.x, tc.foo, None).await.unwrap();
         // and the lock was released
-        assert_eq!(x, Value::Number { val: 0 });
+        assert_eq!(x, Value::Int { val: 0 });
         assert_x_unlocked(&tc);
     }
 
@@ -1762,7 +1762,7 @@ mod tests {
         let successful_write = vec![ActionStmt::Assign {
             name: tc.x,
             expr: Expr::Literal {
-                val: Value::Number { val: 1 },
+                val: Value::Int { val: 1 },
             },
         }];
         tc.manager
@@ -1776,7 +1776,7 @@ mod tests {
             ActionStmt::Assign {
                 name: tc.x,
                 expr: Expr::Literal {
-                    val: Value::Number { val: 99 },
+                    val: Value::Int { val: 99 },
                 },
             },
             ActionStmt::Assert(
@@ -1791,7 +1791,7 @@ mod tests {
 
         assert!(result.is_err());
         let state = x_state(&tc);
-        assert_eq!(state.value, Value::Number { val: 1 });
+        assert_eq!(state.value, Value::Int { val: 1 });
         assert_eq!(state.latest_write_txn, previous_txn);
         assert_x_unlocked(&tc);
     }
@@ -1810,7 +1810,7 @@ mod tests {
         let result = tc.manager.execute_action(tc.foo, &stmts).await;
 
         assert!(result.is_err());
-        assert_eq!(x_state(&tc).value, Value::Number { val: 0 });
+        assert_eq!(x_state(&tc).value, Value::Int { val: 0 });
         // NOTE: changed this test case to check that the latest_write_txn is the txn that created
         // the service and not none (as it was previously). Since this is changing a test case,
         // please make sure to review it
@@ -1832,7 +1832,7 @@ mod tests {
                 op: crate::ast::BinOp::Add,
                 expr1: Box::new(Expr::Variable { name: tc.w }),
                 expr2: Box::new(Expr::Literal {
-                    val: Value::Number { val: 5 },
+                    val: Value::Int { val: 5 },
                 }),
             },
         }]);
@@ -1844,7 +1844,7 @@ mod tests {
                         name: tc.w,
                         ty: None,
                         val: Expr::Literal {
-                            val: Value::Number { val: 10 },
+                            val: Value::Int { val: 10 },
                         },
                     },
                     Decl::DefDecl {
@@ -1865,7 +1865,7 @@ mod tests {
                     name: tc.x,
                     ty: None,
                     val: Expr::Literal {
-                        val: Value::Number { val: 0 },
+                        val: Value::Int { val: 0 },
                     },
                 }],
             )
@@ -1880,7 +1880,7 @@ mod tests {
                     op: crate::ast::BinOp::Add,
                     expr1: Box::new(Expr::Variable { name: tc.x }),
                     expr2: Box::new(Expr::Literal {
-                        val: Value::Number { val: 1 },
+                        val: Value::Int { val: 1 },
                     }),
                 },
             },
@@ -1894,11 +1894,11 @@ mod tests {
         // Both services' writes committed
         assert_eq!(
             tc.manager.lookup(tc.x, tc.s1, None).await.unwrap(),
-            Value::Number { val: 1 }
+            Value::Int { val: 1 }
         );
         assert_eq!(
             tc.manager.lookup(tc.w, tc.s2, None).await.unwrap(),
-            Value::Number { val: 15 }
+            Value::Int { val: 15 }
         );
         // Locks released on both services
         assert!(matches!(
@@ -1937,7 +1937,7 @@ mod tests {
                     name: tc.x,
                     ty: None,
                     val: Expr::Literal {
-                        val: Value::Number { val: 0 },
+                        val: Value::Int { val: 0 },
                     },
                 }],
             )
@@ -1979,7 +1979,7 @@ mod tests {
                     name: tc.x,
                     ty: None,
                     val: Expr::Literal {
-                        val: Value::Number { val: 0 },
+                        val: Value::Int { val: 0 },
                     },
                 }],
             )
@@ -2017,7 +2017,7 @@ mod tests {
                     name: tc.x,
                     ty: None,
                     val: Expr::Literal {
-                        val: Value::Number { val: 0 },
+                        val: Value::Int { val: 0 },
                     },
                 }],
             )
@@ -2042,7 +2042,7 @@ mod tests {
                 op: crate::ast::BinOp::Add,
                 expr1: Box::new(Expr::Variable { name: tc.x }),
                 expr2: Box::new(Expr::Literal {
-                    val: Value::Number { val: 1 },
+                    val: Value::Int { val: 1 },
                 }),
             },
         }];
@@ -2076,14 +2076,14 @@ mod tests {
                         name: tc.y,
                         ty: None,
                         val: Expr::Literal {
-                            val: Value::Number { val: 0 },
+                            val: Value::Int { val: 0 },
                         },
                     },
                     Decl::VarDecl {
                         name: tc.x,
                         ty: None,
                         val: Expr::Literal {
-                            val: Value::Number { val: 0 },
+                            val: Value::Int { val: 0 },
                         },
                     },
                 ],
@@ -2115,7 +2115,7 @@ mod tests {
             ActionStmt::Assign {
                 name: tc.y,
                 expr: Expr::Literal {
-                    val: Value::Number { val: 5 },
+                    val: Value::Int { val: 5 },
                 },
             },
             ActionStmt::Assign {
@@ -2124,7 +2124,7 @@ mod tests {
                     op: crate::ast::BinOp::Add,
                     expr1: Box::new(Expr::Variable { name: tc.x }),
                     expr2: Box::new(Expr::Literal {
-                        val: Value::Number { val: 1 },
+                        val: Value::Int { val: 1 },
                     }),
                 },
             },
@@ -2163,7 +2163,7 @@ mod tests {
                     name: tc.x,
                     ty: None,
                     val: Expr::Literal {
-                        val: Value::Number { val: 0 },
+                        val: Value::Int { val: 0 },
                     },
                 }],
             )
@@ -2216,7 +2216,7 @@ mod tests {
                     name: tc.x,
                     ty: None,
                     val: Expr::Literal {
-                        val: Value::Number { val: 0 },
+                        val: Value::Int { val: 0 },
                     },
                 }],
             )
@@ -2256,7 +2256,7 @@ mod tests {
                 op: crate::ast::BinOp::Add,
                 expr1: Box::new(Expr::Variable { name: tc.x }),
                 expr2: Box::new(Expr::Literal {
-                    val: Value::Number { val: 1 },
+                    val: Value::Int { val: 1 },
                 }),
             },
         }];

--- a/meerkat-lib/src/runtime/manager/mod.rs
+++ b/meerkat-lib/src/runtime/manager/mod.rs
@@ -236,7 +236,7 @@ impl Manager {
 
         for decl in decls {
             match decl {
-                Decl::VarDecl { name, val } => {
+                Decl::VarDecl { name, ty: _, val } => {
                     let value = match eval(
                         &val,
                         &env,
@@ -1499,6 +1499,7 @@ mod tests {
         let mut tc = TestContext::new();
         let decls = vec![Decl::VarDecl {
             name: tc.x,
+            ty: None,
             val: Expr::Literal {
                 val: Value::Number { val: 1 },
             },
@@ -1514,12 +1515,14 @@ mod tests {
         let decls = vec![
             Decl::VarDecl {
                 name: tc.x,
+                ty: None,
                 val: Expr::Literal {
                     val: Value::Number { val: 2 },
                 },
             },
             Decl::DefDecl {
                 name: tc.f,
+                ty: None,
                 val: Expr::Binop {
                     op: crate::ast::BinOp::Add,
                     expr1: Box::new(Expr::Variable { name: tc.x }),
@@ -1549,12 +1552,14 @@ mod tests {
         let decls = vec![
             Decl::VarDecl {
                 name: tc.x,
+                ty: None,
                 val: Expr::Literal {
                     val: Value::Number { val: 1 },
                 },
             },
             Decl::DefDecl {
                 name: tc.f,
+                ty: None,
                 val: Expr::Binop {
                     op: crate::ast::BinOp::Add,
                     expr1: Box::new(Expr::Variable { name: tc.x }),
@@ -1585,6 +1590,7 @@ mod tests {
         let mut tc = TestContext::new();
         let decls = vec![Decl::VarDecl {
             name: tc.x,
+            ty: None,
             val: Expr::Literal {
                 val: Value::Number { val: 0 },
             },
@@ -1836,12 +1842,14 @@ mod tests {
                 vec![
                     Decl::VarDecl {
                         name: tc.w,
+                        ty: None,
                         val: Expr::Literal {
                             val: Value::Number { val: 10 },
                         },
                     },
                     Decl::DefDecl {
                         name: tc.bump,
+                        ty: None,
                         val: bump,
                         is_pub: true,
                     },
@@ -1855,6 +1863,7 @@ mod tests {
                 tc.s1,
                 vec![Decl::VarDecl {
                     name: tc.x,
+                    ty: None,
                     val: Expr::Literal {
                         val: Value::Number { val: 0 },
                     },
@@ -1926,6 +1935,7 @@ mod tests {
                 tc.s1,
                 vec![Decl::VarDecl {
                     name: tc.x,
+                    ty: None,
                     val: Expr::Literal {
                         val: Value::Number { val: 0 },
                     },
@@ -1967,6 +1977,7 @@ mod tests {
                 tc.s1,
                 vec![Decl::VarDecl {
                     name: tc.x,
+                    ty: None,
                     val: Expr::Literal {
                         val: Value::Number { val: 0 },
                     },
@@ -2004,6 +2015,7 @@ mod tests {
                 tc.s1,
                 vec![Decl::VarDecl {
                     name: tc.x,
+                    ty: None,
                     val: Expr::Literal {
                         val: Value::Number { val: 0 },
                     },
@@ -2062,12 +2074,14 @@ mod tests {
                 vec![
                     Decl::VarDecl {
                         name: tc.y,
+                        ty: None,
                         val: Expr::Literal {
                             val: Value::Number { val: 0 },
                         },
                     },
                     Decl::VarDecl {
                         name: tc.x,
+                        ty: None,
                         val: Expr::Literal {
                             val: Value::Number { val: 0 },
                         },
@@ -2147,6 +2161,7 @@ mod tests {
                 tc.s1,
                 vec![Decl::VarDecl {
                     name: tc.x,
+                    ty: None,
                     val: Expr::Literal {
                         val: Value::Number { val: 0 },
                     },
@@ -2199,6 +2214,7 @@ mod tests {
                 tc.s1,
                 vec![Decl::VarDecl {
                     name: tc.x,
+                    ty: None,
                     val: Expr::Literal {
                         val: Value::Number { val: 0 },
                     },

--- a/meerkat-lib/src/runtime/mod.rs
+++ b/meerkat-lib/src/runtime/mod.rs
@@ -1,3 +1,8 @@
+//! Runtime components for the Meerkat language.
+//!
+//! This module coordinates AST, interner, interpreter, txn management,
+//! type definitions, and semantic analysis modules
+
 pub mod ast;
 pub mod interner;
 pub mod interpreter;
@@ -5,6 +10,7 @@ pub mod limits;
 pub mod manager;
 pub mod parser;
 pub mod semantic_analysis;
+pub mod tt;
 pub mod txn;
 
 pub use interner::{Interner, Symbol};

--- a/meerkat-lib/src/runtime/parser/lex.rs
+++ b/meerkat-lib/src/runtime/parser/lex.rs
@@ -180,8 +180,6 @@ pub enum Token<'a> {
     IF_KW,
     #[token("else")]
     ELSE_KW,
-    #[token("number")]
-    NUMBER_KW,
     #[token("string")]
     STRING_KW,
     #[token("bool")]

--- a/meerkat-lib/src/runtime/parser/lex.rs
+++ b/meerkat-lib/src/runtime/parser/lex.rs
@@ -102,6 +102,8 @@ pub enum Token<'a> {
     Assgn,
     #[token("=>")]
     Fn_Assgn,
+    #[token("->")]
+    Arrow,
     #[token("==")]
     EQ_EQ,
     #[token("<")]
@@ -186,6 +188,10 @@ pub enum Token<'a> {
     BOOL_KW,
     #[token("let")]
     LET_KW,
+    #[token("int")]
+    INT_KW,
+    #[token("unit")]
+    UNIT_KW,
     #[token("watch")]
     WATCH_KW,
 

--- a/meerkat-lib/src/runtime/parser/meerkat.lalrpop
+++ b/meerkat-lib/src/runtime/parser/meerkat.lalrpop
@@ -1,10 +1,3 @@
-// L1 Compiler
-// Parser Grammar
-// Author: Miles Conn <mconn@andrew.cmu.edu>
-
-// Initial grammar for L1 
-
-// Grammar 
 grammar<'input>(
     input: &'input str,
     interner: &mut Interner
@@ -15,7 +8,6 @@ use crate::runtime::interner::{Interner, Symbol};
 use lalrpop_util::ParseError;
 use crate::runtime::parser::lex::Token;
 use crate::runtime::limits::MAX_STRING_LITERAL_LENGTH;
-
 use std::str::FromStr;
 
 extern {
@@ -46,12 +38,15 @@ extern {
         "number" => Token::NUMBER_KW,
         "string" => Token::STRING_KW,
         "bool" => Token::BOOL_KW,
+        "int" => Token::INT_KW,
+        "unit" => Token::UNIT_KW,
         "let" => Token::LET_KW,
         "watch" => Token::WATCH_KW,
         ";" => Token::Semicolon,
         "." => Token::Dot,
         "=" => Token::Assgn,
         "=>" => Token::Fn_Assgn,
+        "->" => Token::Arrow,
         "+" => Token::Plus,
         "-" => Token::Minus,
         "*" => Token::Asterisk,
@@ -62,9 +57,6 @@ extern {
         "&&" => Token::AND_AND,
         "||" => Token::OR_OR,
         "!" => Token::NOT_NOT,
-
-        
-        
         "strlit" => Token::StrLit(<&'input str>),
         "ident" => Token::Ident(<&'input str>),
         "num" => Token::Number(<i32>),
@@ -104,7 +96,9 @@ Stmt: Stmt = {
 ActionStmts: Vec<ActionStmt> = ActionStmt*;
 
 ActionStmt: ActionStmt = {
-    "let" <i:Ident> "=" <e:Expr> ";" => ActionStmt::Let { name: i, expr: e },
+    "let" <i:Ident> <t:(":" <Type>)?> "=" <e:Expr> ";" => {
+        ActionStmt::Let { name: i, ty: t, expr: e }
+    },
     "do" <e: Expr> ";" => {
         ActionStmt::Do(e)
     },
@@ -131,43 +125,76 @@ ActionStmt: ActionStmt = {
 }
 
 Decl: Decl = {
-    "var" <i:Ident> "=" <e:Expr> ";" => {
-        Decl::VarDecl { name: i, val: e }
+    "var" <i:Ident> <t:(":" <Type>)?> "=" <e:Expr> ";" => {
+        Decl::VarDecl { name: i, ty: t, val: e }
     },
-    "pub" "def" <i:Ident> "=" <e:Expr> ";" => {
-        Decl::DefDecl { name: i, val: e, is_pub: true }
+    "pub" "def" <i:Ident> <t:(":" <Type>)?> "=" <e:Expr> ";" => {
+        Decl::DefDecl { name: i, ty: t, val: e, is_pub: true }
     },
-    "def" <i:Ident> "=" <e:Expr> ";" => {
-        Decl::DefDecl { name: i, val: e, is_pub: false }
+    "def" <i:Ident> <t:(":" <Type>)?> "=" <e:Expr> ";" => {
+        Decl::DefDecl { name: i, ty: t, val: e, is_pub: false }
     },
-    "table" <i:Ident> "{" <f: Fields> "}" ";" => {
+    "table" <i:Ident> "{" <f: TableFields> "}" ";" => {
         Decl::TableDecl {name: i, fields: f }
     }
 }
 
 Decls: Vec<Decl> = Decl*;
 
-Field: Field = {
-   <i:Ident> ":" <t: DataType> "," => {
+TableField: Field = {
+   <i:Ident> ":" <t: TableType> "," => {
     Field {name: i, ty: t}
    } 
 }
 
-Fields: Vec<Field> = Field*;
+TableFields: Vec<Field> = TableField*;
 
-DataType: DataType = {
-    "number" => DataType::Number,
+TableType: DataType = {
+    "int" => DataType::Int,
     "string" => DataType::String,
     "bool" => DataType::Bool,
 }
 
-Params: Vec<Symbol> = {
-    <mut v:(<Ident> ",")*> <e:Ident?> => 
-    match e {
-        None => v,
-        Some(e) => {
-            v.push(e);
-            v
+Type: Type = {
+    <s:SimpleType> => s,
+    <s:SimpleType> "->" <t:Type> => {
+        Type::Func(Box::new(s), Box::new(t))
+    },
+    "()" "->" <t:Type> => {
+        Type::Func(Box::new(Type::Unit), Box::new(t))
+    },
+}
+
+SimpleType: Type = {
+    "int" => Type::Int,
+    "string" => Type::String,
+    "bool" => Type::Bool,
+    "unit" => Type::Unit,
+    "(" <t:Type> <mut ts:("," <Type>)*> ")" => {
+        if ts.is_empty() {
+            t
+        } else {
+            let mut v = vec![t];
+            v.append(&mut ts);
+            Type::Tuple(v)
+        }
+    }
+}
+
+Param: Param = {
+    <i:Ident> <t:(":" <Type>)?> => Param { name: i, ty: t }
+}
+
+Params: Vec<Param> = {
+    "()" => vec![],
+    <i:Ident> => vec![Param { name: i, ty: None }],
+    "(" <mut v:(<Param> ",")*> <e:Param?> ")" => {
+        match e {
+            None => v,
+            Some(e) => {
+                v.push(e);
+                v
+            }
         }
     }
 }
@@ -182,8 +209,6 @@ Args: Vec<Expr> = {
         }
     }
 }
-
-
 
 SubExpr: Expr = {
     <n:Number> => Expr::Literal { val: Value::Number { val: n } },
@@ -248,7 +273,6 @@ Expr: Expr = {
             op: BinOp::Sub 
         }
     },
-   
 
     #[precedence(level="4")] #[assoc(side="left")]
     <e1:Expr> "==" <e2:Expr> => {
@@ -281,7 +305,6 @@ Expr: Expr = {
             op: BinOp::And 
         }
     },
-   
 
     #[precedence(level="6")] #[assoc(side="left")]
     <e1:Expr> "||" <e2:Expr> => {

--- a/meerkat-lib/src/runtime/parser/meerkat.lalrpop
+++ b/meerkat-lib/src/runtime/parser/meerkat.lalrpop
@@ -170,13 +170,17 @@ SimpleType: Type = {
     "string" => Type::String,
     "bool" => Type::Bool,
     "unit" => Type::Unit,
-    "(" <t:Type> <mut ts:("," <Type>)*> ")" => {
+    "(" <t:Type> <mut ts:("," <Type>)*> ")" =>? {
         if ts.is_empty() {
-            t
+            Ok(t)
         } else {
             let mut v = vec![t];
             v.append(&mut ts);
-            Type::Tuple(TupleType::new(v).unwrap())
+            TupleType::new(v)
+                .map(Type::Tuple)
+                .map_err(|e| ParseError::User {
+                    error: e.to_string(),
+                })
         }
     }
 }
@@ -326,9 +330,12 @@ Expr: Expr = {
     },
 
     #[precedence(level="8")] #[assoc(side="left")]
-    "fn" <params:Params> "=>" <e:Expr> => 
-    Expr::Func {
-        params, body: Box::new(e), return_ty: None
+    "fn" <params:Params> "=>" <e:Expr> => {
+        // The `return_ty` is set to `None` here because return types
+        // are inferred by a later pass instead of being parsed
+        Expr::Func {
+            params, body: Box::new(e), return_ty: None
+        }
     },
     "select" <mut cols: (<Ident> ",")*> <c: Ident?> "from" <t: Ident> "where" <cond: Expr> => Expr::Select {
         table_name: t,

--- a/meerkat-lib/src/runtime/parser/meerkat.lalrpop
+++ b/meerkat-lib/src/runtime/parser/meerkat.lalrpop
@@ -4,7 +4,7 @@ grammar<'input>(
 );
 
 use crate::ast::{Stmt, ActionStmt, Decl, Expr, UnOp, BinOp, TableType, Field, Value};
-use crate::runtime::tt::{Type, Param};
+use crate::runtime::tt::{Type, Param, TupleType};
 use crate::runtime::interner::{Interner, Symbol};
 use lalrpop_util::ParseError;
 use crate::runtime::parser::lex::Token;
@@ -176,7 +176,7 @@ SimpleType: Type = {
         } else {
             let mut v = vec![t];
             v.append(&mut ts);
-            Type::Tuple(v)
+            Type::Tuple(TupleType::new(v).unwrap())
         }
     }
 }

--- a/meerkat-lib/src/runtime/parser/meerkat.lalrpop
+++ b/meerkat-lib/src/runtime/parser/meerkat.lalrpop
@@ -3,7 +3,7 @@ grammar<'input>(
     interner: &mut Interner
 );
 
-use crate::ast::{Stmt, ActionStmt, Decl, Expr, UnOp, BinOp, DataType, Field, Value};
+use crate::ast::{Stmt, ActionStmt, Decl, Expr, UnOp, BinOp, TableType, Field, Value};
 use crate::runtime::tt::{Type, Param};
 use crate::runtime::interner::{Interner, Symbol};
 use lalrpop_util::ParseError;
@@ -36,7 +36,6 @@ extern {
         "then" => Token::THEN_KW,
         "if" => Token::IF_KW,
         "else" => Token::ELSE_KW,
-        "number" => Token::NUMBER_KW,
         "string" => Token::STRING_KW,
         "bool" => Token::BOOL_KW,
         "int" => Token::INT_KW,
@@ -150,10 +149,10 @@ TableField: Field = {
 
 TableFields: Vec<Field> = TableField*;
 
-TableType: DataType = {
-    "number" => DataType::Number,
-    "string" => DataType::String,
-    "bool" => DataType::Bool,
+TableType: TableType = {
+    "int" => TableType::Int,
+    "string" => TableType::String,
+    "bool" => TableType::Bool,
 }
 
 Type: Type = {
@@ -213,7 +212,7 @@ Args: Vec<Expr> = {
 }
 
 SubExpr: Expr = {
-    <n:Number> => Expr::Literal { val: Value::Number { val: n } },
+    <n:Number> => Expr::Literal { val: Value::Int { val: n } },
     <b:Bool> => Expr::Literal { val: Value::Bool { val: b } },
     <s: "strlit"> => Expr::Literal { val: Value::String { val: s.to_owned() } },
     <i:Ident> => Expr::Variable { name: i },

--- a/meerkat-lib/src/runtime/parser/meerkat.lalrpop
+++ b/meerkat-lib/src/runtime/parser/meerkat.lalrpop
@@ -4,6 +4,7 @@ grammar<'input>(
 );
 
 use crate::ast::{Stmt, ActionStmt, Decl, Expr, UnOp, BinOp, DataType, Field, Value};
+use crate::runtime::tt::{Type, Param};
 use crate::runtime::interner::{Interner, Symbol};
 use lalrpop_util::ParseError;
 use crate::runtime::parser::lex::Token;
@@ -150,7 +151,7 @@ TableField: Field = {
 TableFields: Vec<Field> = TableField*;
 
 TableType: DataType = {
-    "int" => DataType::Int,
+    "number" => DataType::Number,
     "string" => DataType::String,
     "bool" => DataType::Bool,
 }
@@ -160,7 +161,7 @@ Type: Type = {
     <s:SimpleType> "->" <t:Type> => {
         Type::Func(Box::new(s), Box::new(t))
     },
-    "()" "->" <t:Type> => {
+    "(" ")" "->" <t:Type> => {
         Type::Func(Box::new(Type::Unit), Box::new(t))
     },
 }
@@ -186,9 +187,9 @@ Param: Param = {
 }
 
 Params: Vec<Param> = {
-    "()" => vec![],
+    "(" ")" => vec![],
     <i:Ident> => vec![Param { name: i, ty: None }],
-    "(" <mut v:(<Param> ",")*> <e:Param?> ")" => {
+    "(" <mut v:(<Param> ",")+> <e:Param?> ")" => {
         match e {
             None => v,
             Some(e) => {
@@ -196,7 +197,8 @@ Params: Vec<Param> = {
                 v
             }
         }
-    }
+    },
+    "(" <e:Param> ")" => vec![e],
 }
 
 Args: Vec<Expr> = {

--- a/meerkat-lib/src/runtime/parser/meerkat.lalrpop
+++ b/meerkat-lib/src/runtime/parser/meerkat.lalrpop
@@ -328,7 +328,7 @@ Expr: Expr = {
     #[precedence(level="8")] #[assoc(side="left")]
     "fn" <params:Params> "=>" <e:Expr> => 
     Expr::Func {
-        params, body: Box::new(e)
+        params, body: Box::new(e), return_ty: None
     },
     "select" <mut cols: (<Ident> ",")*> <c: Ident?> "from" <t: Ident> "where" <cond: Expr> => Expr::Select {
         table_name: t,

--- a/meerkat-lib/src/runtime/parser/mod.rs
+++ b/meerkat-lib/src/runtime/parser/mod.rs
@@ -215,4 +215,37 @@ mod tests {
             Err(ParseError::User { ref error }) if error.contains("Assertion text exceeds maximum length")
         ));
     }
+
+    /// Verify that parsing a table declaration with unified `int` type
+    /// is successful
+    #[test]
+    fn test_parse_table_definition() {
+        use crate::ast::{Decl, Stmt, TableType};
+
+        let mut interner = Interner::new();
+        let input = "service test_srv { \
+            table test_tbl { \
+                id: int, \
+                name: string, \
+                active: bool, \
+            }; \
+        }";
+        let res = parse_string(input, &mut interner);
+        assert!(res.is_ok());
+        let ast = res.unwrap();
+        assert_eq!(ast.len(), 1);
+        if let Stmt::Service { decls, .. } = &ast[0] {
+            assert_eq!(decls.len(), 1);
+            if let Decl::TableDecl { fields, .. } = &decls[0] {
+                assert_eq!(fields.len(), 3);
+                assert_eq!(fields[0].ty, TableType::Int);
+                assert_eq!(fields[1].ty, TableType::String);
+                assert_eq!(fields[2].ty, TableType::Bool);
+            } else {
+                panic!("Expected TableDecl");
+            }
+        } else {
+            panic!("Expected Service Stmt");
+        }
+    }
 }

--- a/meerkat-lib/src/runtime/semantic_analysis/var_analysis/alpha_rename.rs
+++ b/meerkat-lib/src/runtime/semantic_analysis/var_analysis/alpha_rename.rs
@@ -43,7 +43,7 @@ impl Expr {
                 expr1.alpha_rename(var_binded, renames);
                 expr2.alpha_rename(var_binded, renames);
             }
-            Expr::Func { params, body } => {
+            Expr::Func { params, body, .. } => {
                 let mut new_binds = var_binded.clone();
                 new_binds.extend(params.iter().map(|p| p.name));
                 body.alpha_rename(&new_binds, renames);

--- a/meerkat-lib/src/runtime/semantic_analysis/var_analysis/alpha_rename.rs
+++ b/meerkat-lib/src/runtime/semantic_analysis/var_analysis/alpha_rename.rs
@@ -45,7 +45,7 @@ impl Expr {
             }
             Expr::Func { params, body } => {
                 let mut new_binds = var_binded.clone();
-                new_binds.extend(params.iter().cloned());
+                new_binds.extend(params.iter().map(|p| p.name));
                 body.alpha_rename(&new_binds, renames);
             }
             Expr::Call { func, args } => {

--- a/meerkat-lib/src/runtime/semantic_analysis/var_analysis/mod.rs
+++ b/meerkat-lib/src/runtime/semantic_analysis/var_analysis/mod.rs
@@ -121,7 +121,7 @@ mod tests {
                     name: v2,
                     ty: None,
                     val: Expr::Literal {
-                        val: Value::Number { val: 1 },
+                        val: Value::Int { val: 1 },
                     },
                 },
                 Decl::DefDecl {
@@ -150,7 +150,7 @@ mod tests {
                     name: v2,
                     ty: None,
                     val: Expr::Literal {
-                        val: Value::Number { val: 2 },
+                        val: Value::Int { val: 2 },
                     },
                 },
                 Decl::DefDecl {

--- a/meerkat-lib/src/runtime/semantic_analysis/var_analysis/mod.rs
+++ b/meerkat-lib/src/runtime/semantic_analysis/var_analysis/mod.rs
@@ -119,12 +119,14 @@ mod tests {
             decls: vec![
                 Decl::VarDecl {
                     name: v2,
+                    ty: None,
                     val: Expr::Literal {
                         val: Value::Number { val: 1 },
                     },
                 },
                 Decl::DefDecl {
                     name: v3,
+                    ty: None,
                     val: Expr::Variable { name: v2 },
                     is_pub: false,
                 },
@@ -146,12 +148,14 @@ mod tests {
             decls: vec![
                 Decl::VarDecl {
                     name: v2,
+                    ty: None,
                     val: Expr::Literal {
                         val: Value::Number { val: 2 },
                     },
                 },
                 Decl::DefDecl {
                     name: v3,
+                    ty: None,
                     val: Expr::Variable { name: v2 },
                     is_pub: true,
                 },

--- a/meerkat-lib/src/runtime/semantic_analysis/var_analysis/read_write.rs
+++ b/meerkat-lib/src/runtime/semantic_analysis/var_analysis/read_write.rs
@@ -53,7 +53,7 @@ impl Expr {
                 free_vars.extend(expr2.free_var(reactive_names, var_binded));
                 free_vars
             }
-            Expr::Func { params, body } => {
+            Expr::Func { params, body, .. } => {
                 let mut new_binds = var_binded.clone();
                 new_binds.extend(params.iter().map(|p| p.name));
                 body.free_var(reactive_names, &new_binds)

--- a/meerkat-lib/src/runtime/semantic_analysis/var_analysis/read_write.rs
+++ b/meerkat-lib/src/runtime/semantic_analysis/var_analysis/read_write.rs
@@ -55,7 +55,7 @@ impl Expr {
             }
             Expr::Func { params, body } => {
                 let mut new_binds = var_binded.clone();
-                new_binds.extend(params.iter().cloned());
+                new_binds.extend(params.iter().map(|p| p.name));
                 body.free_var(reactive_names, &new_binds)
             }
             Expr::Call { func, args } => {
@@ -78,7 +78,11 @@ impl Expr {
                         ActionStmt::Assert(expr, _) => {
                             free_vars.extend(expr.free_var(reactive_names, var_binded));
                         }
-                        ActionStmt::Let { name: _, expr } => {
+                        ActionStmt::Let {
+                            name: _,
+                            ty: _,
+                            expr,
+                        } => {
                             free_vars.extend(expr.free_var(reactive_names, var_binded));
                         }
                         ActionStmt::Expr(expr) => {

--- a/meerkat-lib/src/runtime/tt/mod.rs
+++ b/meerkat-lib/src/runtime/tt/mod.rs
@@ -3,4 +3,5 @@
 pub mod types;
 
 pub use types::Param;
+pub use types::TupleType;
 pub use types::Type;

--- a/meerkat-lib/src/runtime/tt/mod.rs
+++ b/meerkat-lib/src/runtime/tt/mod.rs
@@ -1,0 +1,6 @@
+//! Type system module
+
+pub mod types;
+
+pub use types::Param;
+pub use types::Type;

--- a/meerkat-lib/src/runtime/tt/types.rs
+++ b/meerkat-lib/src/runtime/tt/types.rs
@@ -105,16 +105,14 @@ impl std::fmt::Display for Type {
             Type::Func(t1, t2) => {
                 // Determine if the left-hand side is a function type
                 // to preserve right-associativity during formatting
-                let is_func = match t1.as_ref() {
-                    Type::Func(_, _) => true,
-                    Type::Int | Type::String | Type::Bool | Type::Unit | Type::Tuple(_) => false,
-                };
-                if is_func {
-                    write!(f, "({}) -> {}", t1, t2)
-                } else if matches!(t1.as_ref(), Type::Unit) {
-                    write!(f, "() -> {}", t2)
-                } else {
-                    write!(f, "{} -> {}", t1, t2)
+                match t1.as_ref() {
+                    Type::Func(..) => {
+                        write!(f, "({}) -> {}", t1, t2)
+                    }
+                    Type::Unit => write!(f, "() -> {}", t2),
+                    Type::Int | Type::String | Type::Bool | Type::Tuple(_) => {
+                        write!(f, "{} -> {}", t1, t2)
+                    }
                 }
             }
         }

--- a/meerkat-lib/src/runtime/tt/types.rs
+++ b/meerkat-lib/src/runtime/tt/types.rs
@@ -15,8 +15,64 @@ pub enum Type {
     String,
     Bool,
     Unit,
-    Tuple(Vec<Type>),
+    Tuple(TupleType),
     Func(Box<Type>, Box<Type>),
+}
+
+/// A tuple type wrapping a list of types of arity 2 or greater
+///
+/// This structure enforces the canonical representation invariant
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct TupleType(Vec<Type>);
+
+impl TupleType {
+    /// Create a new `TupleType` with at least 2 elements
+    ///
+    /// Args:
+    ///     `types` (`Vec<Type>`): The list of types to wrap
+    ///
+    /// Returns:
+    ///     `Result<Self, &'static str>`: The constructed `TupleType`
+    ///     if valid
+    pub fn new(types: Vec<Type>) -> Result<Self, &'static str> {
+        if types.len() < 2 {
+            Err("Tuple must contain at least 2 elements")
+        } else {
+            Ok(Self(types))
+        }
+    }
+}
+
+impl std::ops::Deref for TupleType {
+    type Target = [Type];
+
+    /// Dereference to the underlying slice of `Type`
+    ///
+    /// Returns:
+    ///     `&[Type]`: The slice of types
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl std::fmt::Display for TupleType {
+    /// Format the tuple type for display
+    ///
+    /// Args:
+    ///     `f` (`&mut std::fmt::Formatter<'_>`): Formatter
+    ///
+    /// Returns:
+    ///     `std::fmt::Result`: The result of formatting
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "(")?;
+        for (i, t) in self.0.iter().enumerate() {
+            if i > 0 {
+                write!(f, ", ")?;
+            }
+            write!(f, "{}", t)?;
+        }
+        write!(f, ")")
+    }
 }
 
 /// Represents a function parameter
@@ -45,16 +101,7 @@ impl std::fmt::Display for Type {
             Type::String => write!(f, "string"),
             Type::Bool => write!(f, "bool"),
             Type::Unit => write!(f, "unit"),
-            Type::Tuple(ts) => {
-                write!(f, "(")?;
-                for (i, t) in ts.iter().enumerate() {
-                    if i > 0 {
-                        write!(f, ", ")?;
-                    }
-                    write!(f, "{}", t)?;
-                }
-                write!(f, ")")
-            }
+            Type::Tuple(ts) => write!(f, "{}", ts),
             Type::Func(t1, t2) => {
                 // Determine if the left-hand side is a function type
                 // to preserve right-associativity during formatting
@@ -145,7 +192,32 @@ mod tests {
         assert_eq!(ty6.to_string(), "(() -> int) -> bool");
 
         // case 7: (unit) -> int
-        let ty7 = Type::Func(Box::new(Type::Tuple(vec![Type::Unit])), Box::new(Type::Int));
-        assert_eq!(ty7.to_string(), "(unit) -> int");
+        let ty7 = Type::Func(
+            Box::new(Type::Tuple(
+                TupleType::new(vec![Type::Unit, Type::Unit]).unwrap(),
+            )),
+            Box::new(Type::Int),
+        );
+        assert_eq!(ty7.to_string(), "(unit, unit) -> int");
+    }
+
+    /// Verify that `TupleType` enforces arity constraints
+    /// and supports `Deref`
+    #[test]
+    fn test_tuple_type_invariants() {
+        // Negative cases
+        assert!(TupleType::new(vec![]).is_err());
+        assert!(TupleType::new(vec![Type::Int]).is_err());
+
+        // Positive cases
+        let types = vec![Type::Int, Type::String];
+        let tuple_res = TupleType::new(types.clone());
+        assert!(tuple_res.is_ok());
+        let tuple = tuple_res.unwrap();
+
+        // Test `Deref` slice behavior
+        assert_eq!(tuple.len(), 2);
+        assert_eq!(tuple[0], Type::Int);
+        assert_eq!(tuple[1], Type::String);
     }
 }

--- a/meerkat-lib/src/runtime/tt/types.rs
+++ b/meerkat-lib/src/runtime/tt/types.rs
@@ -55,7 +55,19 @@ impl std::fmt::Display for Type {
                 }
                 write!(f, ")")
             }
-            Type::Func(t1, t2) => write!(f, "{} -> {}", t1, t2),
+            Type::Func(t1, t2) => {
+                // Determine if the left-hand side is a function type
+                // to preserve right-associativity during formatting
+                let is_func = match &**t1 {
+                    Type::Func(_, _) => true,
+                    Type::Int | Type::String | Type::Bool | Type::Unit | Type::Tuple(_) => false,
+                };
+                if is_func {
+                    write!(f, "({}) -> {}", t1, t2)
+                } else {
+                    write!(f, "{} -> {}", t1, t2)
+                }
+            }
         }
     }
 }
@@ -77,5 +89,46 @@ impl std::fmt::Display for Param {
         } else {
             write!(f, "{}", self.name)
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Verify that `Type` formats nested function types to
+    /// preserve associativity
+    #[test]
+    fn test_nested_type_formatting() {
+        // case 1: (int -> bool) -> string
+        let ty1 = Type::Func(
+            Box::new(Type::Func(Box::new(Type::Int), Box::new(Type::Bool))),
+            Box::new(Type::String),
+        );
+        assert_eq!(ty1.to_string(), "(int -> bool) -> string");
+
+        // case 2: int -> bool -> string (which is int -> (bool -> string))
+        let ty2 = Type::Func(
+            Box::new(Type::Int),
+            Box::new(Type::Func(Box::new(Type::Bool), Box::new(Type::String))),
+        );
+        assert_eq!(ty2.to_string(), "int -> bool -> string");
+
+        // case 3: ((int -> string) -> bool) -> unit
+        let ty3 = Type::Func(
+            Box::new(Type::Func(
+                Box::new(Type::Func(Box::new(Type::Int), Box::new(Type::String))),
+                Box::new(Type::Bool),
+            )),
+            Box::new(Type::Unit),
+        );
+        assert_eq!(ty3.to_string(), "((int -> string) -> bool) -> unit");
+
+        // case 4: (int -> bool) -> (string -> unit)
+        let ty4 = Type::Func(
+            Box::new(Type::Func(Box::new(Type::Int), Box::new(Type::Bool))),
+            Box::new(Type::Func(Box::new(Type::String), Box::new(Type::Unit))),
+        );
+        assert_eq!(ty4.to_string(), "(int -> bool) -> string -> unit");
     }
 }

--- a/meerkat-lib/src/runtime/tt/types.rs
+++ b/meerkat-lib/src/runtime/tt/types.rs
@@ -1,8 +1,11 @@
-//! Type definitions
+//! Type system representations
+//!
+//! This module defines the core type representation structures used during parsing,
+//! type checking, and translation of type annotations
 
 use crate::runtime::interner::Symbol;
 
-/// Represents a type in the Meerkat language.
+/// Represents a type in the Meerkat language
 ///
 /// This enum models all valid types including primitives, tuples, and function
 /// signatures
@@ -16,7 +19,7 @@ pub enum Type {
     Func(Box<Type>, Box<Type>),
 }
 
-/// Represents a function parameter.
+/// Represents a function parameter
 ///
 /// This structure holds the name of a parameter and its optional type annotation
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -25,7 +28,17 @@ pub struct Param {
     pub ty: Option<Type>,
 }
 
+/// Implement the `Display` trait for the `Type` type
+///
+/// Provides a human-readable string representation of a type
 impl std::fmt::Display for Type {
+    /// Format the type for display
+    ///
+    /// Args:
+    ///     `f` (`&mut std::fmt::Formatter<'_>`): The formatter target
+    ///
+    /// Returns:
+    ///     `std::fmt::Result`: The result of the formatting operation
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Type::Int => write!(f, "int"),
@@ -47,7 +60,17 @@ impl std::fmt::Display for Type {
     }
 }
 
+/// Implement the `Display` trait for the `Param` type
+///
+/// Provides a human-readable string representation of a parameter
 impl std::fmt::Display for Param {
+    /// Format the parameter for display
+    ///
+    /// Args:
+    ///     `f` (`&mut std::fmt::Formatter<'_>`): The formatter target
+    ///
+    /// Returns:
+    ///     `std::fmt::Result`: The result of the formatting operation
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         if let Some(ty) = &self.ty {
             write!(f, "{}: {}", self.name, ty)

--- a/meerkat-lib/src/runtime/tt/types.rs
+++ b/meerkat-lib/src/runtime/tt/types.rs
@@ -58,12 +58,14 @@ impl std::fmt::Display for Type {
             Type::Func(t1, t2) => {
                 // Determine if the left-hand side is a function type
                 // to preserve right-associativity during formatting
-                let is_func = match &**t1 {
+                let is_func = match t1.as_ref() {
                     Type::Func(_, _) => true,
                     Type::Int | Type::String | Type::Bool | Type::Unit | Type::Tuple(_) => false,
                 };
                 if is_func {
                     write!(f, "({}) -> {}", t1, t2)
+                } else if matches!(t1.as_ref(), Type::Unit) {
+                    write!(f, "() -> {}", t2)
                 } else {
                     write!(f, "{} -> {}", t1, t2)
                 }
@@ -130,5 +132,20 @@ mod tests {
             Box::new(Type::Func(Box::new(Type::String), Box::new(Type::Unit))),
         );
         assert_eq!(ty4.to_string(), "(int -> bool) -> string -> unit");
+
+        // case 5: () -> int
+        let ty5 = Type::Func(Box::new(Type::Unit), Box::new(Type::Int));
+        assert_eq!(ty5.to_string(), "() -> int");
+
+        // case 6: (() -> int) -> bool
+        let ty6 = Type::Func(
+            Box::new(Type::Func(Box::new(Type::Unit), Box::new(Type::Int))),
+            Box::new(Type::Bool),
+        );
+        assert_eq!(ty6.to_string(), "(() -> int) -> bool");
+
+        // case 7: (unit) -> int
+        let ty7 = Type::Func(Box::new(Type::Tuple(vec![Type::Unit])), Box::new(Type::Int));
+        assert_eq!(ty7.to_string(), "(unit) -> int");
     }
 }

--- a/meerkat-lib/src/runtime/tt/types.rs
+++ b/meerkat-lib/src/runtime/tt/types.rs
@@ -1,0 +1,58 @@
+//! Type definitions
+
+use crate::runtime::interner::Symbol;
+
+/// Represents a type in the Meerkat language.
+///
+/// This enum models all valid types including primitives, tuples, and function
+/// signatures
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum Type {
+    Int,
+    String,
+    Bool,
+    Unit,
+    Tuple(Vec<Type>),
+    Func(Box<Type>, Box<Type>),
+}
+
+/// Represents a function parameter.
+///
+/// This structure holds the name of a parameter and its optional type annotation
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Param {
+    pub name: Symbol,
+    pub ty: Option<Type>,
+}
+
+impl std::fmt::Display for Type {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Type::Int => write!(f, "int"),
+            Type::String => write!(f, "string"),
+            Type::Bool => write!(f, "bool"),
+            Type::Unit => write!(f, "unit"),
+            Type::Tuple(ts) => {
+                write!(f, "(")?;
+                for (i, t) in ts.iter().enumerate() {
+                    if i > 0 {
+                        write!(f, ", ")?;
+                    }
+                    write!(f, "{}", t)?;
+                }
+                write!(f, ")")
+            }
+            Type::Func(t1, t2) => write!(f, "{} -> {}", t1, t2),
+        }
+    }
+}
+
+impl std::fmt::Display for Param {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if let Some(ty) = &self.ty {
+            write!(f, "{}: {}", self.name, ty)
+        } else {
+            write!(f, "{}", self.name)
+        }
+    }
+}

--- a/meerkat-lib/tests/interning_tests.rs
+++ b/meerkat-lib/tests/interning_tests.rs
@@ -188,13 +188,14 @@ fn test_ast_printer_type_display() {
     let interner = Interner::new();
     let printer = AstPrinter::new(&interner);
 
+    use meerkat_lib::runtime::tt::{TupleType, Type};
+
     // Create a type: (int, string) -> bool
-    let test_type = meerkat_lib::runtime::tt::Type::Func(
-        Box::new(meerkat_lib::runtime::tt::Type::Tuple(vec![
-            meerkat_lib::runtime::tt::Type::Int,
-            meerkat_lib::runtime::tt::Type::String,
-        ])),
-        Box::new(meerkat_lib::runtime::tt::Type::Bool),
+    let test_type = Type::Func(
+        Box::new(Type::Tuple(
+            TupleType::new(vec![Type::Int, Type::String]).unwrap(),
+        )),
+        Box::new(Type::Bool),
     );
 
     let formatted_some = printer.format_type_opt(&Some(test_type));

--- a/meerkat-lib/tests/interning_tests.rs
+++ b/meerkat-lib/tests/interning_tests.rs
@@ -46,11 +46,11 @@ fn test_transaction_maps_indexing() {
     txn.locked.insert(key.clone());
     assert!(txn.locked.contains(&key));
 
-    let read_value = meerkat_lib::runtime::ast::Value::Number { val: 42 };
+    let read_value = meerkat_lib::runtime::ast::Value::Int { val: 42 };
     txn.read_cache.insert(key.clone(), read_value.clone());
     assert_eq!(txn.read_cache.get(&key), Some(&read_value));
 
-    let write_value = meerkat_lib::runtime::ast::Value::Number { val: 100 };
+    let write_value = meerkat_lib::runtime::ast::Value::Int { val: 100 };
     txn.written.insert(key.clone(), write_value.clone());
     assert_eq!(txn.written.get(&key), Some(&write_value));
 }
@@ -180,4 +180,26 @@ fn test_servicenetid_equality_and_hashing() {
     map.insert(id1.clone(), 100);
     assert_eq!(map.get(&id2), Some(&100));
     assert_eq!(map.get(&id3), None);
+}
+
+/// Verify that `AstPrinter` prints optional types using their display format
+#[test]
+fn test_ast_printer_type_display() {
+    let interner = Interner::new();
+    let printer = AstPrinter::new(&interner);
+
+    // Create a type: (int, string) -> bool
+    let test_type = meerkat_lib::runtime::tt::Type::Func(
+        Box::new(meerkat_lib::runtime::tt::Type::Tuple(vec![
+            meerkat_lib::runtime::tt::Type::Int,
+            meerkat_lib::runtime::tt::Type::String,
+        ])),
+        Box::new(meerkat_lib::runtime::tt::Type::Bool),
+    );
+
+    let formatted_some = printer.format_type_opt(&Some(test_type));
+    assert_eq!(formatted_some, "Some((int, string) -> bool)");
+
+    let formatted_none = printer.format_type_opt(&None);
+    assert_eq!(formatted_none, "None");
 }

--- a/meerkat-lib/tests/interning_tests.rs
+++ b/meerkat-lib/tests/interning_tests.rs
@@ -150,6 +150,7 @@ fn test_parser_simple_expression_interning() {
         assert_eq!(decls.len(), 1);
         if let Decl::VarDecl {
             name: var_name,
+            ty: _,
             val: _,
         } = &decls[0]
         {

--- a/meerkat/tests/type_annotations.mkt
+++ b/meerkat/tests/type_annotations.mkt
@@ -19,6 +19,29 @@ service type_suite {
     // Mixed parameters, single unqualified parameter, higher order parameters
     pub def d_mixed: (int, string) -> bool =
         fn (a: int, b: string) => true;
+
+    // Non-nested cases
+    def d_non_nested: int -> bool = fn (x: int) => true;
+
+    // Right-nested (nesting in return type position)
+    def d_right_nested_implicit: int -> bool -> bool =
+        fn (x: int) => fn (y: bool) => true;
+    def d_right_nested_explicit: int -> (bool -> bool) =
+        fn (x: int) => fn (y: bool) => true;
+
+    // Left-nested (nesting in parameter position)
+    def d_left_nested: (int -> bool) -> bool =
+        fn (f: int -> bool) => true;
+
+    // Deeply left-nested
+    def d_deep_left_nested: ((int -> bool) -> bool) -> bool =
+        fn (f: (int -> bool) -> bool) => true;
+
+    // Mixed nesting cases
+    def d_mixed_nested_1: (int -> bool) -> (bool -> bool) =
+        fn (f: int -> bool) => fn (s: bool) => true;
+    def d_mixed_nested_2: (int -> (bool -> bool)) -> bool =
+        fn (f: int -> (bool -> bool)) => true;
 }
 
 @test(type_suite) {
@@ -41,10 +64,42 @@ service type_suite {
     let l_mixed: (int, bool) -> bool =
         fn (x: int, y) => true;
 
+    // Non-nested case
+    let l_non_nested: int -> bool = fn (x: int) => true;
+
+    // Right-nested (nesting in return type position)
+    let l_right_nested_implicit: int -> bool -> bool =
+        fn (x: int) => fn (y: bool) => true;
+    let l_right_nested_explicit: int -> (bool -> bool) =
+        fn (x: int) => fn (y: bool) => true;
+
+    // Left-nested (nesting in parameter position)
+    let l_left_nested: (int -> bool) -> bool =
+        fn (f: int -> bool) => true;
+
+    // Deeply left-nested
+    let l_deep_left_nested: ((int -> bool) -> bool) -> bool =
+        fn (f: (int -> bool) -> bool) => true;
+
+    // Mixed nesting cases
+    let l_mixed_nested_1: (int -> bool) -> (bool -> bool) =
+        fn (f: int -> bool) => fn (s: bool) => true;
+    let l_mixed_nested_2: (int -> (bool -> bool)) -> bool =
+        fn (f: int -> (bool -> bool)) => true;
+
     // Verify executions
     assert(l_int == 100);
     assert(l_func());
     assert(l_single_param(5) == 5);
     assert(l_arrow(1)("a"));
     assert(l_mixed(1, "untyped"));
+
+    // Verify exhaustive nested cases
+    assert(l_non_nested(1));
+    assert(l_right_nested_implicit(1)(true));
+    assert(l_right_nested_explicit(1)(true));
+    assert(l_left_nested(fn (x: int) => true));
+    assert(l_deep_left_nested(fn (f: int -> bool) => true));
+    assert(l_mixed_nested_1(fn (x: int) => true)(true));
+    assert(l_mixed_nested_2(fn (x: int) => fn (y: bool) => true));
 }

--- a/meerkat/tests/type_annotations.mkt
+++ b/meerkat/tests/type_annotations.mkt
@@ -1,0 +1,50 @@
+service type_suite {
+    // def declarations with various type permutations
+    def d_int: int = 42;
+    def d_str: string = "hello";
+    def d_bool: bool = true;
+    def d_unit: unit = 42;
+
+    // Functions with primitive and tuple type signatures
+    def d_func: (int) -> string = fn (a: int) => "res";
+    pub def d_nullary: () -> int = fn () => 42;
+
+    // Single parenthesized type signature
+    def d_single_paren: (int) = 42;
+
+    // Complex higher-order function type
+    def d_complex: (int -> bool) -> (string -> bool) =
+        fn (f: int -> bool) => fn (s: string) => true;
+
+    // Mixed parameters, single unqualified parameter, higher order parameters
+    pub def d_mixed: (int, string) -> bool =
+        fn (a: int, b: string) => true;
+}
+
+@test(type_suite) {
+    // var declaration types inside test/actions
+    let l_int: int = 100;
+    let l_str: string = "test";
+    let l_bool: bool = false;
+    let l_unit: unit = 100;
+
+    let l_func: () -> bool = fn () => true;
+
+    // Single unqualified parameter
+    let l_single_param: (int) -> int = fn x => x;
+
+    // Higher-order function type annotation
+    let l_arrow: int -> string -> bool =
+        fn (x: int) => fn (y: string) => true;
+
+    // Mixed parameters lambda (typed and untyped)
+    let l_mixed: (int, bool) -> bool =
+        fn (x: int, y) => true;
+
+    // Verify executions
+    assert(l_int == 100);
+    assert(l_func());
+    assert(l_single_param(5) == 5);
+    assert(l_arrow(1)("a"));
+    assert(l_mixed(1, "untyped"));
+}

--- a/meerkat/tests/type_annotations.mkt
+++ b/meerkat/tests/type_annotations.mkt
@@ -3,7 +3,7 @@ service type_suite {
     def d_int: int = 42;
     def d_str: string = "hello";
     def d_bool: bool = true;
-    def d_unit_func: () -> unit = fn () => true;
+    def d_unit_func: () -> unit = fn () => {};
 
     // Functions with primitive and tuple type signatures
     def d_func: (int) -> string = fn (a: int) => "res";
@@ -49,7 +49,7 @@ service type_suite {
     let l_int: int = 100;
     let l_str: string = "test";
     let l_bool: bool = false;
-    let l_unit_func: () -> unit = fn () => true;
+    let l_unit_func: () -> unit = fn () => {};
 
     let l_func: () -> bool = fn () => true;
 
@@ -92,7 +92,7 @@ service type_suite {
     assert(l_func());
     assert(l_single_param(5) == 5);
     assert(l_arrow(1)("a"));
-    assert(l_mixed(1, "untyped"));
+    assert(l_mixed(1, true));
 
     // Verify exhaustive nested cases
     assert(l_non_nested(1));

--- a/meerkat/tests/type_annotations.mkt
+++ b/meerkat/tests/type_annotations.mkt
@@ -3,7 +3,7 @@ service type_suite {
     def d_int: int = 42;
     def d_str: string = "hello";
     def d_bool: bool = true;
-    def d_unit: unit = 42;
+    def d_unit_func: () -> unit = fn () => true;
 
     // Functions with primitive and tuple type signatures
     def d_func: (int) -> string = fn (a: int) => "res";
@@ -49,7 +49,7 @@ service type_suite {
     let l_int: int = 100;
     let l_str: string = "test";
     let l_bool: bool = false;
-    let l_unit: unit = 100;
+    let l_unit_func: () -> unit = fn () => true;
 
     let l_func: () -> bool = fn () => true;
 


### PR DESCRIPTION
Draft PR to introduce type annotations to Meerkat. Also related to issues #34 and #58. Will layer in with numerous commits and carefully review each stage to prevent syntactic regressions.

This is part of a PR sequence to fully solve issue #34 and introduce bi-directional type checking.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Expanded static type annotations across `let`, `var`, `def`, function/closure parameters, and optional return types (`->`), including typed table schemas.
  * Added support for higher-order function types and richer type syntax, including `unit`/nullary forms and tuples.
  * Updated network serialization to match the new type model, with a maximum type nesting depth for safety.

* **Bug Fixes**
  * Arithmetic/comparison and `assert` now consistently use integer values.

* **Tests**
  * Updated and added parser, codec, and end-to-end tests covering the new type-annotation syntax and round-trips.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->