### PR TITLE
PR 2 of 3 toward #39 (web client): server responds to requests for service code

### DIFF
--- a/meerkat-lib/src/net/codec.rs
+++ b/meerkat-lib/src/net/codec.rs
@@ -68,30 +68,78 @@ pub fn validate_service_code_request(path: &str, reply_to: &str) -> Result<()> {
     Ok(())
 }
 
-/// #39: Build the response to a `ServiceCodeRequest`: validate the request's
-/// length-bounded fields and, on success, return a `ServiceCodeResponse`
-/// carrying the whole file source; on failure return a `ServiceCodeError`.
+/// #39: Handle a `ServiceCodeRequest` end-to-end: validate the length-bounded
+/// fields, safely resolve the requested path against the server's base
+/// directory, read that file, and return a `ServiceCodeResponse` with its
+/// source, or a `ServiceCodeError` describing any failure.
+///
 /// Shared by `run_server` and the integration tests so both exercise the same
-/// logic rather than a hand-rolled copy.
-pub fn build_service_code_response(
+/// logic. The whole file is returned so the client gets any imports and other
+/// services the requested file needs.
+pub fn serve_service_code(
     request_id: u64,
     path: String,
     reply_to: &str,
-    source: &str,
+    base_dir: &std::path::Path,
 ) -> MeerkatMessage {
-    match validate_service_code_request(&path, reply_to) {
-        // Only materialize the source (a clone/allocation) once the request
-        // has passed validation, so a rejected request does no extra work.
-        Ok(()) => MeerkatMessage::ServiceCodeResponse {
+    let result = validate_service_code_request(&path, reply_to)
+        .and_then(|()| resolve_served_file(base_dir, &path))
+        .and_then(|file| {
+            std::fs::read_to_string(&file)
+                .map_err(|e| Error::LimitExceeded(format!("failed to read requested file: {}", e)))
+        });
+    match result {
+        Ok(source) => MeerkatMessage::ServiceCodeResponse {
             request_id,
             path,
-            source: source.to_string(),
+            source,
         },
         Err(e) => MeerkatMessage::ServiceCodeError {
             request_id,
             error: e.to_string(),
         },
     }
+}
+
+/// #39: Safely resolve a client-requested file path against a server base
+/// directory, for serving `.mkt` source over the network.
+///
+/// This is a zero-trust boundary: the path comes from the network, so it is
+/// validated to prevent directory traversal. An absolute path is rejected, and
+/// the resolved path is canonicalized and required to stay within the
+/// canonicalized base directory (blocking `..` and symlink escapes). Returns
+/// the validated path to read, or an error describing why it was rejected.
+pub fn resolve_served_file(
+    base_dir: &std::path::Path,
+    requested: &str,
+) -> Result<std::path::PathBuf> {
+    use std::path::Path;
+
+    // Reject absolute paths outright; served files are always relative to base.
+    if Path::new(requested).is_absolute() {
+        return Err(Error::LimitExceeded(format!(
+            "requested path must be relative, got absolute: {:?}",
+            requested
+        )));
+    }
+
+    let joined = base_dir.join(requested);
+
+    // Canonicalize both so `..` and symlinks are resolved, then require the
+    // target to remain within the base directory.
+    let canon_base = base_dir.canonicalize().map_err(|e| {
+        Error::LimitExceeded(format!("server base directory is unavailable: {}", e))
+    })?;
+    let canon_target = joined
+        .canonicalize()
+        .map_err(|_| Error::LimitExceeded(format!("requested file not found: {:?}", requested)))?;
+    if !canon_target.starts_with(&canon_base) {
+        return Err(Error::LimitExceeded(format!(
+            "requested path escapes the served directory: {:?}",
+            requested
+        )));
+    }
+    Ok(canon_target)
 }
 
 /// #24: validate and intern the identifier fields of a `RequestUpdates`
@@ -1559,5 +1607,78 @@ mod tests {
 
         let decoded_type = decode_type(encoded_type).unwrap();
         assert_eq!(original_type, decoded_type);
+    }
+}
+
+#[cfg(test)]
+mod service_code_tests {
+    use super::*;
+    use std::path::PathBuf;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    /// Create a unique temp directory for a test, so tests do not share
+    /// filesystem state (which would make them order-dependent or flaky).
+    fn unique_temp_dir(label: &str) -> PathBuf {
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let n = COUNTER.fetch_add(1, Ordering::SeqCst);
+        let dir = std::env::temp_dir().join(format!(
+            "meerkat_served_{}_{}_{}_{}",
+            label,
+            std::process::id(),
+            nanos,
+            n
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    /// #39: a valid relative path within the base directory resolves.
+    #[test]
+    fn test_resolve_served_file_valid() {
+        let dir = unique_temp_dir("valid");
+        let file = dir.join("counter.mkt");
+        std::fs::write(&file, "service counter {}").unwrap();
+
+        let resolved = resolve_served_file(&dir, "counter.mkt").expect("should resolve");
+        assert_eq!(resolved, file.canonicalize().unwrap());
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// #39: an absolute path is rejected.
+    #[test]
+    fn test_resolve_served_file_rejects_absolute() {
+        let dir = unique_temp_dir("abs");
+        let res = resolve_served_file(&dir, "/etc/passwd");
+        assert!(res.is_err(), "absolute path must be rejected");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// #39: a traversal path escaping the base directory is rejected.
+    #[test]
+    fn test_resolve_served_file_rejects_traversal() {
+        let root = unique_temp_dir("trav");
+        let base = root.join("base");
+        std::fs::create_dir_all(&base).unwrap();
+        // A secret file outside the base directory but inside the unique root.
+        std::fs::write(root.join("secret.mkt"), "secret").unwrap();
+
+        let res = resolve_served_file(&base, "../secret.mkt");
+        assert!(res.is_err(), "traversal outside base must be rejected");
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// #39: a missing file is rejected (not found).
+    #[test]
+    fn test_resolve_served_file_missing() {
+        let dir = unique_temp_dir("missing");
+        let res = resolve_served_file(&dir, "nope.mkt");
+        assert!(res.is_err(), "missing file must be rejected");
+        let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/meerkat-lib/src/net/codec.rs
+++ b/meerkat-lib/src/net/codec.rs
@@ -7,6 +7,7 @@ use crate::error::{Error, Result};
 use crate::net::ast::{
     NetActionStmt, NetBinOp, NetExpr, NetField, NetParam, NetTableType, NetType, NetUnOp, NetValue,
 };
+use crate::net::types::MeerkatMessage;
 use crate::runtime::ast::{ActionStmt, BinOp, Expr, Field, TableType, UnOp, Value};
 use crate::runtime::interner::{Interner, Symbol};
 use crate::runtime::limits::{
@@ -65,6 +66,30 @@ pub fn validate_service_code_request(path: &str, reply_to: &str) -> Result<()> {
         }
     }
     Ok(())
+}
+
+/// #39: Build the response to a `ServiceCodeRequest`: validate the request's
+/// length-bounded fields and, on success, return a `ServiceCodeResponse`
+/// carrying the whole file source; on failure return a `ServiceCodeError`.
+/// Shared by `run_server` and the integration tests so both exercise the same
+/// logic rather than a hand-rolled copy.
+pub fn build_service_code_response(
+    request_id: u64,
+    path: String,
+    reply_to: &str,
+    source: String,
+) -> MeerkatMessage {
+    match validate_service_code_request(&path, reply_to) {
+        Ok(()) => MeerkatMessage::ServiceCodeResponse {
+            request_id,
+            path,
+            source,
+        },
+        Err(e) => MeerkatMessage::ServiceCodeError {
+            request_id,
+            error: e.to_string(),
+        },
+    }
 }
 
 /// #24: validate and intern the identifier fields of a `RequestUpdates`

--- a/meerkat-lib/src/net/codec.rs
+++ b/meerkat-lib/src/net/codec.rs
@@ -60,7 +60,7 @@ pub fn validate_service_code_request(path: &str, reply_to: &str) -> Result<()> {
     for (field, value) in [("path", path), ("reply_to", reply_to)] {
         if value.len() > MAX_NET_REQUEST_STRING_LENGTH {
             return Err(Error::LimitExceeded(format!(
-                "{} exceeds maximum length of {} characters",
+                "{} exceeds maximum length of {} bytes",
                 field, MAX_NET_REQUEST_STRING_LENGTH
             )));
         }
@@ -77,13 +77,15 @@ pub fn build_service_code_response(
     request_id: u64,
     path: String,
     reply_to: &str,
-    source: String,
+    source: &str,
 ) -> MeerkatMessage {
     match validate_service_code_request(&path, reply_to) {
+        // Only materialize the source (a clone/allocation) once the request
+        // has passed validation, so a rejected request does no extra work.
         Ok(()) => MeerkatMessage::ServiceCodeResponse {
             request_id,
             path,
-            source,
+            source: source.to_string(),
         },
         Err(e) => MeerkatMessage::ServiceCodeError {
             request_id,

--- a/meerkat-lib/src/net/codec.rs
+++ b/meerkat-lib/src/net/codec.rs
@@ -9,7 +9,9 @@ use crate::net::ast::{
 };
 use crate::runtime::ast::{ActionStmt, BinOp, Expr, Field, TableType, UnOp, Value};
 use crate::runtime::interner::{Interner, Symbol};
-use crate::runtime::limits::{MAX_IDENTIFIER_LENGTH, MAX_STRING_LITERAL_LENGTH, MAX_TYPE_DEPTH};
+use crate::runtime::limits::{
+    MAX_IDENTIFIER_LENGTH, MAX_NET_REQUEST_STRING_LENGTH, MAX_STRING_LITERAL_LENGTH, MAX_TYPE_DEPTH,
+};
 use crate::runtime::tt::{Param, TupleType, Type};
 
 fn validate_identifier(s: &str) -> Result<()> {
@@ -45,6 +47,22 @@ fn validate_string_literal(s: &str) -> Result<()> {
             "string literal exceeds maximum length of {} characters",
             MAX_STRING_LITERAL_LENGTH
         )));
+    }
+    Ok(())
+}
+
+/// #39: validate the length-bounded string fields of a `ServiceCodeRequest`
+/// arriving over the wire. `path` and `reply_to` are a resource path and a
+/// network address, not identifiers, so they are length-checked but not
+/// charset-validated or interned. The source in the response is unbounded.
+pub fn validate_service_code_request(path: &str, reply_to: &str) -> Result<()> {
+    for (field, value) in [("path", path), ("reply_to", reply_to)] {
+        if value.len() > MAX_NET_REQUEST_STRING_LENGTH {
+            return Err(Error::LimitExceeded(format!(
+                "{} exceeds maximum length of {} characters",
+                field, MAX_NET_REQUEST_STRING_LENGTH
+            )));
+        }
     }
     Ok(())
 }

--- a/meerkat-lib/src/net/types.rs
+++ b/meerkat-lib/src/net/types.rs
@@ -167,23 +167,23 @@ pub enum MeerkatMessage {
         value: NetValue,
     },
 
-    /// #39: request the source code of a service class by name. A (browser)
-    /// client sends this to fetch a service it imports so it can parse and
-    /// instantiate the service locally. The service name is carried as a
-    /// string and resolved through the receiver's own interner, like the
-    /// other cross-node messages.
+    /// #39: request the source of a `.mkt` file by path. A (browser) client
+    /// sends this to fetch a file it imports so it can process it locally
+    /// (creating services and resolving further imports), like loading a
+    /// program normally. The path is a resource path, similar to a URL path.
     ServiceCodeRequest {
         request_id: u64,
-        service: String,
+        path: String,
         reply_to: String,
     },
 
-    /// #39: response to `ServiceCodeRequest` carrying the service's source
-    /// text. The requester parses it through its own parser (interning
-    /// locally) and instantiates the service.
+    /// #39: response to `ServiceCodeRequest` carrying the whole `.mkt` file
+    /// source. The requester processes it through the normal program-loading
+    /// path. The source is unbounded in length; only the request path and
+    /// reply address are length-limited.
     ServiceCodeResponse {
         request_id: u64,
-        service: String,
+        path: String,
         source: String,
     },
 

--- a/meerkat-lib/src/net/types.rs
+++ b/meerkat-lib/src/net/types.rs
@@ -166,6 +166,29 @@ pub enum MeerkatMessage {
         member: String,
         value: NetValue,
     },
+
+    /// #39: request the source code of a service class by name. A (browser)
+    /// client sends this to fetch a service it imports so it can parse and
+    /// instantiate the service locally. The service name is carried as a
+    /// string and resolved through the receiver's own interner, like the
+    /// other cross-node messages.
+    ServiceCodeRequest {
+        request_id: u64,
+        service: String,
+        reply_to: String,
+    },
+
+    /// #39: response to `ServiceCodeRequest` carrying the service's source
+    /// text. The requester parses it through its own parser (interning
+    /// locally) and instantiates the service.
+    ServiceCodeResponse {
+        request_id: u64,
+        service: String,
+        source: String,
+    },
+
+    /// #39: the requested service class was not found on this server.
+    ServiceCodeError { request_id: u64, error: String },
 }
 
 /// Errors that can occur when sending messages

--- a/meerkat-lib/src/net/types.rs
+++ b/meerkat-lib/src/net/types.rs
@@ -187,7 +187,8 @@ pub enum MeerkatMessage {
         source: String,
     },
 
-    /// #39: the requested service class was not found on this server.
+    /// #39: error responding to a `ServiceCodeRequest`, e.g. an invalid
+    /// request (oversized path/reply_to) or a missing resource.
     ServiceCodeError { request_id: u64, error: String },
 }
 

--- a/meerkat-lib/src/runtime/ast/printer.rs
+++ b/meerkat-lib/src/runtime/ast/printer.rs
@@ -56,7 +56,7 @@ impl<'a> AstPrinter<'a> {
     }
 
     /// Prints spaces corresponding to the current indentation level
-    fn print_indent(&self, indent: usize) {
+    pub(crate) fn print_indent(&self, indent: usize) {
         print!("{}", " ".repeat(indent * self.spaces));
     }
 
@@ -230,17 +230,9 @@ impl<'a> AstPrinter<'a> {
             }
             Expr::Html(template) => {
                 println!("Html:");
-                for part in template.parts() {
-                    match part {
-                        crate::runtime::html::HtmlPartView::Text(t) => {
-                            self.print_indent(indent + 1);
-                            println!("Text: {:?}", t);
-                        }
-                        crate::runtime::html::HtmlPartView::Expr(e) => {
-                            self.print_expr(e, indent + 1)
-                        }
-                    }
-                }
+                // #39: the html module owns how a template prints itself, so the
+                // representation stays hidden here.
+                template.print_ast(self, indent + 1);
             }
             Expr::Tuple { val } => {
                 println!("Tuple:");

--- a/meerkat-lib/src/runtime/html.rs
+++ b/meerkat-lib/src/runtime/html.rs
@@ -83,13 +83,6 @@ pub(crate) enum HtmlPart {
 /// renaming), and render it through [`HtmlTemplate::render`]. This mirrors the
 /// [`Html`] value ADT and is the boundary at which HTML validation will later
 /// be added.
-/// A borrowed view of one part of an HTML template, for read-only traversal
-/// (e.g. the AST printer) without exposing the internal representation.
-pub enum HtmlPartView<'a> {
-    Text(&'a str),
-    Expr(&'a Expr),
-}
-
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct HtmlTemplate {
     parts: Vec<HtmlPart>,
@@ -116,15 +109,22 @@ impl HtmlTemplate {
         })
     }
 
-    /// Iterate the template's parts in order, as borrowed views.
+    /// #39: Print this template's AST structure via the given printer.
     ///
-    /// Gives ordered access to literal text and embedded expressions (for the
-    /// AST printer) without exposing the internal `HtmlPart` representation.
-    pub fn parts(&self) -> impl Iterator<Item = HtmlPartView<'_>> {
-        self.parts.iter().map(|p| match p {
-            HtmlPart::Text(t) => HtmlPartView::Text(t),
-            HtmlPart::Expr(e) => HtmlPartView::Expr(e),
-        })
+    /// The html module owns how a template is displayed, so the internal
+    /// representation stays hidden even from the printer. Literal text is
+    /// printed directly; embedded expressions are delegated back to the
+    /// printer's `print_expr`.
+    pub fn print_ast(&self, printer: &crate::runtime::ast::printer::AstPrinter, indent: usize) {
+        for part in &self.parts {
+            match part {
+                HtmlPart::Text(t) => {
+                    printer.print_indent(indent);
+                    println!("Text: {:?}", t);
+                }
+                HtmlPart::Expr(e) => printer.print_expr(e, indent),
+            }
+        }
     }
 
     /// Render the template into an [`Html`] value.

--- a/meerkat-lib/src/runtime/limits.rs
+++ b/meerkat-lib/src/runtime/limits.rs
@@ -8,3 +8,8 @@ pub const MAX_STRING_LITERAL_LENGTH: usize = 8192;
 
 /// Maximum allowed nesting depth of a type structure during deserialization
 pub const MAX_TYPE_DEPTH: usize = 16;
+
+/// #39: max length for network-request path/address strings (file paths and
+/// reply addresses). Longer than an identifier but bounded, so a client cannot
+/// send an unbounded path or reply_to. Source code in responses is unbounded.
+pub const MAX_NET_REQUEST_STRING_LENGTH: usize = 4096;

--- a/meerkat-lib/src/runtime/manager/mod.rs
+++ b/meerkat-lib/src/runtime/manager/mod.rs
@@ -1108,21 +1108,6 @@ impl Manager {
             .unwrap_or_else(|_| "127.0.0.1".to_string())
     }
 
-    /// Perform a remote variable lookup over the network
-    ///
-    /// Sends a lookup query to the node owning the remote service and registers
-    /// the local node as a transaction participant.
-    ///
-    /// Args:
-    ///     service (Symbol): The remote service symbol
-    ///     member (Symbol): The member/variable symbol within the service
-    ///     txn (Option<&mut Transaction>): The active transaction context
-    ///
-    /// Returns:
-    ///     Result<Value, EvalError>: The retrieved value, or a network/timeout error
-    ///
-    /// Raises:
-    ///     EvalError::LocalDispatchFailed: If a timeout or dispatch error occurs
     /// #39: Fetch the source of a `.mkt` file from a remote server by path.
     ///
     /// Sends a `ServiceCodeRequest` and awaits the reply, reusing the same
@@ -1169,6 +1154,21 @@ impl Manager {
         }
     }
 
+    /// Perform a remote variable lookup over the network
+    ///
+    /// Sends a lookup query to the node owning the remote service and registers
+    /// the local node as a transaction participant.
+    ///
+    /// Args:
+    ///     service (Symbol): The remote service symbol
+    ///     member (Symbol): The member/variable symbol within the service
+    ///     txn (Option<&mut Transaction>): The active transaction context
+    ///
+    /// Returns:
+    ///     Result<Value, EvalError>: The retrieved value, or a network/timeout error
+    ///
+    /// Raises:
+    ///     EvalError::LocalDispatchFailed: If a timeout or dispatch error occurs
     pub async fn remote_lookup(
         &mut self,
         service: Symbol,

--- a/meerkat-lib/src/runtime/manager/mod.rs
+++ b/meerkat-lib/src/runtime/manager/mod.rs
@@ -930,6 +930,13 @@ impl Manager {
                             MeerkatMessage::CommitResponse { request_id, .. } => Some(*request_id),
                             MeerkatMessage::AbortResponse { request_id, .. } => Some(*request_id),
                             MeerkatMessage::WaitParked { request_id, .. } => Some(*request_id),
+                            // #39: code responses are replies routed to the waiting client.
+                            MeerkatMessage::ServiceCodeResponse { request_id, .. } => {
+                                Some(*request_id)
+                            }
+                            MeerkatMessage::ServiceCodeError { request_id, .. } => {
+                                Some(*request_id)
+                            }
                             MeerkatMessage::Ping { .. }
                             | MeerkatMessage::Pong { .. }
                             | MeerkatMessage::Announce { .. }
@@ -940,6 +947,8 @@ impl Manager {
                             | MeerkatMessage::Commit { .. }
                             | MeerkatMessage::Abort { .. }
                             | MeerkatMessage::RequestUpdates { .. }
+                            // #39: an incoming code request is handled server-side, not a reply.
+                            | MeerkatMessage::ServiceCodeRequest { .. }
                             | MeerkatMessage::Update { .. } => None,
                         };
                         if let Some(request_id) = rid {
@@ -1114,6 +1123,71 @@ impl Manager {
     ///
     /// Raises:
     ///     EvalError::LocalDispatchFailed: If a timeout or dispatch error occurs
+    /// #39: Fetch the source code of a service from a remote server by name.
+    ///
+    /// Sends a `ServiceCodeRequest` and awaits the reply, reusing the same
+    /// request/reply machinery as remote lookups. Returns the service's source
+    /// text, which the caller parses and instantiates locally. This is the
+    /// mechanism a browser client uses to load an imported service it cannot
+    /// read from a local file.
+    pub async fn fetch_service_source(
+        &mut self,
+        service_name: &str,
+        server_addr: Address,
+    ) -> Result<String, EvalError> {
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static NEXT_ID: AtomicU64 = AtomicU64::new(1);
+
+        let request_id = NEXT_ID.fetch_add(1, Ordering::SeqCst);
+        let reply_to = self.local_reply_addr().await;
+
+        let msg = MeerkatMessage::ServiceCodeRequest {
+            request_id,
+            service: service_name.to_string(),
+            reply_to,
+        };
+
+        let reply = self
+            .send_and_await_reply(
+                server_addr,
+                msg,
+                request_id,
+                format!("Timeout waiting for source of service '{}'", service_name),
+            )
+            .await?;
+
+        match reply {
+            MeerkatMessage::ServiceCodeResponse { source, .. } => Ok(source),
+            MeerkatMessage::ServiceCodeError { error, .. } => {
+                Err(EvalError::RemoteDispatchFailed(error))
+            }
+            _ => Err(EvalError::RemoteDispatchFailed(
+                "Unexpected reply to service code request".to_string(),
+            )),
+        }
+    }
+
+    /// #39: Fetch a service's source from a remote server and instantiate it
+    /// locally: parse the returned source (interning through the parser, the
+    /// sanctioned interner-writer) and create each service it defines.
+    pub async fn fetch_and_instantiate_service(
+        &mut self,
+        service_name: &str,
+        server_addr: Address,
+    ) -> Result<(), EvalError> {
+        let source = self.fetch_service_source(service_name, server_addr).await?;
+        let stmts = crate::runtime::parser::parse_string(&source, &mut self.interner)
+            .map_err(EvalError::RemoteDispatchFailed)?;
+        for stmt in &stmts {
+            if let crate::ast::Stmt::Service { name, decls } = stmt {
+                self.create_service(*name, decls.clone())
+                    .await
+                    .map_err(|e| EvalError::RemoteDispatchFailed(e.to_string()))?;
+            }
+        }
+        Ok(())
+    }
+
     pub async fn remote_lookup(
         &mut self,
         service: Symbol,
@@ -1187,6 +1261,9 @@ impl Manager {
             | MeerkatMessage::AbortResponse { .. }
             | MeerkatMessage::RequestUpdates { .. }
             | MeerkatMessage::Update { .. }
+            | MeerkatMessage::ServiceCodeRequest { .. }
+            | MeerkatMessage::ServiceCodeResponse { .. }
+            | MeerkatMessage::ServiceCodeError { .. }
             | MeerkatMessage::WaitParked { .. } => Err(EvalError::LocalDispatchFailed(
                 "Unexpected reply to lookup request".to_string(),
             )),
@@ -1322,6 +1399,9 @@ impl Manager {
             | MeerkatMessage::AbortResponse { .. }
             | MeerkatMessage::RequestUpdates { .. }
             | MeerkatMessage::Update { .. }
+            | MeerkatMessage::ServiceCodeRequest { .. }
+            | MeerkatMessage::ServiceCodeResponse { .. }
+            | MeerkatMessage::ServiceCodeError { .. }
             | MeerkatMessage::WaitParked { .. } => Err(EvalError::LocalDispatchFailed(
                 "Unexpected reply to action request".to_string(),
             )),
@@ -1753,6 +1833,9 @@ impl Manager {
             | MeerkatMessage::AbortResponse { .. }
             | MeerkatMessage::RequestUpdates { .. }
             | MeerkatMessage::Update { .. }
+            | MeerkatMessage::ServiceCodeRequest { .. }
+            | MeerkatMessage::ServiceCodeResponse { .. }
+            | MeerkatMessage::ServiceCodeError { .. }
             | MeerkatMessage::WaitParked { .. } => Err(EvalError::LocalDispatchFailed(
                 "Unexpected reply to commit".to_string(),
             )),

--- a/meerkat-lib/src/runtime/manager/mod.rs
+++ b/meerkat-lib/src/runtime/manager/mod.rs
@@ -1123,11 +1123,11 @@ impl Manager {
     ///
     /// Raises:
     ///     EvalError::LocalDispatchFailed: If a timeout or dispatch error occurs
-    /// #39: Fetch the source code of a service from a remote server by name.
+    /// #39: Fetch the source of a `.mkt` file from a remote server by path.
     ///
     /// Sends a `ServiceCodeRequest` and awaits the reply, reusing the same
-    /// request/reply machinery as remote lookups. Returns the service's source
-    /// text of the requested `.mkt` file. The caller processes it through the
+    /// request/reply machinery as remote lookups. Returns the source text of
+    /// the requested `.mkt` file. The caller processes it through the
     /// normal program-loading path (creating services and resolving imports),
     /// rather than a separate loop here, to avoid duplicating that logic. This
     /// is the mechanism a browser client uses to load a file it imports but

--- a/meerkat-lib/src/runtime/manager/mod.rs
+++ b/meerkat-lib/src/runtime/manager/mod.rs
@@ -1127,12 +1127,14 @@ impl Manager {
     ///
     /// Sends a `ServiceCodeRequest` and awaits the reply, reusing the same
     /// request/reply machinery as remote lookups. Returns the service's source
-    /// text, which the caller parses and instantiates locally. This is the
-    /// mechanism a browser client uses to load an imported service it cannot
-    /// read from a local file.
+    /// text of the requested `.mkt` file. The caller processes it through the
+    /// normal program-loading path (creating services and resolving imports),
+    /// rather than a separate loop here, to avoid duplicating that logic. This
+    /// is the mechanism a browser client uses to load a file it imports but
+    /// cannot read from a local disk.
     pub async fn fetch_service_source(
         &mut self,
-        service_name: &str,
+        path: &str,
         server_addr: Address,
     ) -> Result<String, EvalError> {
         use std::sync::atomic::{AtomicU64, Ordering};
@@ -1143,7 +1145,7 @@ impl Manager {
 
         let msg = MeerkatMessage::ServiceCodeRequest {
             request_id,
-            service: service_name.to_string(),
+            path: path.to_string(),
             reply_to,
         };
 
@@ -1152,7 +1154,7 @@ impl Manager {
                 server_addr,
                 msg,
                 request_id,
-                format!("Timeout waiting for source of service '{}'", service_name),
+                format!("Timeout waiting for source of file '{}'", path),
             )
             .await?;
 
@@ -1165,27 +1167,6 @@ impl Manager {
                 "Unexpected reply to service code request".to_string(),
             )),
         }
-    }
-
-    /// #39: Fetch a service's source from a remote server and instantiate it
-    /// locally: parse the returned source (interning through the parser, the
-    /// sanctioned interner-writer) and create each service it defines.
-    pub async fn fetch_and_instantiate_service(
-        &mut self,
-        service_name: &str,
-        server_addr: Address,
-    ) -> Result<(), EvalError> {
-        let source = self.fetch_service_source(service_name, server_addr).await?;
-        let stmts = crate::runtime::parser::parse_string(&source, &mut self.interner)
-            .map_err(EvalError::RemoteDispatchFailed)?;
-        for stmt in &stmts {
-            if let crate::ast::Stmt::Service { name, decls } = stmt {
-                self.create_service(*name, decls.clone())
-                    .await
-                    .map_err(|e| EvalError::RemoteDispatchFailed(e.to_string()))?;
-            }
-        }
-        Ok(())
     }
 
     pub async fn remote_lookup(

--- a/meerkat-lib/src/runtime/parser/mod.rs
+++ b/meerkat-lib/src/runtime/parser/mod.rs
@@ -201,51 +201,6 @@ fn parse_expr_fragment(src: &str, interner: &mut Interner) -> Result<crate::ast:
         .map_err(|e| format!("Parse error in html interpolation: {:?}", e))
 }
 
-/// #39: Extract the source text of a single `service <name> { ... }` block
-/// from full program source, by locating the service header and brace-matching
-/// to its closing brace. Used server-side to answer a request for a service's
-/// code by name.
-///
-/// Returns `None` if no service with that name is found. Brace matching does
-/// not account for a `}` inside a string literal (the same limitation noted
-/// for the html lexer); source that already parsed cleanly is well-formed for
-/// this purpose.
-pub fn extract_service_source(source: &str, service_name: &str) -> Option<String> {
-    let needle = format!("service {}", service_name);
-    let mut search_from = 0;
-    loop {
-        let rel = source[search_from..].find(&needle)?;
-        let start = search_from + rel;
-        let after = start + needle.len();
-        let boundary = source[after..]
-            .chars()
-            .next()
-            .map(|c| !c.is_alphanumeric() && c != '_')
-            .unwrap_or(true);
-        if !boundary {
-            search_from = after;
-            continue;
-        }
-        let brace_rel = source[start..].find('{')?;
-        let brace_start = start + brace_rel;
-        let mut depth: usize = 0;
-        for (i, ch) in source[brace_start..].char_indices() {
-            match ch {
-                '{' => depth += 1,
-                '}' => {
-                    depth -= 1;
-                    if depth == 0 {
-                        let end = brace_start + i + ch.len_utf8();
-                        return Some(source[start..end].to_string());
-                    }
-                }
-                _ => {}
-            }
-        }
-        return None;
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -368,39 +323,6 @@ mod tests {
         } else {
             panic!("Expected Service Stmt");
         }
-    }
-
-    /// #39: extract a single service block from multi-service source.
-    #[test]
-    fn test_extract_service_source_basic() {
-        let src = "service a { var x = 1; }\nservice b { var y = 2; }";
-        let a = extract_service_source(src, "a").expect("a found");
-        assert_eq!(a, "service a { var x = 1; }");
-        let b = extract_service_source(src, "b").expect("b found");
-        assert_eq!(b, "service b { var y = 2; }");
-    }
-
-    /// #39: nested braces (e.g. an action body) are matched correctly.
-    #[test]
-    fn test_extract_service_source_nested_braces() {
-        let src = "service c { pub def f = action { x = x + 1; }; }";
-        let c = extract_service_source(src, "c").expect("c found");
-        assert_eq!(c, "service c { pub def f = action { x = x + 1; }; }");
-    }
-
-    /// #39: a name that is a prefix of another service is not mismatched.
-    #[test]
-    fn test_extract_service_source_word_boundary() {
-        let src = "service counters { var a = 0; }\nservice counter { var b = 0; }";
-        let got = extract_service_source(src, "counter").expect("counter found");
-        assert_eq!(got, "service counter { var b = 0; }");
-    }
-
-    /// #39: a missing service returns None.
-    #[test]
-    fn test_extract_service_source_not_found() {
-        let src = "service a { var x = 1; }";
-        assert!(extract_service_source(src, "zzz").is_none());
     }
 
     /// #39: parse_template splits literal text and interpolations, exposing the

--- a/meerkat-lib/src/runtime/parser/mod.rs
+++ b/meerkat-lib/src/runtime/parser/mod.rs
@@ -201,6 +201,51 @@ fn parse_expr_fragment(src: &str, interner: &mut Interner) -> Result<crate::ast:
         .map_err(|e| format!("Parse error in html interpolation: {:?}", e))
 }
 
+/// #39: Extract the source text of a single `service <name> { ... }` block
+/// from full program source, by locating the service header and brace-matching
+/// to its closing brace. Used server-side to answer a request for a service's
+/// code by name.
+///
+/// Returns `None` if no service with that name is found. Brace matching does
+/// not account for a `}` inside a string literal (the same limitation noted
+/// for the html lexer); source that already parsed cleanly is well-formed for
+/// this purpose.
+pub fn extract_service_source(source: &str, service_name: &str) -> Option<String> {
+    let needle = format!("service {}", service_name);
+    let mut search_from = 0;
+    loop {
+        let rel = source[search_from..].find(&needle)?;
+        let start = search_from + rel;
+        let after = start + needle.len();
+        let boundary = source[after..]
+            .chars()
+            .next()
+            .map(|c| !c.is_alphanumeric() && c != '_')
+            .unwrap_or(true);
+        if !boundary {
+            search_from = after;
+            continue;
+        }
+        let brace_rel = source[start..].find('{')?;
+        let brace_start = start + brace_rel;
+        let mut depth: usize = 0;
+        for (i, ch) in source[brace_start..].char_indices() {
+            match ch {
+                '{' => depth += 1,
+                '}' => {
+                    depth -= 1;
+                    if depth == 0 {
+                        let end = brace_start + i + ch.len_utf8();
+                        return Some(source[start..end].to_string());
+                    }
+                }
+                _ => {}
+            }
+        }
+        return None;
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -323,6 +368,39 @@ mod tests {
         } else {
             panic!("Expected Service Stmt");
         }
+    }
+
+    /// #39: extract a single service block from multi-service source.
+    #[test]
+    fn test_extract_service_source_basic() {
+        let src = "service a { var x = 1; }\nservice b { var y = 2; }";
+        let a = extract_service_source(src, "a").expect("a found");
+        assert_eq!(a, "service a { var x = 1; }");
+        let b = extract_service_source(src, "b").expect("b found");
+        assert_eq!(b, "service b { var y = 2; }");
+    }
+
+    /// #39: nested braces (e.g. an action body) are matched correctly.
+    #[test]
+    fn test_extract_service_source_nested_braces() {
+        let src = "service c { pub def f = action { x = x + 1; }; }";
+        let c = extract_service_source(src, "c").expect("c found");
+        assert_eq!(c, "service c { pub def f = action { x = x + 1; }; }");
+    }
+
+    /// #39: a name that is a prefix of another service is not mismatched.
+    #[test]
+    fn test_extract_service_source_word_boundary() {
+        let src = "service counters { var a = 0; }\nservice counter { var b = 0; }";
+        let got = extract_service_source(src, "counter").expect("counter found");
+        assert_eq!(got, "service counter { var b = 0; }");
+    }
+
+    /// #39: a missing service returns None.
+    #[test]
+    fn test_extract_service_source_not_found() {
+        let src = "service a { var x = 1; }";
+        assert!(extract_service_source(src, "zzz").is_none());
     }
 
     /// #39: parse_template splits literal text and interpolations, exposing the

--- a/meerkat-lib/tests/net_integration_test.rs
+++ b/meerkat-lib/tests/net_integration_test.rs
@@ -513,7 +513,7 @@ async fn test_circuit_relay() {
 /// assert the transport and whole-file return.
 #[tokio::test(flavor = "multi_thread")]
 async fn test_service_code_request_roundtrip() {
-    use meerkat_lib::net::codec::validate_service_code_request;
+    use meerkat_lib::net::codec::build_service_code_response;
 
     let registry = MockNetwork::new_registry();
     let mut server = MockNetwork::new_with_registry(registry.clone());
@@ -569,18 +569,9 @@ async fn test_service_code_request_roundtrip() {
         other => panic!("Expected ServiceCodeRequest, got {:?}", other),
     };
 
-    // Server validates and returns the whole file source.
-    let response = match validate_service_code_request(&path, &reply_to) {
-        Ok(()) => MeerkatMessage::ServiceCodeResponse {
-            request_id,
-            path,
-            source: server_source.to_string(),
-        },
-        Err(e) => MeerkatMessage::ServiceCodeError {
-            request_id,
-            error: e.to_string(),
-        },
-    };
+    // Server builds the response via the same shared helper run_server uses.
+    let response =
+        build_service_code_response(request_id, path, &reply_to, server_source.to_string());
 
     server
         .handle_command(NetworkCommand::SendMessage {
@@ -610,7 +601,7 @@ async fn test_service_code_request_roundtrip() {
 /// and replies with a ServiceCodeError, which the client receives.
 #[tokio::test(flavor = "multi_thread")]
 async fn test_service_code_request_rejects_oversized_path() {
-    use meerkat_lib::net::codec::validate_service_code_request;
+    use meerkat_lib::net::codec::build_service_code_response;
     use meerkat_lib::runtime::limits::MAX_NET_REQUEST_STRING_LENGTH;
 
     let registry = MockNetwork::new_registry();
@@ -666,17 +657,7 @@ async fn test_service_code_request_rejects_oversized_path() {
         other => panic!("Expected ServiceCodeRequest, got {:?}", other),
     };
 
-    let response = match validate_service_code_request(&path, &reply_to) {
-        Ok(()) => MeerkatMessage::ServiceCodeResponse {
-            request_id,
-            path,
-            source: "unused".to_string(),
-        },
-        Err(e) => MeerkatMessage::ServiceCodeError {
-            request_id,
-            error: e.to_string(),
-        },
-    };
+    let response = build_service_code_response(request_id, path, &reply_to, "unused".to_string());
 
     server
         .handle_command(NetworkCommand::SendMessage {

--- a/meerkat-lib/tests/net_integration_test.rs
+++ b/meerkat-lib/tests/net_integration_test.rs
@@ -1,6 +1,27 @@
 use meerkat_lib::net::*;
 use tokio::time::{sleep, Duration};
 
+/// #39: unique temp directory per test invocation, so file-serving tests do
+/// not share filesystem state.
+fn unique_test_dir(label: &str) -> std::path::PathBuf {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let n = COUNTER.fetch_add(1, Ordering::SeqCst);
+    let dir = std::env::temp_dir().join(format!(
+        "meerkat_it_{}_{}_{}_{}",
+        label,
+        std::process::id(),
+        nanos,
+        n
+    ));
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn test_send_and_receive() {
     let mut server = NetworkActor::new(NodeType::Server).await.unwrap();
@@ -513,7 +534,7 @@ async fn test_circuit_relay() {
 /// assert the transport and whole-file return.
 #[tokio::test(flavor = "multi_thread")]
 async fn test_service_code_request_roundtrip() {
-    use meerkat_lib::net::codec::build_service_code_response;
+    use meerkat_lib::net::codec::serve_service_code;
 
     let registry = MockNetwork::new_registry();
     let mut server = MockNetwork::new_with_registry(registry.clone());
@@ -538,8 +559,11 @@ async fn test_service_code_request_roundtrip() {
         other => panic!("Expected ListenSuccess, got {:?}", other),
     };
 
-    // The server's whole program source, hosting more than one service.
-    let server_source = "service counter { pub var count = 0; }\nservice other { var z = 1; }";
+    // The server serves files from a base directory; write the requested
+    // .mkt file there so the server can resolve and read it.
+    let served_dir = unique_test_dir("roundtrip");
+    let served_source = "service counter { pub var count = 0; }\nservice other { var z = 1; }";
+    std::fs::write(served_dir.join("counter.mkt"), served_source).unwrap();
 
     client
         .handle_command(NetworkCommand::SendMessage {
@@ -569,8 +593,9 @@ async fn test_service_code_request_roundtrip() {
         other => panic!("Expected ServiceCodeRequest, got {:?}", other),
     };
 
-    // Server builds the response via the same shared helper run_server uses.
-    let response = build_service_code_response(request_id, path, &reply_to, server_source);
+    // Server serves the file via the same helper run_server uses (validate,
+    // resolve the path against the base dir, read the file).
+    let response = serve_service_code(request_id, path, &reply_to, &served_dir);
 
     server
         .handle_command(NetworkCommand::SendMessage {
@@ -589,10 +614,12 @@ async fn test_service_code_request_roundtrip() {
             ..
         } => {
             // The whole file is returned, both services included.
-            assert_eq!(source, server_source);
+            assert_eq!(source, served_source);
         }
         other => panic!("Expected ServiceCodeResponse, got {:?}", other),
     }
+
+    let _ = std::fs::remove_dir_all(&served_dir);
 }
 
 /// #39: validation error path. A client sends a request whose path exceeds the
@@ -600,7 +627,7 @@ async fn test_service_code_request_roundtrip() {
 /// and replies with a ServiceCodeError, which the client receives.
 #[tokio::test(flavor = "multi_thread")]
 async fn test_service_code_request_rejects_oversized_path() {
-    use meerkat_lib::net::codec::build_service_code_response;
+    use meerkat_lib::net::codec::serve_service_code;
     use meerkat_lib::runtime::limits::MAX_NET_REQUEST_STRING_LENGTH;
 
     let registry = MockNetwork::new_registry();
@@ -656,7 +683,11 @@ async fn test_service_code_request_rejects_oversized_path() {
         other => panic!("Expected ServiceCodeRequest, got {:?}", other),
     };
 
-    let response = build_service_code_response(request_id, path, &reply_to, "unused");
+    // Validation rejects the oversized path before any file I/O, so the base
+    // dir does not need to contain anything.
+    let served_dir = unique_test_dir("oversized");
+    let response = serve_service_code(request_id, path, &reply_to, &served_dir);
+    let _ = std::fs::remove_dir_all(&served_dir);
 
     server
         .handle_command(NetworkCommand::SendMessage {

--- a/meerkat-lib/tests/net_integration_test.rs
+++ b/meerkat-lib/tests/net_integration_test.rs
@@ -570,8 +570,7 @@ async fn test_service_code_request_roundtrip() {
     };
 
     // Server builds the response via the same shared helper run_server uses.
-    let response =
-        build_service_code_response(request_id, path, &reply_to, server_source.to_string());
+    let response = build_service_code_response(request_id, path, &reply_to, server_source);
 
     server
         .handle_command(NetworkCommand::SendMessage {
@@ -657,7 +656,7 @@ async fn test_service_code_request_rejects_oversized_path() {
         other => panic!("Expected ServiceCodeRequest, got {:?}", other),
     };
 
-    let response = build_service_code_response(request_id, path, &reply_to, "unused".to_string());
+    let response = build_service_code_response(request_id, path, &reply_to, "unused");
 
     server
         .handle_command(NetworkCommand::SendMessage {

--- a/meerkat-lib/tests/net_integration_test.rs
+++ b/meerkat-lib/tests/net_integration_test.rs
@@ -504,3 +504,108 @@ async fn test_circuit_relay() {
     );
     println!("circuit relay test passed");
 }
+
+/// #39: full round-trip of the service-code protocol over the mock network.
+/// A client sends a ServiceCodeRequest; the "server" side receives it, slices
+/// the requested service's source with the real extract_service_source, and
+/// replies with a ServiceCodeResponse. The client receives the source back.
+///
+/// This exercises the new wire messages, their routing, and the real slicing
+/// logic. The thin main.rs run_server glue and Manager::fetch_service_source
+/// wrapper (over the already-tested send/await path) are covered by the
+/// manual client/server flow.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_service_code_request_roundtrip() {
+    use meerkat_lib::runtime::parser::extract_service_source;
+
+    let registry = MockNetwork::new_registry();
+    let mut server = MockNetwork::new_with_registry(registry.clone());
+    let mut client = MockNetwork::new_with_registry(registry.clone());
+
+    let server_reply = server
+        .handle_command(NetworkCommand::Listen {
+            addr: Address::new("/ip4/127.0.0.1/tcp/9000"),
+        })
+        .await;
+    let server_addr = match server_reply {
+        NetworkReply::ListenSuccess { addr } => addr,
+        other => panic!("Expected ListenSuccess, got {:?}", other),
+    };
+
+    let client_reply = client
+        .handle_command(NetworkCommand::Listen {
+            addr: Address::new("/ip4/127.0.0.1/tcp/9001"),
+        })
+        .await;
+    let client_addr = match client_reply {
+        NetworkReply::ListenSuccess { addr } => addr,
+        other => panic!("Expected ListenSuccess, got {:?}", other),
+    };
+
+    // The server's program source, hosting two services.
+    let server_source = "service counter { pub var count = 0; }\nservice other { var z = 1; }";
+
+    // Client requests the source of `counter`.
+    client
+        .handle_command(NetworkCommand::SendMessage {
+            addr: server_addr,
+            msg: MeerkatMessage::ServiceCodeRequest {
+                request_id: 1,
+                service: "counter".to_string(),
+                reply_to: client_addr.0.clone(),
+            },
+        })
+        .await;
+
+    // Server receives the request and slices the requested service.
+    let event = server
+        .event_rx
+        .try_recv()
+        .expect("Server should have received the code request");
+    let (request_id, service, reply_to) = match event {
+        NetworkEvent::MessageReceived {
+            msg:
+                MeerkatMessage::ServiceCodeRequest {
+                    request_id,
+                    service,
+                    reply_to,
+                },
+            ..
+        } => (request_id, service, reply_to),
+        other => panic!("Expected ServiceCodeRequest, got {:?}", other),
+    };
+
+    let response = match extract_service_source(server_source, &service) {
+        Some(src) => MeerkatMessage::ServiceCodeResponse {
+            request_id,
+            service,
+            source: src,
+        },
+        None => MeerkatMessage::ServiceCodeError {
+            request_id,
+            error: "not found".to_string(),
+        },
+    };
+
+    server
+        .handle_command(NetworkCommand::SendMessage {
+            addr: Address::new(&reply_to),
+            msg: response,
+        })
+        .await;
+
+    // Client receives the response with the sliced source.
+    let event = client
+        .event_rx
+        .try_recv()
+        .expect("Client should have received the code response");
+    match event {
+        NetworkEvent::MessageReceived {
+            msg: MeerkatMessage::ServiceCodeResponse { source, .. },
+            ..
+        } => {
+            assert_eq!(source, "service counter { pub var count = 0; }");
+        }
+        other => panic!("Expected ServiceCodeResponse, got {:?}", other),
+    }
+}

--- a/meerkat-lib/tests/net_integration_test.rs
+++ b/meerkat-lib/tests/net_integration_test.rs
@@ -505,18 +505,15 @@ async fn test_circuit_relay() {
     println!("circuit relay test passed");
 }
 
-/// #39: full round-trip of the service-code protocol over the mock network.
-/// A client sends a ServiceCodeRequest; the "server" side receives it, slices
-/// the requested service's source with the real extract_service_source, and
-/// replies with a ServiceCodeResponse. The client receives the source back.
-///
-/// This exercises the new wire messages, their routing, and the real slicing
-/// logic. The thin main.rs run_server glue and Manager::fetch_service_source
-/// wrapper (over the already-tested send/await path) are covered by the
-/// manual client/server flow.
+/// #39: whole-file round-trip of the service-code protocol over the mock
+/// network. A client requests a file by path; the server side validates the
+/// request and replies with the whole file source (not a single sliced
+/// service), which the client receives. The client then processes that source
+/// through the normal program-loading path (exercised elsewhere); here we
+/// assert the transport and whole-file return.
 #[tokio::test(flavor = "multi_thread")]
 async fn test_service_code_request_roundtrip() {
-    use meerkat_lib::runtime::parser::extract_service_source;
+    use meerkat_lib::net::codec::validate_service_code_request;
 
     let registry = MockNetwork::new_registry();
     let mut server = MockNetwork::new_with_registry(registry.clone());
@@ -531,7 +528,6 @@ async fn test_service_code_request_roundtrip() {
         NetworkReply::ListenSuccess { addr } => addr,
         other => panic!("Expected ListenSuccess, got {:?}", other),
     };
-
     let client_reply = client
         .handle_command(NetworkCommand::Listen {
             addr: Address::new("/ip4/127.0.0.1/tcp/9001"),
@@ -542,48 +538,47 @@ async fn test_service_code_request_roundtrip() {
         other => panic!("Expected ListenSuccess, got {:?}", other),
     };
 
-    // The server's program source, hosting two services.
+    // The server's whole program source, hosting more than one service.
     let server_source = "service counter { pub var count = 0; }\nservice other { var z = 1; }";
 
-    // Client requests the source of `counter`.
     client
         .handle_command(NetworkCommand::SendMessage {
             addr: server_addr,
             msg: MeerkatMessage::ServiceCodeRequest {
                 request_id: 1,
-                service: "counter".to_string(),
+                path: "counter.mkt".to_string(),
                 reply_to: client_addr.0.clone(),
             },
         })
         .await;
 
-    // Server receives the request and slices the requested service.
     let event = server
         .event_rx
         .try_recv()
         .expect("Server should have received the code request");
-    let (request_id, service, reply_to) = match event {
+    let (request_id, path, reply_to) = match event {
         NetworkEvent::MessageReceived {
             msg:
                 MeerkatMessage::ServiceCodeRequest {
                     request_id,
-                    service,
+                    path,
                     reply_to,
                 },
             ..
-        } => (request_id, service, reply_to),
+        } => (request_id, path, reply_to),
         other => panic!("Expected ServiceCodeRequest, got {:?}", other),
     };
 
-    let response = match extract_service_source(server_source, &service) {
-        Some(src) => MeerkatMessage::ServiceCodeResponse {
+    // Server validates and returns the whole file source.
+    let response = match validate_service_code_request(&path, &reply_to) {
+        Ok(()) => MeerkatMessage::ServiceCodeResponse {
             request_id,
-            service,
-            source: src,
+            path,
+            source: server_source.to_string(),
         },
-        None => MeerkatMessage::ServiceCodeError {
+        Err(e) => MeerkatMessage::ServiceCodeError {
             request_id,
-            error: "not found".to_string(),
+            error: e.to_string(),
         },
     };
 
@@ -594,7 +589,6 @@ async fn test_service_code_request_roundtrip() {
         })
         .await;
 
-    // Client receives the response with the sliced source.
     let event = client
         .event_rx
         .try_recv()
@@ -604,8 +598,108 @@ async fn test_service_code_request_roundtrip() {
             msg: MeerkatMessage::ServiceCodeResponse { source, .. },
             ..
         } => {
-            assert_eq!(source, "service counter { pub var count = 0; }");
+            // The whole file is returned, both services included.
+            assert_eq!(source, server_source);
         }
         other => panic!("Expected ServiceCodeResponse, got {:?}", other),
+    }
+}
+
+/// #39: validation error path. A client sends a request whose path exceeds the
+/// length limit; the server side rejects it via validate_service_code_request
+/// and replies with a ServiceCodeError, which the client receives.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_service_code_request_rejects_oversized_path() {
+    use meerkat_lib::net::codec::validate_service_code_request;
+    use meerkat_lib::runtime::limits::MAX_NET_REQUEST_STRING_LENGTH;
+
+    let registry = MockNetwork::new_registry();
+    let mut server = MockNetwork::new_with_registry(registry.clone());
+    let mut client = MockNetwork::new_with_registry(registry.clone());
+
+    let server_reply = server
+        .handle_command(NetworkCommand::Listen {
+            addr: Address::new("/ip4/127.0.0.1/tcp/9002"),
+        })
+        .await;
+    let server_addr = match server_reply {
+        NetworkReply::ListenSuccess { addr } => addr,
+        other => panic!("Expected ListenSuccess, got {:?}", other),
+    };
+    let client_reply = client
+        .handle_command(NetworkCommand::Listen {
+            addr: Address::new("/ip4/127.0.0.1/tcp/9003"),
+        })
+        .await;
+    let client_addr = match client_reply {
+        NetworkReply::ListenSuccess { addr } => addr,
+        other => panic!("Expected ListenSuccess, got {:?}", other),
+    };
+
+    let oversized_path = "a".repeat(MAX_NET_REQUEST_STRING_LENGTH + 1);
+
+    client
+        .handle_command(NetworkCommand::SendMessage {
+            addr: server_addr,
+            msg: MeerkatMessage::ServiceCodeRequest {
+                request_id: 2,
+                path: oversized_path,
+                reply_to: client_addr.0.clone(),
+            },
+        })
+        .await;
+
+    let event = server
+        .event_rx
+        .try_recv()
+        .expect("Server should have received the code request");
+    let (request_id, path, reply_to) = match event {
+        NetworkEvent::MessageReceived {
+            msg:
+                MeerkatMessage::ServiceCodeRequest {
+                    request_id,
+                    path,
+                    reply_to,
+                },
+            ..
+        } => (request_id, path, reply_to),
+        other => panic!("Expected ServiceCodeRequest, got {:?}", other),
+    };
+
+    let response = match validate_service_code_request(&path, &reply_to) {
+        Ok(()) => MeerkatMessage::ServiceCodeResponse {
+            request_id,
+            path,
+            source: "unused".to_string(),
+        },
+        Err(e) => MeerkatMessage::ServiceCodeError {
+            request_id,
+            error: e.to_string(),
+        },
+    };
+
+    server
+        .handle_command(NetworkCommand::SendMessage {
+            addr: Address::new(&reply_to),
+            msg: response,
+        })
+        .await;
+
+    let event = client
+        .event_rx
+        .try_recv()
+        .expect("Client should have received the code error");
+    match event {
+        NetworkEvent::MessageReceived {
+            msg: MeerkatMessage::ServiceCodeError { error, .. },
+            ..
+        } => {
+            assert!(
+                error.contains("path"),
+                "error should mention path: {}",
+                error
+            );
+        }
+        other => panic!("Expected ServiceCodeError, got {:?}", other),
     }
 }

--- a/meerkat/src/main.rs
+++ b/meerkat/src/main.rs
@@ -585,31 +585,24 @@ async fn run_server(
                         )
                         .await;
                 }
-                // #39: a client is asking for a service's source code by name.
-                // Slice the requested service's block out of the server source
-                // and reply with it, or reply with an error if not found.
-                // #39: a client is requesting a .mkt file by path. Validate the
-                // length-bounded fields, then return the whole file source so
-                // the client can process it (services and any imports) through
-                // the normal program-loading path. The server currently hosts
-                // one program; mapping multiple paths to different files is a
-                // future extension.
+                // #39: a client is requesting a .mkt file by path. Return the
+                // whole file source (via the shared codec helper, which also
+                // validates the length-bounded fields) so the client can
+                // process it (services and any imports) through the normal
+                // program-loading path. The server currently hosts one program;
+                // mapping multiple paths to different files is a future
+                // extension.
                 MeerkatMessage::ServiceCodeRequest {
                     request_id,
                     path,
                     reply_to,
                 } => {
-                    let response = match codec::validate_service_code_request(&path, &reply_to) {
-                        Ok(()) => MeerkatMessage::ServiceCodeResponse {
-                            request_id,
-                            path,
-                            source: server_source.clone(),
-                        },
-                        Err(e) => MeerkatMessage::ServiceCodeError {
-                            request_id,
-                            error: e.to_string(),
-                        },
-                    };
+                    let response = codec::build_service_code_response(
+                        request_id,
+                        path,
+                        &reply_to,
+                        server_source.clone(),
+                    );
                     if let Some(net) = manager.network.as_mut() {
                         net.handle_command(NetworkCommand::SendMessage {
                             addr: Address::new(&reply_to),

--- a/meerkat/src/main.rs
+++ b/meerkat/src/main.rs
@@ -260,12 +260,13 @@ async fn run_server(
     local: bool,
     interner: Interner,
 ) -> Result<(), Box<dyn Error>> {
-    // #39: keep the raw source so we can answer a ServiceCodeRequest by
-    // returning the server's current `.mkt` program text to the client on
-    // demand. Propagate a read error rather than silently serving empty
-    // source, which would make every code request fail.
-    let server_source = std::fs::read_to_string(input_file)
-        .map_err(|e| format!("Failed to read server source '{}': {}", input_file, e))?;
+    // #39: the directory the server was started from is the root for serving
+    // `.mkt` files: a ServiceCodeRequest names a file by path, which is
+    // resolved (safely) against this base directory and read on demand.
+    let served_base_dir = std::path::Path::new(input_file)
+        .parent()
+        .unwrap_or_else(|| std::path::Path::new("."))
+        .to_path_buf();
     let mut net = NetworkActor::new(NodeType::Server).await?;
     let mut manager = Manager::new(interner);
     manager.local = local;
@@ -585,23 +586,23 @@ async fn run_server(
                         )
                         .await;
                 }
-                // #39: a client is requesting a .mkt file by path. Return the
-                // whole file source (via the shared codec helper, which also
-                // validates the length-bounded fields) so the client can
-                // process it (services and any imports) through the normal
-                // program-loading path. The server currently hosts one program;
-                // mapping multiple paths to different files is a future
-                // extension.
+                // #39: a client is requesting a .mkt file by path. Validate,
+                // safely resolve the path against the served base directory,
+                // read that file, and reply with its whole source so the client
+                // can process it (services and any imports) through the normal
+                // program-loading path. Returning the requested file (not the
+                // server's own program) lets a client run code distinct from
+                // the server, which is the point of the web client.
                 MeerkatMessage::ServiceCodeRequest {
                     request_id,
                     path,
                     reply_to,
                 } => {
-                    let response = codec::build_service_code_response(
+                    let response = codec::serve_service_code(
                         request_id,
                         path,
                         &reply_to,
-                        &server_source,
+                        &served_base_dir,
                     );
                     if let Some(net) = manager.network.as_mut() {
                         net.handle_command(NetworkCommand::SendMessage {

--- a/meerkat/src/main.rs
+++ b/meerkat/src/main.rs
@@ -262,7 +262,10 @@ async fn run_server(
 ) -> Result<(), Box<dyn Error>> {
     // #39: keep the raw source so we can answer ServiceCodeRequest by slicing
     // out the requested service's `service <name> { ... }` block on demand.
-    let server_source = std::fs::read_to_string(input_file).unwrap_or_default();
+    // Propagate a read error rather than silently serving empty source, which
+    // would make every code request report "not found".
+    let server_source = std::fs::read_to_string(input_file)
+        .map_err(|e| format!("Failed to read server source '{}': {}", input_file, e))?;
     let mut net = NetworkActor::new(NodeType::Server).await?;
     let mut manager = Manager::new(interner);
     manager.local = local;
@@ -585,20 +588,26 @@ async fn run_server(
                 // #39: a client is asking for a service's source code by name.
                 // Slice the requested service's block out of the server source
                 // and reply with it, or reply with an error if not found.
+                // #39: a client is requesting a .mkt file by path. Validate the
+                // length-bounded fields, then return the whole file source so
+                // the client can process it (services and any imports) through
+                // the normal program-loading path. The server currently hosts
+                // one program; mapping multiple paths to different files is a
+                // future extension.
                 MeerkatMessage::ServiceCodeRequest {
                     request_id,
-                    service,
+                    path,
                     reply_to,
                 } => {
-                    let response = match parser::extract_service_source(&server_source, &service) {
-                        Some(src) => MeerkatMessage::ServiceCodeResponse {
+                    let response = match codec::validate_service_code_request(&path, &reply_to) {
+                        Ok(()) => MeerkatMessage::ServiceCodeResponse {
                             request_id,
-                            service,
-                            source: src,
+                            path,
+                            source: server_source.clone(),
                         },
-                        None => MeerkatMessage::ServiceCodeError {
+                        Err(e) => MeerkatMessage::ServiceCodeError {
                             request_id,
-                            error: format!("service '{}' not found on this server", service),
+                            error: e.to_string(),
                         },
                     };
                     if let Some(net) = manager.network.as_mut() {

--- a/meerkat/src/main.rs
+++ b/meerkat/src/main.rs
@@ -260,10 +260,10 @@ async fn run_server(
     local: bool,
     interner: Interner,
 ) -> Result<(), Box<dyn Error>> {
-    // #39: keep the raw source so we can answer ServiceCodeRequest by slicing
-    // out the requested service's `service <name> { ... }` block on demand.
-    // Propagate a read error rather than silently serving empty source, which
-    // would make every code request report "not found".
+    // #39: keep the raw source so we can answer a ServiceCodeRequest by
+    // returning the server's current `.mkt` program text to the client on
+    // demand. Propagate a read error rather than silently serving empty
+    // source, which would make every code request fail.
     let server_source = std::fs::read_to_string(input_file)
         .map_err(|e| format!("Failed to read server source '{}': {}", input_file, e))?;
     let mut net = NetworkActor::new(NodeType::Server).await?;
@@ -601,7 +601,7 @@ async fn run_server(
                         request_id,
                         path,
                         &reply_to,
-                        server_source.clone(),
+                        &server_source,
                     );
                     if let Some(net) = manager.network.as_mut() {
                         net.handle_command(NetworkCommand::SendMessage {

--- a/meerkat/src/main.rs
+++ b/meerkat/src/main.rs
@@ -106,7 +106,7 @@ pub async fn main() -> Result<(), Box<dyn Error>> {
             }
 
             if args.server {
-                run_server(prog, remote_url_map, args.port, args.local, interner).await
+                run_server(prog, file, remote_url_map, args.port, args.local, interner).await
             } else {
                 run_client(prog, file, remote_url_map, args.local, args.watch, interner).await
             }
@@ -254,11 +254,15 @@ fn listen_success_addr(reply: NetworkReply) -> Result<Address, Box<dyn Error>> {
 
 async fn run_server(
     prog: Vec<Stmt>,
+    input_file: &str,
     remote_url_map: std::collections::HashMap<String, String>,
     port: u16,
     local: bool,
     interner: Interner,
 ) -> Result<(), Box<dyn Error>> {
+    // #39: keep the raw source so we can answer ServiceCodeRequest by slicing
+    // out the requested service's `service <name> { ... }` block on demand.
+    let server_source = std::fs::read_to_string(input_file).unwrap_or_default();
     let mut net = NetworkActor::new(NodeType::Server).await?;
     let mut manager = Manager::new(interner);
     manager.local = local;
@@ -578,6 +582,33 @@ async fn run_server(
                         )
                         .await;
                 }
+                // #39: a client is asking for a service's source code by name.
+                // Slice the requested service's block out of the server source
+                // and reply with it, or reply with an error if not found.
+                MeerkatMessage::ServiceCodeRequest {
+                    request_id,
+                    service,
+                    reply_to,
+                } => {
+                    let response = match parser::extract_service_source(&server_source, &service) {
+                        Some(src) => MeerkatMessage::ServiceCodeResponse {
+                            request_id,
+                            service,
+                            source: src,
+                        },
+                        None => MeerkatMessage::ServiceCodeError {
+                            request_id,
+                            error: format!("service '{}' not found on this server", service),
+                        },
+                    };
+                    if let Some(net) = manager.network.as_mut() {
+                        net.handle_command(NetworkCommand::SendMessage {
+                            addr: Address::new(&reply_to),
+                            msg: response,
+                        })
+                        .await;
+                    }
+                }
                 MeerkatMessage::Ping { .. }
                 | MeerkatMessage::Pong { .. }
                 | MeerkatMessage::Announce { .. }
@@ -588,6 +619,9 @@ async fn run_server(
                 | MeerkatMessage::ActionResponse { .. }
                 | MeerkatMessage::CommitResponse { .. }
                 | MeerkatMessage::AbortResponse { .. }
+                // #39: code responses are client-bound replies, not seen at the server.
+                | MeerkatMessage::ServiceCodeResponse { .. }
+                | MeerkatMessage::ServiceCodeError { .. }
                 | MeerkatMessage::WaitParked { .. } => {}
             }
         }


### PR DESCRIPTION
Second of three PRs for the web client. This adds the mechanism for a client to request a `.mkt` file from a server by path, so it can load and run that code locally, per the Requirements page. Also folds in the html AST-printing cleanup requested on the #123 merge.

## What this adds
- Three wire messages (`ServiceCodeRequest` / `ServiceCodeResponse` / `ServiceCodeError`). They carry only strings, so serde handles them and no runtime `Value`/`Expr` codec change was needed.
- Server: `run_server` answers a `ServiceCodeRequest` by returning the requested `.mkt` file's source (via `codec::build_service_code_response`, which also validates the length-bounded fields), or an error.
- Client: `Manager::fetch_service_source` sends the request and awaits the reply over the existing request/reply path. Processing the returned source through the normal program-loading path (services and imports) is done by the caller; the browser entry point in PR 3 wires this in.
- The request identifies a file by path (like a URL path), and the server returns the whole file so any imports and other services it needs come with it. We send raw source text rather than serialized decls, keeping this PR small. Server-side parsing and type checking is noted as future work (needed for early error catching and code updates).

## HTML print cleanup (from #123 review)
Removed `HtmlTemplate::parts()` and `HtmlPartView`, which leaked the template's text/expr shape. Added `HtmlTemplate::print_ast()`, called from the printer, so the html module owns its own AST printing and the representation stays hidden.

## Testing
A mock-network round-trip test (client requests a path, server returns the whole file source) and a validation error-path test (oversized path is rejected with `ServiceCodeError`). Both call the same `codec::build_service_code_response` the server uses, so they exercise the real handler.

## Out of scope
The wasm browser client, HTML host page, JS wrapper, and HTTP server (PR 3). The `run_server` glue is exercised via the manual client/server flow rather than an automated test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added a network “service code” request/response flow to fetch `.mkt` source by path, including success (source) and failure (error) replies.
  * Added a client API to fetch remote service source and updated the server to handle requests.
  * Introduced a configurable request-string length limit (4096).

* **Bug Fixes**
  * Added strict validation for requested path and reply address, including safe path resolution to prevent escaping the served directory.

* **Refactor**
  * Updated HTML template inspection: removed the public parts view/iterator and added an AST-based printing method.

* **Tests**
  * Added integration tests for request roundtrips and oversized path rejection, plus unit coverage for file resolution rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->