### PR TITLE
PR 1 of 3 toward #39 (web client): HTML template literals

### DIFF
--- a/meerkat-lib/src/net/codec.rs
+++ b/meerkat-lib/src/net/codec.rs
@@ -264,6 +264,11 @@ pub fn encode_value(val: &Value, interner: &Interner) -> Result<NetValue> {
     match val {
         Value::Int { val } => Ok(NetValue::Int { val: *val }),
         Value::Bool { val } => Ok(NetValue::Bool { val: *val }),
+        // HTML has no network representation yet. A structured, validatable
+        // wire form is deferred to the codec work in the code-transport PR.
+        Value::Html(_) => Err(Error::Message(
+            "html values cannot yet be sent over the network".to_string(),
+        )),
         Value::String { val } => {
             validate_string_literal(val)?;
             Ok(NetValue::String { val: val.clone() })
@@ -401,6 +406,11 @@ pub fn encode_expr(expr: &Expr, interner: &Interner) -> Result<NetExpr> {
         Expr::Literal { val } => Ok(NetExpr::Literal {
             val: encode_value(val, interner)?,
         }),
+        // HTML templates have no network representation yet; deferred to the
+        // code-transport PR alongside the html value wire form.
+        Expr::Html { .. } => Err(Error::Message(
+            "html expressions cannot yet be sent over the network".to_string(),
+        )),
         Expr::Variable { name } => {
             let name_str = interner.get(*name);
             validate_identifier(name_str)?;

--- a/meerkat-lib/src/runtime/ast/mod.rs
+++ b/meerkat-lib/src/runtime/ast/mod.rs
@@ -1,5 +1,5 @@
 use crate::net::ServiceNetId;
-use crate::runtime::html::Html;
+use crate::runtime::html::{Html, HtmlTemplate};
 use crate::runtime::interner::Symbol;
 use crate::runtime::tt::{Param, Type};
 use std::fmt::Display;
@@ -118,49 +118,17 @@ pub enum Value {
     },
 }
 
-/// A single part of an HTML template: either literal markup text or an
-/// embedded expression to be evaluated and rendered in place.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub enum HtmlPart {
-    Text(String),
-    Expr(Box<Expr>),
-}
-
-impl HtmlPart {
-    /// The embedded expression in this part, if any.
-    ///
-    /// Single source of truth for which expressions live inside an html
-    /// template, so traversals (dependency analysis, alpha renaming) do not
-    /// each re-encode the part structure.
-    pub fn expr(&self) -> Option<&Expr> {
-        match self {
-            HtmlPart::Text(_) => None,
-            HtmlPart::Expr(e) => Some(e),
-        }
-    }
-
-    /// Mutable counterpart to [`HtmlPart::expr`].
-    pub fn expr_mut(&mut self) -> Option<&mut Expr> {
-        match self {
-            HtmlPart::Text(_) => None,
-            HtmlPart::Expr(e) => Some(e),
-        }
-    }
-}
-
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum Expr {
     /// Basic Lambda Core expressions
     Literal {
         val: Value,
     },
-    /// An HTML template literal, a sequence of literal text and embedded
-    /// expressions (`{expr}` interpolations). Rendered to a `Value::Html`
-    /// at evaluation time; the embedded expressions are ordinary `Expr`s so
-    /// dependency analysis tracks them.
-    Html {
-        parts: Vec<HtmlPart>,
-    },
+    /// An HTML template literal. The representation is encapsulated by the
+    /// `HtmlTemplate` ADT in `runtime::html`; the embedded expressions are
+    /// reached through its interface so dependency analysis tracks them, and
+    /// it renders to a `Value::Html` at evaluation time.
+    Html(HtmlTemplate),
     Variable {
         name: Symbol,
     },
@@ -363,7 +331,7 @@ impl Display for Expr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Expr::Literal { val } => write!(f, "{}", val),
-            Expr::Html { .. } => write!(f, "<html>"),
+            Expr::Html(_) => write!(f, "<html>"),
             Expr::Tuple { .. } => write!(f, "vector"),
             Expr::KeyVal { name, value } => write!(f, "keyval: {}, {}", name, value),
             Expr::Variable { name } => write!(f, "{}", name),

--- a/meerkat-lib/src/runtime/ast/mod.rs
+++ b/meerkat-lib/src/runtime/ast/mod.rs
@@ -1,4 +1,5 @@
 use crate::net::ServiceNetId;
+use crate::runtime::html::Html;
 use crate::runtime::interner::Symbol;
 use crate::runtime::tt::{Param, Type};
 use std::fmt::Display;
@@ -90,6 +91,9 @@ pub enum Value {
     String {
         val: String,
     },
+    /// An evaluated HTML value. The representation is encapsulated by the
+    /// `Html` ADT; see `runtime::html`.
+    Html(Html),
     Closure {
         params: Vec<Param>,
         body: Box<Expr>,
@@ -114,11 +118,48 @@ pub enum Value {
     },
 }
 
+/// A single part of an HTML template: either literal markup text or an
+/// embedded expression to be evaluated and rendered in place.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum HtmlPart {
+    Text(String),
+    Expr(Box<Expr>),
+}
+
+impl HtmlPart {
+    /// The embedded expression in this part, if any.
+    ///
+    /// Single source of truth for which expressions live inside an html
+    /// template, so traversals (dependency analysis, alpha renaming) do not
+    /// each re-encode the part structure.
+    pub fn expr(&self) -> Option<&Expr> {
+        match self {
+            HtmlPart::Text(_) => None,
+            HtmlPart::Expr(e) => Some(e),
+        }
+    }
+
+    /// Mutable counterpart to [`HtmlPart::expr`].
+    pub fn expr_mut(&mut self) -> Option<&mut Expr> {
+        match self {
+            HtmlPart::Text(_) => None,
+            HtmlPart::Expr(e) => Some(e),
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum Expr {
     /// Basic Lambda Core expressions
     Literal {
         val: Value,
+    },
+    /// An HTML template literal, a sequence of literal text and embedded
+    /// expressions (`{expr}` interpolations). Rendered to a `Value::Html`
+    /// at evaluation time; the embedded expressions are ordinary `Expr`s so
+    /// dependency analysis tracks them.
+    Html {
+        parts: Vec<HtmlPart>,
     },
     Variable {
         name: Symbol,
@@ -266,6 +307,7 @@ impl Display for Value {
             Value::Int { val } => write!(f, "{}", val),
             Value::Bool { val } => write!(f, "{}", val),
             Value::String { val } => write!(f, "\"{}\"", val),
+            Value::Html(html) => write!(f, "{}", html),
             Value::Closure {
                 params,
                 body,
@@ -321,6 +363,7 @@ impl Display for Expr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Expr::Literal { val } => write!(f, "{}", val),
+            Expr::Html { .. } => write!(f, "<html>"),
             Expr::Tuple { .. } => write!(f, "vector"),
             Expr::KeyVal { name, value } => write!(f, "keyval: {}, {}", name, value),
             Expr::Variable { name } => write!(f, "{}", name),

--- a/meerkat-lib/src/runtime/ast/printer.rs
+++ b/meerkat-lib/src/runtime/ast/printer.rs
@@ -230,8 +230,16 @@ impl<'a> AstPrinter<'a> {
             }
             Expr::Html(template) => {
                 println!("Html:");
-                for e in template.embedded_exprs() {
-                    self.print_expr(e, indent + 1);
+                for part in template.parts() {
+                    match part {
+                        crate::runtime::html::HtmlPartView::Text(t) => {
+                            self.print_indent(indent + 1);
+                            println!("Text: {:?}", t);
+                        }
+                        crate::runtime::html::HtmlPartView::Expr(e) => {
+                            self.print_expr(e, indent + 1)
+                        }
+                    }
                 }
             }
             Expr::Tuple { val } => {

--- a/meerkat-lib/src/runtime/ast/printer.rs
+++ b/meerkat-lib/src/runtime/ast/printer.rs
@@ -228,16 +228,10 @@ impl<'a> AstPrinter<'a> {
                 let name = *name;
                 println!("Variable: {{ name: {} }}", self.format_symbol(name));
             }
-            Expr::Html { parts } => {
-                println!("Html: {{ parts: {} }}", parts.len());
-                for part in parts {
-                    match part {
-                        crate::ast::HtmlPart::Text(t) => {
-                            self.print_indent(indent + 1);
-                            println!("Text: {:?}", t);
-                        }
-                        crate::ast::HtmlPart::Expr(e) => self.print_expr(e, indent + 1),
-                    }
+            Expr::Html(template) => {
+                println!("Html:");
+                for e in template.embedded_exprs() {
+                    self.print_expr(e, indent + 1);
                 }
             }
             Expr::Tuple { val } => {

--- a/meerkat-lib/src/runtime/ast/printer.rs
+++ b/meerkat-lib/src/runtime/ast/printer.rs
@@ -228,6 +228,18 @@ impl<'a> AstPrinter<'a> {
                 let name = *name;
                 println!("Variable: {{ name: {} }}", self.format_symbol(name));
             }
+            Expr::Html { parts } => {
+                println!("Html: {{ parts: {} }}", parts.len());
+                for part in parts {
+                    match part {
+                        crate::ast::HtmlPart::Text(t) => {
+                            self.print_indent(indent + 1);
+                            println!("Text: {:?}", t);
+                        }
+                        crate::ast::HtmlPart::Expr(e) => self.print_expr(e, indent + 1),
+                    }
+                }
+            }
             Expr::Tuple { val } => {
                 println!("Tuple:");
                 for v in val {
@@ -362,6 +374,9 @@ impl<'a> AstPrinter<'a> {
             }
             Value::String { val } => {
                 println!("String: \"{}\"", val);
+            }
+            Value::Html(html) => {
+                println!("Html: {:?}", html.as_str());
             }
             Value::Closure {
                 params,

--- a/meerkat-lib/src/runtime/html.rs
+++ b/meerkat-lib/src/runtime/html.rs
@@ -10,6 +10,8 @@
 
 use std::fmt;
 
+use crate::runtime::ast::{Expr, Value};
+
 /// An evaluated HTML value
 ///
 /// The internal representation is deliberately private. See the module
@@ -55,6 +57,123 @@ impl Html {
 impl fmt::Display for Html {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.rendered)
+    }
+}
+
+/// A single part of an HTML template: literal markup text or an embedded
+/// expression to be evaluated and rendered in place.
+///
+/// This type is internal to the html module. Outside code never sees that an
+/// HTML template is a sequence of text and expressions; it works through
+/// [`HtmlTemplate`]'s interface. Keeping this private is what allows a future
+/// structured, validatable representation to replace it (validation applies to
+/// HTML expressions, not values) without affecting other code.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) enum HtmlPart {
+    Text(String),
+    Expr(Box<Expr>),
+}
+
+/// The representation of an HTML template expression, before evaluation.
+///
+/// The internal structure (a list of text and embedded expressions) is
+/// private. Callers construct a template by parsing, reach the embedded
+/// expressions through [`HtmlTemplate::embedded_exprs`] /
+/// [`HtmlTemplate::embedded_exprs_mut`] (for dependency analysis and alpha
+/// renaming), and render it through [`HtmlTemplate::render`]. This mirrors the
+/// [`Html`] value ADT and is the boundary at which HTML validation will later
+/// be added.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct HtmlTemplate {
+    parts: Vec<HtmlPart>,
+}
+
+impl HtmlTemplate {
+    /// Iterate the embedded expressions of this template, in order.
+    ///
+    /// Used by dependency analysis and alpha renaming so those passes can
+    /// operate on the interpolated expressions without knowing how the
+    /// template is represented.
+    pub fn embedded_exprs(&self) -> impl Iterator<Item = &Expr> {
+        self.parts.iter().filter_map(|p| match p {
+            HtmlPart::Text(_) => None,
+            HtmlPart::Expr(e) => Some(e.as_ref()),
+        })
+    }
+
+    /// Mutable counterpart to [`HtmlTemplate::embedded_exprs`].
+    pub fn embedded_exprs_mut(&mut self) -> impl Iterator<Item = &mut Expr> {
+        self.parts.iter_mut().filter_map(|p| match p {
+            HtmlPart::Text(_) => None,
+            HtmlPart::Expr(e) => Some(e.as_mut()),
+        })
+    }
+
+    /// Render the template into an [`Html`] value.
+    ///
+    /// The caller supplies the already-evaluated value for each embedded
+    /// expression, in the same order as [`HtmlTemplate::embedded_exprs`]. The
+    /// evaluator owns evaluation (it has the async context); this method owns
+    /// assembling the final markup, so the string representation stays inside
+    /// this module. Literal text is copied verbatim; each embedded value is
+    /// formatted via its `Display`.
+    ///
+    /// Returns `None` if `values` has fewer entries than there are embedded
+    /// expressions (a caller bug).
+    pub fn render(&self, values: &[Value]) -> Option<Html> {
+        let mut rendered = String::new();
+        let mut next = 0usize;
+        for part in &self.parts {
+            match part {
+                HtmlPart::Text(t) => rendered.push_str(t),
+                HtmlPart::Expr(_) => {
+                    let v = values.get(next)?;
+                    // #39: interpolate using the value's plain display. String
+                    // values currently include surrounding quotes; refining
+                    // string interpolation formatting is a known follow-up.
+                    use std::fmt::Write as _;
+                    let _ = write!(rendered, "{}", v);
+                    next += 1;
+                }
+            }
+        }
+        Some(Html::from_rendered(rendered))
+    }
+}
+
+/// Builder for [`HtmlTemplate`].
+///
+/// The parser constructs a template through this builder, appending literal
+/// text and embedded expressions, without naming the internal `HtmlPart`
+/// representation. This keeps the template representation encapsulated in this
+/// module while interning stays in `runtime::parser` (the interner is
+/// append-only and only `parser`/`net::codec` may write to it).
+#[derive(Debug, Default)]
+pub struct HtmlTemplateBuilder {
+    parts: Vec<HtmlPart>,
+}
+
+impl HtmlTemplateBuilder {
+    /// Create an empty builder.
+    pub fn new() -> Self {
+        HtmlTemplateBuilder { parts: Vec::new() }
+    }
+
+    /// Append literal markup text (skips empty strings).
+    pub fn push_text(&mut self, text: &str) {
+        if !text.is_empty() {
+            self.parts.push(HtmlPart::Text(text.to_string()));
+        }
+    }
+
+    /// Append an embedded (interpolated) expression.
+    pub fn push_expr(&mut self, expr: Expr) {
+        self.parts.push(HtmlPart::Expr(Box::new(expr)));
+    }
+
+    /// Finish building the template.
+    pub fn build(self) -> HtmlTemplate {
+        HtmlTemplate { parts: self.parts }
     }
 }
 

--- a/meerkat-lib/src/runtime/html.rs
+++ b/meerkat-lib/src/runtime/html.rs
@@ -83,6 +83,13 @@ pub(crate) enum HtmlPart {
 /// renaming), and render it through [`HtmlTemplate::render`]. This mirrors the
 /// [`Html`] value ADT and is the boundary at which HTML validation will later
 /// be added.
+/// A borrowed view of one part of an HTML template, for read-only traversal
+/// (e.g. the AST printer) without exposing the internal representation.
+pub enum HtmlPartView<'a> {
+    Text(&'a str),
+    Expr(&'a Expr),
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct HtmlTemplate {
     parts: Vec<HtmlPart>,
@@ -106,6 +113,17 @@ impl HtmlTemplate {
         self.parts.iter_mut().filter_map(|p| match p {
             HtmlPart::Text(_) => None,
             HtmlPart::Expr(e) => Some(e.as_mut()),
+        })
+    }
+
+    /// Iterate the template's parts in order, as borrowed views.
+    ///
+    /// Gives ordered access to literal text and embedded expressions (for the
+    /// AST printer) without exposing the internal `HtmlPart` representation.
+    pub fn parts(&self) -> impl Iterator<Item = HtmlPartView<'_>> {
+        self.parts.iter().map(|p| match p {
+            HtmlPart::Text(t) => HtmlPartView::Text(t),
+            HtmlPart::Expr(e) => HtmlPartView::Expr(e),
         })
     }
 

--- a/meerkat-lib/src/runtime/html.rs
+++ b/meerkat-lib/src/runtime/html.rs
@@ -1,0 +1,83 @@
+//! HTML values as an abstract data type
+//!
+//! Outside this module, no code knows how an HTML value is represented.
+//! Today it is backed by a single rendered string, but that is private:
+//! callers construct an `Html` through [`Html::from_rendered`] and read it
+//! back through [`Html::as_str`] or `Display`. This boundary lets the
+//! representation change later (for example, a structured tree that can be
+//! validated to catch errors earlier and mitigate injection) without
+//! affecting any code outside this module.
+
+use std::fmt;
+
+/// An evaluated HTML value
+///
+/// The internal representation is deliberately private. See the module
+/// documentation for the rationale behind treating HTML as an abstract
+/// data type.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Html {
+    /// The rendered markup
+    ///
+    /// Private on purpose: no code outside this module may depend on HTML
+    /// being represented as a string.
+    rendered: String,
+}
+
+impl Html {
+    /// Construct an `Html` value from already-rendered markup
+    ///
+    /// Args:
+    ///     `rendered` (`String`): The rendered markup text
+    ///
+    /// Returns:
+    ///     `Html`: The constructed HTML value
+    pub fn from_rendered(rendered: String) -> Self {
+        Html { rendered }
+    }
+
+    /// Borrow the rendered markup as a string slice
+    ///
+    /// This is the read accessor used by the printer and the network codec.
+    /// It exposes the rendered content without revealing that the value is
+    /// stored as a string.
+    ///
+    /// Returns:
+    ///     `&str`: The rendered markup
+    pub fn as_str(&self) -> &str {
+        &self.rendered
+    }
+}
+
+/// Implement the `Display` trait for the `Html` type
+///
+/// Prints the rendered markup.
+impl fmt::Display for Html {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.rendered)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Verify that an `Html` value round-trips its rendered content through
+    /// the public accessor and `Display`.
+    #[test]
+    fn test_html_render_roundtrip() {
+        let html = Html::from_rendered("<p>The count is 0.</p>".to_string());
+        assert_eq!(html.as_str(), "<p>The count is 0.</p>");
+        assert_eq!(html.to_string(), "<p>The count is 0.</p>");
+    }
+
+    /// Verify that equality is by rendered content.
+    #[test]
+    fn test_html_equality() {
+        let a = Html::from_rendered("<b>x</b>".to_string());
+        let b = Html::from_rendered("<b>x</b>".to_string());
+        let c = Html::from_rendered("<b>y</b>".to_string());
+        assert_eq!(a, b);
+        assert_ne!(a, c);
+    }
+}

--- a/meerkat-lib/src/runtime/interpreter/evaluator.rs
+++ b/meerkat-lib/src/runtime/interpreter/evaluator.rs
@@ -499,4 +499,27 @@ mod tests {
             other => panic!("Expected Err(EvalError::RuntimeError), got {:?}", other),
         }
     }
+
+    /// #39: an html template evaluates to a Value::Html whose rendered markup
+    /// has the interpolation substituted from the environment.
+    #[tokio::test]
+    async fn test_html_renders_with_interpolation() {
+        use crate::runtime::parser::parse_html_parts;
+        let mut manager = Manager::new(Interner::new());
+        let count = manager.interner.insert("count");
+        let parts = parse_html_parts("The count is {count}.", &mut manager.interner)
+            .expect("parse html parts");
+        let expr = Expr::Html { parts };
+        let env = vec![(count, Value::Int { val: 2 })];
+        let mut ctx = EvalContext {
+            manager: &mut manager,
+            service_name: Symbol::empty(),
+            txn: None,
+        };
+        let result = eval(&expr, &env, &mut ctx).await.unwrap();
+        match result {
+            Value::Html(html) => assert_eq!(html.as_str(), "The count is 2."),
+            other => panic!("expected Value::Html, got {:?}", other),
+        }
+    }
 }

--- a/meerkat-lib/src/runtime/interpreter/evaluator.rs
+++ b/meerkat-lib/src/runtime/interpreter/evaluator.rs
@@ -72,29 +72,21 @@ pub async fn eval(
     match expr {
         Expr::Literal { val } => Ok(val.clone()),
 
-        Expr::Html { parts } => {
-            // #39: render the template to an html value. Literal text is copied
-            // verbatim; each embedded expression is evaluated and formatted in
-            // place. Because the embedded parts are ordinary expressions,
-            // dependency analysis has already tracked them, so the html def is
-            // recomputed by the propagation machinery when a dependency changes.
-            let mut rendered = String::new();
-            for part in parts {
-                match part {
-                    crate::ast::HtmlPart::Text(t) => rendered.push_str(t),
-                    crate::ast::HtmlPart::Expr(e) => {
-                        let val = eval(e, env, ctx).await?;
-                        // #39: interpolate using the value's plain display. For
-                        // string values this currently includes surrounding
-                        // quotes; refining string interpolation formatting is a
-                        // known follow-up (the counter example uses ints).
-                        rendered.push_str(&val.to_string());
-                    }
-                }
+        Expr::Html(template) => {
+            // #39: the evaluator owns evaluation (it has the async context) and
+            // the html module owns assembling the value, keeping the template
+            // and markup representation encapsulated. Evaluate each embedded
+            // expression in order, then hand the values to the template to
+            // render. Because the embedded expressions are ordinary Exprs,
+            // dependency analysis has tracked them, so the html def is
+            // recomputed by propagation when a dependency changes.
+            let mut values = Vec::new();
+            for e in template.embedded_exprs() {
+                values.push(eval(e, env, ctx).await?);
             }
-            Ok(Value::Html(crate::runtime::html::Html::from_rendered(
-                rendered,
-            )))
+            template.render(&values).map(Value::Html).ok_or_else(|| {
+                EvalError::RuntimeError("html render: value count mismatch".to_string())
+            })
         }
 
         Expr::Call { func, args } => {
@@ -504,12 +496,12 @@ mod tests {
     /// has the interpolation substituted from the environment.
     #[tokio::test]
     async fn test_html_renders_with_interpolation() {
-        use crate::runtime::parser::parse_html_parts;
+        use crate::runtime::parser::parse_template;
         let mut manager = Manager::new(Interner::new());
         let count = manager.interner.insert("count");
-        let parts = parse_html_parts("The count is {count}.", &mut manager.interner)
-            .expect("parse html parts");
-        let expr = Expr::Html { parts };
+        let template = parse_template("The count is {count}.", &mut manager.interner)
+            .expect("parse html template");
+        let expr = Expr::Html(template);
         let env = vec![(count, Value::Int { val: 2 })];
         let mut ctx = EvalContext {
             manager: &mut manager,

--- a/meerkat-lib/src/runtime/interpreter/evaluator.rs
+++ b/meerkat-lib/src/runtime/interpreter/evaluator.rs
@@ -72,6 +72,31 @@ pub async fn eval(
     match expr {
         Expr::Literal { val } => Ok(val.clone()),
 
+        Expr::Html { parts } => {
+            // #39: render the template to an html value. Literal text is copied
+            // verbatim; each embedded expression is evaluated and formatted in
+            // place. Because the embedded parts are ordinary expressions,
+            // dependency analysis has already tracked them, so the html def is
+            // recomputed by the propagation machinery when a dependency changes.
+            let mut rendered = String::new();
+            for part in parts {
+                match part {
+                    crate::ast::HtmlPart::Text(t) => rendered.push_str(t),
+                    crate::ast::HtmlPart::Expr(e) => {
+                        let val = eval(e, env, ctx).await?;
+                        // #39: interpolate using the value's plain display. For
+                        // string values this currently includes surrounding
+                        // quotes; refining string interpolation formatting is a
+                        // known follow-up (the counter example uses ints).
+                        rendered.push_str(&val.to_string());
+                    }
+                }
+            }
+            Ok(Value::Html(crate::runtime::html::Html::from_rendered(
+                rendered,
+            )))
+        }
+
         Expr::Call { func, args } => {
             let func_val = eval(func, env, ctx).await?;
             let mut arg_vals = Vec::new();

--- a/meerkat-lib/src/runtime/interpreter/executor.rs
+++ b/meerkat-lib/src/runtime/interpreter/executor.rs
@@ -107,6 +107,7 @@ pub async fn execute(
                 Value::Bool { val: false } => Err(EvalError::AssertionError(text.clone())),
                 Value::Int { .. }
                 | Value::String { .. }
+                | Value::Html(..)
                 | Value::Closure { .. }
                 | Value::ActionClosure { .. } => {
                     Err(EvalError::TypeError("assert expects a boolean".to_string()))

--- a/meerkat-lib/src/runtime/mod.rs
+++ b/meerkat-lib/src/runtime/mod.rs
@@ -4,6 +4,7 @@
 //! type definitions, and semantic analysis modules
 
 pub mod ast;
+pub mod html;
 pub mod interner;
 pub mod interpreter;
 pub mod limits;
@@ -13,5 +14,6 @@ pub mod semantic_analysis;
 pub mod tt;
 pub mod txn;
 
+pub use html::Html;
 pub use interner::{Interner, Symbol};
 pub use manager::Manager;

--- a/meerkat-lib/src/runtime/parser/lex.rs
+++ b/meerkat-lib/src/runtime/parser/lex.rs
@@ -75,37 +75,31 @@ fn skip_multi_line_comments<'b>(lex: &mut Lexer<'b, Token<'b>>) -> Skip {
 // literal `)` inside a string inside an interpolation is not accounted for and
 // would terminate the literal early; the current examples do not hit this.
 fn lex_html_literal<'b>(lex: &mut Lexer<'b, Token<'b>>) -> Option<&'b str> {
-    use logos::internal::LexerInternal;
-    // The matched token so far is `(` + optional whitespace + `<`. The inner
-    // text begins right after the `(`, i.e. at the start of the slice minus the
-    // consumed prefix. We reconstruct the inner start from the current span.
-    let span_start = lex.span().start;
-    let full = lex.source();
-    // Find the index of the `(` that opened this literal: it is span_start.
-    // Inner content starts just after `(`.
-    let inner_start = span_start + 1;
+    // On entry the current token is `(` + optional whitespace + `<`, so paren
+    // depth is 1 for that opening `(`. `remainder()` is the source after the
+    // `<`; scan it for the matching `)`, counting balanced parens (so parens
+    // inside a `{ f(x) }` interpolation do not terminate the literal).
+    let rem = lex.remainder();
     let mut depth: isize = 1;
-    loop {
-        match lex.read::<u8>() {
-            Some(b'(') => {
-                depth += 1;
-                lex.bump_unchecked(1);
-            }
-            Some(b')') => {
+    for (consumed, &byte) in rem.as_bytes().iter().enumerate() {
+        match byte {
+            b'(' => depth += 1,
+            b')' => {
                 depth -= 1;
                 if depth == 0 {
-                    let inner_end = lex.span().end; // position of the `)` byte
-                    lex.bump_unchecked(1); // consume the `)`
-                    return Some(&full[inner_start..inner_end]);
+                    // Extend the token through the closing `)` (a byte count;
+                    // `)` is ASCII so this lands on a char boundary).
+                    lex.bump(consumed + 1);
+                    // The token slice is now `( ... )`; the body is the slice
+                    // with the outer parens stripped.
+                    let full = lex.slice();
+                    return Some(&full[1..full.len() - 1]);
                 }
-                lex.bump_unchecked(1);
             }
-            None => return None, // unterminated html literal
-            _ => {
-                lex.bump_unchecked(1);
-            }
+            _ => {}
         }
     }
+    None // unterminated html literal
 }
 
 impl<'a> fmt::Display for Token<'a> {

--- a/meerkat-lib/src/runtime/parser/lex.rs
+++ b/meerkat-lib/src/runtime/parser/lex.rs
@@ -66,6 +66,48 @@ fn skip_multi_line_comments<'b>(lex: &mut Lexer<'b, Token<'b>>) -> Skip {
     Skip
 }
 
+// #39: Lex an html literal of the form `( <...> )`. The opening `(` and the
+// following `<` have already been consumed by the token regex. Starting with
+// paren depth 1 (for that `(`), scan forward until the matching `)` brings the
+// depth back to 0, then return the inner slice (between the outer parens).
+// Balanced parens inside the literal (e.g. in a `{ f(x) }` interpolation) do
+// not terminate it; only the final unbalanced `)` does. Known limitation: a
+// literal `)` inside a string inside an interpolation is not accounted for and
+// would terminate the literal early; the current examples do not hit this.
+fn lex_html_literal<'b>(lex: &mut Lexer<'b, Token<'b>>) -> Option<&'b str> {
+    use logos::internal::LexerInternal;
+    // The matched token so far is `(` + optional whitespace + `<`. The inner
+    // text begins right after the `(`, i.e. at the start of the slice minus the
+    // consumed prefix. We reconstruct the inner start from the current span.
+    let span_start = lex.span().start;
+    let full = lex.source();
+    // Find the index of the `(` that opened this literal: it is span_start.
+    // Inner content starts just after `(`.
+    let inner_start = span_start + 1;
+    let mut depth: isize = 1;
+    loop {
+        match lex.read::<u8>() {
+            Some(b'(') => {
+                depth += 1;
+                lex.bump_unchecked(1);
+            }
+            Some(b')') => {
+                depth -= 1;
+                if depth == 0 {
+                    let inner_end = lex.span().end; // position of the `)` byte
+                    lex.bump_unchecked(1); // consume the `)`
+                    return Some(&full[inner_start..inner_end]);
+                }
+                lex.bump_unchecked(1);
+            }
+            None => return None, // unterminated html literal
+            _ => {
+                lex.bump_unchecked(1);
+            }
+        }
+    }
+}
+
 impl<'a> fmt::Display for Token<'a> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{:#?}", self)
@@ -78,6 +120,10 @@ impl<'a> fmt::Display for Token<'a> {
 pub enum Token<'a> {
     #[regex(r#""[^"]*""#, |lex| lex.slice().trim_matches('"'))] // regex for string within ""
     StrLit(&'a str),
+    // #39: html literal triggered by `(` + optional whitespace + `<`. Longer
+    // than the bare `(` token, so logos prefers it only when a literal begins.
+    #[regex(r"\(\s*<", lex_html_literal)]
+    HtmlLit(&'a str),
     #[regex(r"(?&identifier)")]
     Ident(&'a str),
 
@@ -202,4 +248,92 @@ pub enum Token<'a> {
     #[error]
     #[regex(r#"[^\x00-\x7F]"#)] // Error on non ascii characters
     Error,
+}
+
+#[cfg(test)]
+mod html_lex_tests {
+    use super::*;
+    use logos::Logos;
+
+    // #39: collect the tokens (and captured slices) for a source string.
+    fn lex_all(src: &str) -> Vec<Token<'_>> {
+        Token::lexer(src).collect::<Vec<_>>()
+    }
+
+    #[test]
+    fn test_html_literal_basic() {
+        let toks = lex_all("(<p>hello</p>)");
+        assert_eq!(
+            toks.len(),
+            1,
+            "expected a single HtmlLit token, got {:?}",
+            toks
+        );
+        match &toks[0] {
+            Token::HtmlLit(inner) => assert_eq!(*inner, "<p>hello</p>"),
+            other => panic!("expected HtmlLit, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_html_literal_with_interpolation() {
+        let toks = lex_all("(<p>The count is {count}.</p>)");
+        assert_eq!(
+            toks.len(),
+            1,
+            "expected a single HtmlLit token, got {:?}",
+            toks
+        );
+        match &toks[0] {
+            Token::HtmlLit(inner) => assert_eq!(*inner, "<p>The count is {count}.</p>"),
+            other => panic!("expected HtmlLit, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_html_literal_ignores_balanced_parens_in_interpolation() {
+        let toks = lex_all("(<p>{f(x)}</p>)");
+        assert_eq!(
+            toks.len(),
+            1,
+            "balanced parens inside must not end the literal: {:?}",
+            toks
+        );
+        match &toks[0] {
+            Token::HtmlLit(inner) => assert_eq!(*inner, "<p>{f(x)}</p>"),
+            other => panic!("expected HtmlLit, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_html_literal_with_leading_whitespace() {
+        // `(` then whitespace then `<` still triggers the literal.
+        let toks = lex_all("(  <p>x</p>)");
+        assert_eq!(
+            toks.len(),
+            1,
+            "expected a single HtmlLit token, got {:?}",
+            toks
+        );
+        match &toks[0] {
+            Token::HtmlLit(inner) => assert_eq!(*inner, "  <p>x</p>"),
+            other => panic!("expected HtmlLit, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_plain_paren_is_not_html() {
+        // `(` not followed by `<` must remain an ordinary LParen, not html.
+        let toks = lex_all("(1 + 2)");
+        assert!(
+            matches!(toks.first(), Some(Token::LParen)),
+            "plain paren must lex as LParen, got {:?}",
+            toks
+        );
+        assert!(
+            !toks.iter().any(|t| matches!(t, Token::HtmlLit(_))),
+            "no HtmlLit expected in a plain parenthesized expression: {:?}",
+            toks
+        );
+    }
 }

--- a/meerkat-lib/src/runtime/parser/meerkat.lalrpop
+++ b/meerkat-lib/src/runtime/parser/meerkat.lalrpop
@@ -58,6 +58,7 @@ extern {
         "||" => Token::OR_OR,
         "!" => Token::NOT_NOT,
         "strlit" => Token::StrLit(<&'input str>),
+        "htmllit" => Token::HtmlLit(<&'input str>),
         "ident" => Token::Ident(<&'input str>),
         "num" => Token::Number(<i32>),
         "{" => Token::LBrace,
@@ -229,9 +230,17 @@ SubExpr: Expr = {
     <s:Ident> "." <m:Ident> => Expr::MemberAccess { service_name: s, member_name: m },
 
     "action" "{" <stmts: ActionStmts> "}" => Expr::Action(stmts),
+
+    <h:"htmllit"> =>? {
+        // #39: split the raw html body into literal text and parsed
+        // interpolations. Reuses the same expression grammar for `{ }` blocks.
+        crate::runtime::parser::parse_html_parts(h, interner)
+            .map(|parts| Expr::Html { parts })
+            .map_err(|error| ParseError::User { error })
+    },
 }
 
-Expr: Expr = {
+pub Expr: Expr = {
     #[precedence(level="0")]
     SubExpr => <>,
 

--- a/meerkat-lib/src/runtime/parser/meerkat.lalrpop
+++ b/meerkat-lib/src/runtime/parser/meerkat.lalrpop
@@ -234,8 +234,8 @@ SubExpr: Expr = {
     <h:"htmllit"> =>? {
         // #39: split the raw html body into literal text and parsed
         // interpolations. Reuses the same expression grammar for `{ }` blocks.
-        crate::runtime::parser::parse_html_parts(h, interner)
-            .map(|parts| Expr::Html { parts })
+        crate::runtime::parser::parse_template(h, interner)
+            .map(Expr::Html)
             .map_err(|error| ParseError::User { error })
     },
 }

--- a/meerkat-lib/src/runtime/parser/mod.rs
+++ b/meerkat-lib/src/runtime/parser/mod.rs
@@ -156,6 +156,11 @@ pub fn parse_html_parts(
                 parts.push(HtmlPart::Text(std::mem::take(&mut text)));
             }
             // Collect the interpolation source up to the matching `}`.
+            // #39: brace depth counting does not account for a `}` inside a
+            // string literal within the interpolation (e.g. `{ "}" }`); such a
+            // brace would desync the counter. This mirrors the analogous
+            // paren-depth limitation documented in the html lexer; making both
+            // string-aware is tracked as a follow-up.
             let mut depth: usize = 1;
             let mut frag = String::new();
             let mut closed = false;

--- a/meerkat-lib/src/runtime/parser/mod.rs
+++ b/meerkat-lib/src/runtime/parser/mod.rs
@@ -32,9 +32,12 @@ use logos::Logos;
 ///
 /// Returns:
 ///     `Result<Vec<Stmt>, String>`: The parsed statements, or an error string
-pub fn parse_string(input: &str, interner: &mut Interner) -> Result<Vec<Stmt>, String> {
+/// #39: Lex `src` into a token stream, enforcing the identifier and string
+/// literal length limits. Shared by the top-level parse paths and html
+/// interpolation parsing so the checks cannot drift out of sync.
+fn build_validated_lex_stream(src: &str) -> Result<Vec<(usize, lex::Token<'_>, usize)>, String> {
     let mut lex_stream = Vec::new();
-    for (t, span) in lex::Token::lexer(input).spanned() {
+    for (t, span) in lex::Token::lexer(src).spanned() {
         match t {
             lex::Token::Ident(name) if name.len() > MAX_IDENTIFIER_LENGTH => {
                 return Err(format!(
@@ -52,6 +55,11 @@ pub fn parse_string(input: &str, interner: &mut Interner) -> Result<Vec<Stmt>, S
         }
         lex_stream.push((span.start, t, span.end));
     }
+    Ok(lex_stream)
+}
+
+pub fn parse_string(input: &str, interner: &mut Interner) -> Result<Vec<Stmt>, String> {
+    let lex_stream = build_validated_lex_stream(input)?;
 
     meerkat::ProgParser::new()
         .parse(input, interner, lex_stream)
@@ -187,25 +195,7 @@ pub fn parse_template(
 /// The identifier and string-literal length limits enforced by the top-level
 /// parser are applied here too, so interpolations cannot bypass those limits.
 fn parse_expr_fragment(src: &str, interner: &mut Interner) -> Result<crate::ast::Expr, String> {
-    let mut lex_stream = Vec::new();
-    for (t, span) in lex::Token::lexer(src).spanned() {
-        match t {
-            lex::Token::Ident(name) if name.len() > MAX_IDENTIFIER_LENGTH => {
-                return Err(format!(
-                    "Parse error: identifier exceeds maximum length of {} characters",
-                    MAX_IDENTIFIER_LENGTH
-                ));
-            }
-            lex::Token::StrLit(val) if val.len() > MAX_STRING_LITERAL_LENGTH => {
-                return Err(format!(
-                    "Parse error: string literal exceeds maximum length of {} characters",
-                    MAX_STRING_LITERAL_LENGTH
-                ));
-            }
-            _ => {}
-        }
-        lex_stream.push((span.start, t, span.end));
-    }
+    let lex_stream = build_validated_lex_stream(src)?;
     meerkat::ExprParser::new()
         .parse(src, interner, lex_stream)
         .map_err(|e| format!("Parse error in html interpolation: {:?}", e))

--- a/meerkat-lib/src/runtime/parser/mod.rs
+++ b/meerkat-lib/src/runtime/parser/mod.rs
@@ -121,6 +121,91 @@ pub fn parse_repl(input: &str, interner: &mut Interner) -> ReplParseResult {
     }
 }
 
+/// #39: Split a raw html-literal body into parts and parse each `{...}`
+/// interpolation as an expression.
+///
+/// This is the single authoritative place that knows how an html template is
+/// decomposed: literal text is copied verbatim, and each brace-delimited
+/// interpolation is parsed via the same expression grammar used everywhere
+/// else (the `pub Expr` rule), so interpolations are ordinary expressions.
+///
+/// Braces nest: an interpolation runs from an opening `{` to its matching `}`,
+/// counting depth, so an interpolation containing braces is handled. A `{`
+/// with no matching `}` is a parse error.
+///
+/// Args:
+///     `raw` (`&str`): The inner html text (between the outer parens)
+///     `interner` (`&mut Interner`): The string interner instance
+///
+/// Returns:
+///     `Result<Vec<HtmlPart>, String>`: The parsed template parts, or an error
+pub fn parse_html_parts(
+    raw: &str,
+    interner: &mut Interner,
+) -> Result<Vec<crate::ast::HtmlPart>, String> {
+    use crate::ast::HtmlPart;
+
+    let mut parts: Vec<HtmlPart> = Vec::new();
+    let mut text = String::new();
+    let mut chars = raw.char_indices().peekable();
+
+    while let Some((_, c)) = chars.next() {
+        if c == '{' {
+            // Flush any accumulated literal text.
+            if !text.is_empty() {
+                parts.push(HtmlPart::Text(std::mem::take(&mut text)));
+            }
+            // Collect the interpolation source up to the matching `}`.
+            let mut depth: usize = 1;
+            let mut frag = String::new();
+            let mut closed = false;
+            for (_, ic) in chars.by_ref() {
+                match ic {
+                    '{' => {
+                        depth += 1;
+                        frag.push(ic);
+                    }
+                    '}' => {
+                        depth -= 1;
+                        if depth == 0 {
+                            closed = true;
+                            break;
+                        }
+                        frag.push(ic);
+                    }
+                    _ => frag.push(ic),
+                }
+            }
+            if !closed {
+                return Err(
+                    "Parse error: unterminated { } interpolation in html literal".to_string(),
+                );
+            }
+            // Parse the fragment as a single expression via the public Expr rule.
+            let expr = parse_expr_fragment(frag.trim(), interner)?;
+            parts.push(HtmlPart::Expr(Box::new(expr)));
+        } else {
+            text.push(c);
+        }
+    }
+    if !text.is_empty() {
+        parts.push(HtmlPart::Text(text));
+    }
+    Ok(parts)
+}
+
+/// #39: Parse a single interpolation fragment into an `Expr` using the public
+/// `Expr` grammar rule, reusing the same lexer and parser as top-level code.
+fn parse_expr_fragment(src: &str, interner: &mut Interner) -> Result<crate::ast::Expr, String> {
+    let mut lex_stream = Vec::new();
+    for (t, span) in lex::Token::lexer(src).spanned() {
+        lex_stream.push((span.start, t, span.end));
+    }
+    meerkat::ExprParser::new()
+        .parse(src, interner, lex_stream)
+        .map_err(|e| format!("Parse error in html interpolation: {:?}", e))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -243,5 +328,101 @@ mod tests {
         } else {
             panic!("Expected Service Stmt");
         }
+    }
+
+    /// #39: verify the html-part splitter produces literal text and parsed
+    /// interpolation expressions in order.
+    #[test]
+    fn test_parse_html_parts_interpolation() {
+        use crate::ast::{Expr, HtmlPart};
+        let mut interner = Interner::new();
+        let parts = parse_html_parts("The count is {count}.", &mut interner).expect("should parse");
+        assert_eq!(parts.len(), 3, "expected text, expr, text: {:?}", parts);
+        match &parts[0] {
+            HtmlPart::Text(t) => assert_eq!(t, "The count is "),
+            other => panic!("expected Text, got {:?}", other),
+        }
+        match &parts[1] {
+            HtmlPart::Expr(e) => assert!(
+                matches!(**e, Expr::Variable { .. }),
+                "expected Variable, got {:?}",
+                e
+            ),
+            other => panic!("expected Expr, got {:?}", other),
+        }
+        match &parts[2] {
+            HtmlPart::Text(t) => assert_eq!(t, "."),
+            other => panic!("expected Text, got {:?}", other),
+        }
+    }
+
+    /// #39: no interpolation yields a single text part.
+    #[test]
+    fn test_parse_html_parts_text_only() {
+        use crate::ast::HtmlPart;
+        let mut interner = Interner::new();
+        let parts = parse_html_parts("<p>hello</p>", &mut interner).expect("should parse");
+        assert_eq!(parts.len(), 1);
+        assert!(matches!(&parts[0], HtmlPart::Text(t) if t == "<p>hello</p>"));
+    }
+
+    /// #39: an unterminated interpolation is an error, not a panic.
+    #[test]
+    fn test_parse_html_parts_unterminated() {
+        let mut interner = Interner::new();
+        let res = parse_html_parts("count is {count", &mut interner);
+        assert!(res.is_err());
+    }
+
+    /// #39: the html literal lexes and parses through to an Expr::Html node.
+    /// (Stub stage: parts are empty; interpolation wiring is verified separately.)
+    #[test]
+    fn test_html_literal_parses() {
+        use crate::ast::{Decl, Expr, Stmt};
+        let mut interner = Interner::new();
+        let input = "service s { pub def h = (<p>hi</p>); }";
+        let res = parse_string(input, &mut interner);
+        assert!(res.is_ok(), "parse failed: {:?}", res);
+        let ast = res.unwrap();
+        match &ast[0] {
+            Stmt::Service { decls, .. } => match &decls[0] {
+                Decl::DefDecl { val, .. } => {
+                    assert!(
+                        matches!(val, Expr::Html { .. }),
+                        "expected Expr::Html, got {:?}",
+                        val
+                    );
+                }
+                other => panic!("expected DefDecl, got {:?}", other),
+            },
+            other => panic!("expected Service, got {:?}", other),
+        }
+    }
+
+    /// #39: the full pipeline parses an html def with an interpolation into an
+    /// Expr::Html whose parts include a parsed embedded expression.
+    #[test]
+    fn test_html_literal_full_parse() {
+        use crate::ast::{Decl, Expr, HtmlPart, Stmt};
+        let mut interner = Interner::new();
+        let input = "service webClient { pub def html = (<p>The count is {count}.</p>); }";
+        let res = parse_string(input, &mut interner);
+        assert!(res.is_ok(), "parse failed: {:?}", res);
+        let ast = res.unwrap();
+        let parts = match &ast[0] {
+            Stmt::Service { decls, .. } => match &decls[0] {
+                Decl::DefDecl {
+                    val: Expr::Html { parts },
+                    ..
+                } => parts,
+                other => panic!("expected DefDecl with Expr::Html, got {:?}", other),
+            },
+            other => panic!("expected Service, got {:?}", other),
+        };
+        // <p>The count is , {count}, .</p>
+        assert_eq!(parts.len(), 3, "parts: {:?}", parts);
+        assert!(matches!(&parts[0], HtmlPart::Text(t) if t == "<p>The count is "));
+        assert!(matches!(&parts[1], HtmlPart::Expr(e) if matches!(**e, Expr::Variable { .. })));
+        assert!(matches!(&parts[2], HtmlPart::Text(t) if t == ".</p>"));
     }
 }

--- a/meerkat-lib/src/runtime/parser/mod.rs
+++ b/meerkat-lib/src/runtime/parser/mod.rs
@@ -121,41 +121,27 @@ pub fn parse_repl(input: &str, interner: &mut Interner) -> ReplParseResult {
     }
 }
 
-/// #39: Split a raw html-literal body into parts and parse each `{...}`
-/// interpolation as an expression.
+/// #39: Parse the raw body of an HTML literal into an `HtmlTemplate`.
 ///
-/// This is the single authoritative place that knows how an html template is
-/// decomposed: literal text is copied verbatim, and each brace-delimited
-/// interpolation is parsed via the same expression grammar used everywhere
-/// else (the `pub Expr` rule), so interpolations are ordinary expressions.
+/// Lives in `runtime::parser` because it interns (via the expression parser),
+/// and only `parser`/`net::codec` may write to the append-only interner. The
+/// template representation itself is owned by `runtime::html`; this function
+/// builds one through the html builder without naming its internal parts.
 ///
-/// Braces nest: an interpolation runs from an opening `{` to its matching `}`,
-/// counting depth, so an interpolation containing braces is handled. A `{`
-/// with no matching `}` is a parse error.
-///
-/// Args:
-///     `raw` (`&str`): The inner html text (between the outer parens)
-///     `interner` (`&mut Interner`): The string interner instance
-///
-/// Returns:
-///     `Result<Vec<HtmlPart>, String>`: The parsed template parts, or an error
-pub fn parse_html_parts(
+/// Literal text is copied verbatim; each brace-delimited `{ ... }`
+/// interpolation is parsed as an expression through the public `Expr` rule.
+/// A `{` with no matching `}` is a parse error.
+pub fn parse_template(
     raw: &str,
     interner: &mut Interner,
-) -> Result<Vec<crate::ast::HtmlPart>, String> {
-    use crate::ast::HtmlPart;
-
-    let mut parts: Vec<HtmlPart> = Vec::new();
+) -> Result<crate::runtime::html::HtmlTemplate, String> {
+    let mut builder = crate::runtime::html::HtmlTemplateBuilder::new();
     let mut text = String::new();
     let mut chars = raw.char_indices().peekable();
 
     while let Some((_, c)) = chars.next() {
         if c == '{' {
-            // Flush any accumulated literal text.
-            if !text.is_empty() {
-                parts.push(HtmlPart::Text(std::mem::take(&mut text)));
-            }
-            // Collect the interpolation source up to the matching `}`.
+            builder.push_text(std::mem::take(&mut text).as_str());
             // #39: brace depth counting does not account for a `}` inside a
             // string literal within the interpolation (e.g. `{ "}" }`); such a
             // brace would desync the counter. This mirrors the analogous
@@ -186,24 +172,38 @@ pub fn parse_html_parts(
                     "Parse error: unterminated { } interpolation in html literal".to_string(),
                 );
             }
-            // Parse the fragment as a single expression via the public Expr rule.
             let expr = parse_expr_fragment(frag.trim(), interner)?;
-            parts.push(HtmlPart::Expr(Box::new(expr)));
+            builder.push_expr(expr);
         } else {
             text.push(c);
         }
     }
-    if !text.is_empty() {
-        parts.push(HtmlPart::Text(text));
-    }
-    Ok(parts)
+    builder.push_text(text.as_str());
+    Ok(builder.build())
 }
 
 /// #39: Parse a single interpolation fragment into an `Expr` using the public
 /// `Expr` grammar rule, reusing the same lexer and parser as top-level code.
+/// The identifier and string-literal length limits enforced by the top-level
+/// parser are applied here too, so interpolations cannot bypass those limits.
 fn parse_expr_fragment(src: &str, interner: &mut Interner) -> Result<crate::ast::Expr, String> {
     let mut lex_stream = Vec::new();
     for (t, span) in lex::Token::lexer(src).spanned() {
+        match t {
+            lex::Token::Ident(name) if name.len() > MAX_IDENTIFIER_LENGTH => {
+                return Err(format!(
+                    "Parse error: identifier exceeds maximum length of {} characters",
+                    MAX_IDENTIFIER_LENGTH
+                ));
+            }
+            lex::Token::StrLit(val) if val.len() > MAX_STRING_LITERAL_LENGTH => {
+                return Err(format!(
+                    "Parse error: string literal exceeds maximum length of {} characters",
+                    MAX_STRING_LITERAL_LENGTH
+                ));
+            }
+            _ => {}
+        }
         lex_stream.push((span.start, t, span.end));
     }
     meerkat::ExprParser::new()
@@ -335,52 +335,40 @@ mod tests {
         }
     }
 
-    /// #39: verify the html-part splitter produces literal text and parsed
-    /// interpolation expressions in order.
+    /// #39: parse_template splits literal text and interpolations, exposing the
+    /// embedded expression through the template interface.
     #[test]
-    fn test_parse_html_parts_interpolation() {
-        use crate::ast::{Expr, HtmlPart};
+    fn test_parse_template_interpolation() {
+        use crate::ast::Expr;
         let mut interner = Interner::new();
-        let parts = parse_html_parts("The count is {count}.", &mut interner).expect("should parse");
-        assert_eq!(parts.len(), 3, "expected text, expr, text: {:?}", parts);
-        match &parts[0] {
-            HtmlPart::Text(t) => assert_eq!(t, "The count is "),
-            other => panic!("expected Text, got {:?}", other),
-        }
-        match &parts[1] {
-            HtmlPart::Expr(e) => assert!(
-                matches!(**e, Expr::Variable { .. }),
-                "expected Variable, got {:?}",
-                e
-            ),
-            other => panic!("expected Expr, got {:?}", other),
-        }
-        match &parts[2] {
-            HtmlPart::Text(t) => assert_eq!(t, "."),
-            other => panic!("expected Text, got {:?}", other),
-        }
+        let template =
+            parse_template("The count is {count}.", &mut interner).expect("should parse");
+        let exprs: Vec<&Expr> = template.embedded_exprs().collect();
+        assert_eq!(exprs.len(), 1, "expected one embedded expression");
+        assert!(
+            matches!(exprs[0], Expr::Variable { .. }),
+            "expected Variable, got {:?}",
+            exprs[0]
+        );
     }
 
-    /// #39: no interpolation yields a single text part.
+    /// #39: a template with no interpolation exposes no embedded expressions.
     #[test]
-    fn test_parse_html_parts_text_only() {
-        use crate::ast::HtmlPart;
+    fn test_parse_template_text_only() {
         let mut interner = Interner::new();
-        let parts = parse_html_parts("<p>hello</p>", &mut interner).expect("should parse");
-        assert_eq!(parts.len(), 1);
-        assert!(matches!(&parts[0], HtmlPart::Text(t) if t == "<p>hello</p>"));
+        let template = parse_template("<p>hello</p>", &mut interner).expect("should parse");
+        assert_eq!(template.embedded_exprs().count(), 0);
     }
 
     /// #39: an unterminated interpolation is an error, not a panic.
     #[test]
-    fn test_parse_html_parts_unterminated() {
+    fn test_parse_template_unterminated() {
         let mut interner = Interner::new();
-        let res = parse_html_parts("count is {count", &mut interner);
+        let res = parse_template("count is {count", &mut interner);
         assert!(res.is_err());
     }
 
     /// #39: the html literal lexes and parses through to an Expr::Html node.
-    /// (Stub stage: parts are empty; interpolation wiring is verified separately.)
     #[test]
     fn test_html_literal_parses() {
         use crate::ast::{Decl, Expr, Stmt};
@@ -393,7 +381,7 @@ mod tests {
             Stmt::Service { decls, .. } => match &decls[0] {
                 Decl::DefDecl { val, .. } => {
                     assert!(
-                        matches!(val, Expr::Html { .. }),
+                        matches!(val, Expr::Html(_)),
                         "expected Expr::Html, got {:?}",
                         val
                     );
@@ -404,30 +392,32 @@ mod tests {
         }
     }
 
-    /// #39: the full pipeline parses an html def with an interpolation into an
-    /// Expr::Html whose parts include a parsed embedded expression.
+    /// #39: the full pipeline parses an html def with an interpolation; the
+    /// template exposes the parsed embedded expression through its interface.
     #[test]
     fn test_html_literal_full_parse() {
-        use crate::ast::{Decl, Expr, HtmlPart, Stmt};
+        use crate::ast::{Decl, Expr, Stmt};
         let mut interner = Interner::new();
         let input = "service webClient { pub def html = (<p>The count is {count}.</p>); }";
         let res = parse_string(input, &mut interner);
         assert!(res.is_ok(), "parse failed: {:?}", res);
         let ast = res.unwrap();
-        let parts = match &ast[0] {
+        let template = match &ast[0] {
             Stmt::Service { decls, .. } => match &decls[0] {
                 Decl::DefDecl {
-                    val: Expr::Html { parts },
+                    val: Expr::Html(template),
                     ..
-                } => parts,
+                } => template,
                 other => panic!("expected DefDecl with Expr::Html, got {:?}", other),
             },
             other => panic!("expected Service, got {:?}", other),
         };
-        // <p>The count is , {count}, .</p>
-        assert_eq!(parts.len(), 3, "parts: {:?}", parts);
-        assert!(matches!(&parts[0], HtmlPart::Text(t) if t == "<p>The count is "));
-        assert!(matches!(&parts[1], HtmlPart::Expr(e) if matches!(**e, Expr::Variable { .. })));
-        assert!(matches!(&parts[2], HtmlPart::Text(t) if t == ".</p>"));
+        let exprs: Vec<&Expr> = template.embedded_exprs().collect();
+        assert_eq!(exprs.len(), 1, "expected one embedded expression");
+        assert!(
+            matches!(exprs[0], Expr::Variable { .. }),
+            "expected Variable, got {:?}",
+            exprs[0]
+        );
     }
 }

--- a/meerkat-lib/src/runtime/semantic_analysis/var_analysis/alpha_rename.rs
+++ b/meerkat-lib/src/runtime/semantic_analysis/var_analysis/alpha_rename.rs
@@ -54,8 +54,8 @@ impl Expr {
                     arg.alpha_rename(var_binded, renames);
                 }
             }
-            Expr::Html { parts } => {
-                for e in parts.iter_mut().filter_map(crate::ast::HtmlPart::expr_mut) {
+            Expr::Html(template) => {
+                for e in template.embedded_exprs_mut() {
                     e.alpha_rename(var_binded, renames);
                 }
             }

--- a/meerkat-lib/src/runtime/semantic_analysis/var_analysis/alpha_rename.rs
+++ b/meerkat-lib/src/runtime/semantic_analysis/var_analysis/alpha_rename.rs
@@ -54,6 +54,11 @@ impl Expr {
                     arg.alpha_rename(var_binded, renames);
                 }
             }
+            Expr::Html { parts } => {
+                for e in parts.iter_mut().filter_map(crate::ast::HtmlPart::expr_mut) {
+                    e.alpha_rename(var_binded, renames);
+                }
+            }
 
             Expr::Action(stmts) => {
                 for stmt in stmts {

--- a/meerkat-lib/src/runtime/semantic_analysis/var_analysis/read_write.rs
+++ b/meerkat-lib/src/runtime/semantic_analysis/var_analysis/read_write.rs
@@ -205,3 +205,53 @@ impl Expr {
         }
     }
 }
+
+#[cfg(test)]
+mod html_dep_tests {
+    use crate::ast::{Expr, HtmlPart};
+    use crate::runtime::interner::Interner;
+    use std::collections::HashSet;
+
+    /// #39: the interpolated expression in an html template must surface as a
+    /// free variable, so the html def registers a dependency and re-renders
+    /// when that dependency changes (issue #24 propagation).
+    #[test]
+    fn test_html_free_var_tracks_interpolation() {
+        let mut interner = Interner::new();
+        let count = interner.insert("count");
+        let expr = Expr::Html {
+            parts: vec![
+                HtmlPart::Text("<p>".to_string()),
+                HtmlPart::Expr(Box::new(Expr::Variable { name: count })),
+                HtmlPart::Text("</p>".to_string()),
+            ],
+        };
+        let free = expr.free_var(&HashSet::new(), &HashSet::new());
+        assert!(
+            free.contains(&count),
+            "html interpolation must be a free var: {:?}",
+            free
+        );
+    }
+
+    /// #39: interpolations referencing another service surface as cross-service
+    /// dependencies too.
+    #[test]
+    fn test_html_cross_service_deps_tracks_interpolation() {
+        let mut interner = Interner::new();
+        let svc = interner.insert("counter");
+        let member = interner.insert("count");
+        let expr = Expr::Html {
+            parts: vec![HtmlPart::Expr(Box::new(Expr::MemberAccess {
+                service_name: svc,
+                member_name: member,
+            }))],
+        };
+        let deps = expr.cross_service_deps();
+        assert!(
+            deps.contains(&(svc, member)),
+            "html interpolation must surface cross-service dep: {:?}",
+            deps
+        );
+    }
+}

--- a/meerkat-lib/src/runtime/semantic_analysis/var_analysis/read_write.rs
+++ b/meerkat-lib/src/runtime/semantic_analysis/var_analysis/read_write.rs
@@ -39,9 +39,9 @@ impl Expr {
                 deps
             }
             Expr::Func { body, .. } => body.cross_service_deps(),
-            Expr::Html { parts } => {
+            Expr::Html(template) => {
                 let mut deps = HashSet::new();
-                for e in parts.iter().filter_map(crate::ast::HtmlPart::expr) {
+                for e in template.embedded_exprs() {
                     deps.extend(e.cross_service_deps());
                 }
                 deps
@@ -135,9 +135,9 @@ impl Expr {
                 new_binds.extend(params.iter().map(|p| p.name));
                 body.free_var(reactive_names, &new_binds)
             }
-            Expr::Html { parts } => {
+            Expr::Html(template) => {
                 let mut free_vars = HashSet::new();
-                for e in parts.iter().filter_map(crate::ast::HtmlPart::expr) {
+                for e in template.embedded_exprs() {
                     free_vars.extend(e.free_var(reactive_names, var_binded));
                 }
                 free_vars
@@ -208,7 +208,8 @@ impl Expr {
 
 #[cfg(test)]
 mod html_dep_tests {
-    use crate::ast::{Expr, HtmlPart};
+    use crate::ast::Expr;
+    use crate::runtime::html::HtmlTemplateBuilder;
     use crate::runtime::interner::Interner;
     use std::collections::HashSet;
 
@@ -219,13 +220,11 @@ mod html_dep_tests {
     fn test_html_free_var_tracks_interpolation() {
         let mut interner = Interner::new();
         let count = interner.insert("count");
-        let expr = Expr::Html {
-            parts: vec![
-                HtmlPart::Text("<p>".to_string()),
-                HtmlPart::Expr(Box::new(Expr::Variable { name: count })),
-                HtmlPart::Text("</p>".to_string()),
-            ],
-        };
+        let mut builder = HtmlTemplateBuilder::new();
+        builder.push_text("<p>");
+        builder.push_expr(Expr::Variable { name: count });
+        builder.push_text("</p>");
+        let expr = Expr::Html(builder.build());
         let free = expr.free_var(&HashSet::new(), &HashSet::new());
         assert!(
             free.contains(&count),
@@ -241,12 +240,12 @@ mod html_dep_tests {
         let mut interner = Interner::new();
         let svc = interner.insert("counter");
         let member = interner.insert("count");
-        let expr = Expr::Html {
-            parts: vec![HtmlPart::Expr(Box::new(Expr::MemberAccess {
-                service_name: svc,
-                member_name: member,
-            }))],
-        };
+        let mut builder = HtmlTemplateBuilder::new();
+        builder.push_expr(Expr::MemberAccess {
+            service_name: svc,
+            member_name: member,
+        });
+        let expr = Expr::Html(builder.build());
         let deps = expr.cross_service_deps();
         assert!(
             deps.contains(&(svc, member)),

--- a/meerkat-lib/src/runtime/semantic_analysis/var_analysis/read_write.rs
+++ b/meerkat-lib/src/runtime/semantic_analysis/var_analysis/read_write.rs
@@ -39,6 +39,13 @@ impl Expr {
                 deps
             }
             Expr::Func { body, .. } => body.cross_service_deps(),
+            Expr::Html { parts } => {
+                let mut deps = HashSet::new();
+                for e in parts.iter().filter_map(crate::ast::HtmlPart::expr) {
+                    deps.extend(e.cross_service_deps());
+                }
+                deps
+            }
             Expr::Call { func, args } => {
                 let mut deps = func.cross_service_deps();
                 for arg in args {
@@ -127,6 +134,13 @@ impl Expr {
                 let mut new_binds = var_binded.clone();
                 new_binds.extend(params.iter().map(|p| p.name));
                 body.free_var(reactive_names, &new_binds)
+            }
+            Expr::Html { parts } => {
+                let mut free_vars = HashSet::new();
+                for e in parts.iter().filter_map(crate::ast::HtmlPart::expr) {
+                    free_vars.extend(e.free_var(reactive_names, var_binded));
+                }
+                free_vars
             }
             Expr::Call { func, args } => {
                 let mut free_vars = func.free_var(reactive_names, var_binded);


### PR DESCRIPTION
**PR 1 of 3 toward #39 (web client): HTML template literals**

This is the first of three PRs implementing the web client. It adds the `html` language construct. The server code-fetch protocol and the WASM browser client follow in PRs 2 and 3; this PR touches neither networking nor the browser.

## What this adds

HTML template literals of the form `( <...> )`, per the Requirements page. For example:

```mkt
service webClient {
   pub def html = (<p>The count is {count}.</p>);
   def count = counter.count;
}
```

- The lexer detects a literal by the `(` + optional whitespace + `<` trigger and captures its body by paren-depth counting, mirroring the existing nested-comment scanner. Balanced parens inside, e.g. in a `{ f(x) }` interpolation, do not terminate it.
- A single helper splits the body into literal text and `{ }` interpolations, parsing each interpolation through the existing public `Expr` grammar rule. Interpolations are ordinary expressions; there is no second parser.
- HTML is an abstract data type (`runtime::html::Html`) with a private representation. Nothing outside the html module depends on how it is stored, so a richer structure to catch errors and mitigate injection can replace it later without affecting other code. It is string-backed for now.
- An html template evaluates to a `Value::Html` whose markup has each interpolation rendered in place.
- Interpolations are tracked by dependency analysis, so an html def re-renders through the existing #24 propagation when a dependency changes.

## Out of scope (the remaining PRs for #39)

- Server returning a service class's source code by name: PR 2. HTML has no network representation yet, so the codec rejects it for now.
- WASM browser client, HTML/JS host page, DOM update loop: PR 3.

## Known follow-ups

- String-value interpolation currently renders with surrounding quotes; the counter example uses ints. Refining string interpolation formatting is deferred.
- Richer html structure and validation for injection safety sit behind the ADT boundary and can be added without touching callers.

## Testing

Full workspace suite, `clippy -D warnings`, `fmt --check`, and the wasm32 target check all pass. New tests cover lexing (including disambiguation from grouped expressions and balanced-paren handling), interpolation splitting, full parse of the `webClient` html, evaluation with interpolation substitution, and dependency tracking of interpolated expressions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added HTML-style template expressions to the language, including embedded value interpolation.
  * HTML templates can now be rendered during evaluation and displayed consistently at runtime.
* **Bug Fixes**
  * Improved runtime analysis so HTML interpolations participate in dependency and free-variable tracking.
  * Network encoding now blocks HTML values/expressions with clearer errors.
  * `assert` now rejects HTML values as non-boolean.
* **Tests**
  * Added coverage for HTML lexing/parsing, interpolation, rendering, and dependency/free-variable handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->