### PR TITLE
feat: add list types, list literals, range literals, and for loops

### DIFF
--- a/meerkat-lib/src/net/ast.rs
+++ b/meerkat-lib/src/net/ast.rs
@@ -57,7 +57,7 @@ pub enum NetActionStmt {
     },
     For {
         var: String,
-        range: NetExpr,
+        iterable: NetExpr,
         body: Vec<NetActionStmt>,
     },
 }

--- a/meerkat-lib/src/net/ast.rs
+++ b/meerkat-lib/src/net/ast.rs
@@ -22,6 +22,7 @@ pub enum NetType {
     Unit,
     Tuple(Vec<NetType>),
     Func(Box<NetType>, Box<NetType>),
+    List(Box<NetType>),
 }
 
 /// Network representation of a function parameter
@@ -54,6 +55,11 @@ pub enum NetActionStmt {
         row: NetExpr,
         table_name: String,
     },
+    For {
+        var: String,
+        range: NetExpr,
+        body: Vec<NetActionStmt>,
+    },
 }
 
 /// Network representation of a value
@@ -85,6 +91,13 @@ pub enum NetValue {
         stmts: Vec<NetActionStmt>,
         env: Vec<(String, NetValue)>,
         service_net_id: ServiceNetId,
+    },
+    List {
+        vals: Vec<NetValue>,
+    },
+    Range {
+        start: i32,
+        end: i32,
     },
 }
 
@@ -146,6 +159,11 @@ pub enum NetExpr {
         column_name: String,
         operation: Box<NetExpr>,
         identity: Box<NetExpr>,
+    },
+    List(Vec<NetExpr>),
+    Range {
+        start: Box<NetExpr>,
+        end: Box<NetExpr>,
     },
 }
 

--- a/meerkat-lib/src/net/codec.rs
+++ b/meerkat-lib/src/net/codec.rs
@@ -787,17 +787,17 @@ pub fn encode_action_stmt(stmt: &ActionStmt, interner: &Interner) -> Result<NetA
                 table_name: table_str.to_string(),
             })
         }
-        ActionStmt::For { var, range, body } => {
+        ActionStmt::For { var, iterable, body } => {
             let var_str = interner.get(*var).to_string();
             validate_identifier(&var_str)?;
-            let encoded_range = encode_expr(range, interner)?;
+            let encoded_iterable = encode_expr(iterable, interner)?;
             let mut encoded_body = Vec::new();
             for s in body {
                 encoded_body.push(encode_action_stmt(s, interner)?);
             }
             Ok(NetActionStmt::For {
                 var: var_str,
-                range: encoded_range,
+                iterable: encoded_iterable,
                 body: encoded_body,
             })
         }
@@ -843,16 +843,20 @@ pub fn decode_action_stmt(stmt: NetActionStmt, interner: &mut Interner) -> Resul
                 table_name: interner.insert(&table_name),
             })
         }
-        NetActionStmt::For { var, range, body } => {
+        NetActionStmt::For {
+            var,
+            iterable,
+            body,
+        } => {
             validate_identifier(&var)?;
-            let decoded_range = decode_expr(range, interner)?;
+            let decoded_iterable = decode_expr(iterable, interner)?;
             let mut decoded_body = Vec::new();
             for s in body {
                 decoded_body.push(decode_action_stmt(s, interner)?);
             }
             Ok(ActionStmt::For {
                 var: interner.insert(&var),
-                range: decoded_range,
+                iterable: decoded_iterable,
                 body: decoded_body,
             })
         }

--- a/meerkat-lib/src/net/codec.rs
+++ b/meerkat-lib/src/net/codec.rs
@@ -69,6 +69,10 @@ fn encode_type_internal(ty: &Type, depth: usize) -> Result<NetType> {
             let et2 = encode_type_internal(t2, depth + 1)?;
             Ok(NetType::Func(Box::new(et1), Box::new(et2)))
         }
+        Type::List(t) => {
+            let et = encode_type_internal(t, depth + 1)?;
+            Ok(NetType::List(Box::new(et)))
+        }
     }
 }
 
@@ -132,6 +136,10 @@ fn decode_type_internal(ty: NetType, depth: usize) -> Result<Type> {
             let dt1 = decode_type_internal(*t1, depth + 1)?;
             let dt2 = decode_type_internal(*t2, depth + 1)?;
             Ok(Type::Func(Box::new(dt1), Box::new(dt2)))
+        }
+        NetType::List(t) => {
+            let dt = decode_type_internal(*t, depth + 1)?;
+            Ok(Type::List(Box::new(dt)))
         }
     }
 }
@@ -256,6 +264,16 @@ pub fn encode_value(val: &Value, interner: &Interner) -> Result<NetValue> {
                 service_net_id: service_net_id.clone(),
             })
         }
+        Value::List { vals } => {
+            let mut encoded = Vec::new();
+            for v in vals {
+                encoded.push(encode_value(v, interner)?);
+            }
+            Ok(NetValue::List { vals: encoded })
+        }
+        Value::Range { start, end } => {
+            Ok(NetValue::Range { start: *start, end: *end })
+        }
     }
 }
 
@@ -322,6 +340,16 @@ pub fn decode_value(val: NetValue, interner: &mut Interner) -> Result<Value> {
                 env: decoded_env,
                 service_net_id,
             })
+        }
+        NetValue::List { vals } => {
+            let mut decoded = Vec::new();
+            for v in vals {
+                decoded.push(decode_value(v, interner)?);
+            }
+            Ok(Value::List { vals: decoded })
+        }
+        NetValue::Range { start, end } => {
+            Ok(Value::Range { start, end })
         }
     }
 }
@@ -473,6 +501,19 @@ pub fn encode_expr(expr: &Expr, interner: &Interner) -> Result<NetExpr> {
                 identity: Box::new(encode_expr(identity, interner)?),
             })
         }
+        Expr::List(exprs) => {
+            let mut encoded = Vec::new();
+            for e in exprs {
+                encoded.push(encode_expr(e, interner)?);
+            }
+            Ok(NetExpr::List(encoded))
+        }
+        Expr::Range { start, end } => {
+            Ok(NetExpr::Range {
+                start: Box::new(encode_expr(start, interner)?),
+                end: Box::new(encode_expr(end, interner)?),
+            })
+        }
     }
 }
 
@@ -617,6 +658,19 @@ pub fn decode_expr(expr: NetExpr, interner: &mut Interner) -> Result<Expr> {
                 identity: Box::new(decode_expr(*identity, interner)?),
             })
         }
+        NetExpr::List(exprs) => {
+            let mut decoded = Vec::new();
+            for e in exprs {
+                decoded.push(decode_expr(e, interner)?);
+            }
+            Ok(Expr::List(decoded))
+        }
+        NetExpr::Range { start, end } => {
+            Ok(Expr::Range {
+                start: Box::new(decode_expr(*start, interner)?),
+                end: Box::new(decode_expr(*end, interner)?),
+            })
+        }
     }
 }
 
@@ -666,6 +720,20 @@ pub fn encode_action_stmt(stmt: &ActionStmt, interner: &Interner) -> Result<NetA
                 table_name: table_str.to_string(),
             })
         }
+        ActionStmt::For { var, range, body } => {
+            let var_str = interner.get(*var).to_string();
+            validate_identifier(&var_str)?;
+            let encoded_range = encode_expr(range, interner)?;
+            let mut encoded_body = Vec::new();
+            for s in body {
+                encoded_body.push(encode_action_stmt(s, interner)?);
+            }
+            Ok(NetActionStmt::For {
+                var: var_str,
+                range: encoded_range,
+                body: encoded_body,
+            })
+        }
     }
 }
 
@@ -706,6 +774,19 @@ pub fn decode_action_stmt(stmt: NetActionStmt, interner: &mut Interner) -> Resul
             Ok(ActionStmt::Insert {
                 row: decode_expr(row, interner)?,
                 table_name: interner.insert(&table_name),
+            })
+        }
+        NetActionStmt::For { var, range, body } => {
+            validate_identifier(&var)?;
+            let decoded_range = decode_expr(range, interner)?;
+            let mut decoded_body = Vec::new();
+            for s in body {
+                decoded_body.push(decode_action_stmt(s, interner)?);
+            }
+            Ok(ActionStmt::For {
+                var: interner.insert(&var),
+                range: decoded_range,
+                body: decoded_body,
             })
         }
     }

--- a/meerkat-lib/src/net/codec.rs
+++ b/meerkat-lib/src/net/codec.rs
@@ -787,7 +787,11 @@ pub fn encode_action_stmt(stmt: &ActionStmt, interner: &Interner) -> Result<NetA
                 table_name: table_str.to_string(),
             })
         }
-        ActionStmt::For { var, iterable, body } => {
+        ActionStmt::For {
+            var,
+            iterable,
+            body,
+        } => {
             let var_str = interner.get(*var).to_string();
             validate_identifier(&var_str)?;
             let encoded_iterable = encode_expr(iterable, interner)?;

--- a/meerkat-lib/src/net/codec.rs
+++ b/meerkat-lib/src/net/codec.rs
@@ -338,9 +338,10 @@ pub fn encode_value(val: &Value, interner: &Interner) -> Result<NetValue> {
             }
             Ok(NetValue::List { vals: encoded })
         }
-        Value::Range { start, end } => {
-            Ok(NetValue::Range { start: *start, end: *end })
-        }
+        Value::Range { start, end } => Ok(NetValue::Range {
+            start: *start,
+            end: *end,
+        }),
     }
 }
 
@@ -415,9 +416,7 @@ pub fn decode_value(val: NetValue, interner: &mut Interner) -> Result<Value> {
             }
             Ok(Value::List { vals: decoded })
         }
-        NetValue::Range { start, end } => {
-            Ok(Value::Range { start, end })
-        }
+        NetValue::Range { start, end } => Ok(Value::Range { start, end }),
     }
 }
 
@@ -580,12 +579,10 @@ pub fn encode_expr(expr: &Expr, interner: &Interner) -> Result<NetExpr> {
             }
             Ok(NetExpr::List(encoded))
         }
-        Expr::Range { start, end } => {
-            Ok(NetExpr::Range {
-                start: Box::new(encode_expr(start, interner)?),
-                end: Box::new(encode_expr(end, interner)?),
-            })
-        }
+        Expr::Range { start, end } => Ok(NetExpr::Range {
+            start: Box::new(encode_expr(start, interner)?),
+            end: Box::new(encode_expr(end, interner)?),
+        }),
     }
 }
 
@@ -737,12 +734,10 @@ pub fn decode_expr(expr: NetExpr, interner: &mut Interner) -> Result<Expr> {
             }
             Ok(Expr::List(decoded))
         }
-        NetExpr::Range { start, end } => {
-            Ok(Expr::Range {
-                start: Box::new(decode_expr(*start, interner)?),
-                end: Box::new(decode_expr(*end, interner)?),
-            })
-        }
+        NetExpr::Range { start, end } => Ok(Expr::Range {
+            start: Box::new(decode_expr(*start, interner)?),
+            end: Box::new(decode_expr(*end, interner)?),
+        }),
     }
 }
 

--- a/meerkat-lib/src/runtime/ast/mod.rs
+++ b/meerkat-lib/src/runtime/ast/mod.rs
@@ -49,6 +49,11 @@ pub enum ActionStmt {
         row: Expr,
         table_name: Symbol,
     },
+    For {
+        var: Symbol,
+        range: Expr,
+        body: Vec<ActionStmt>,
+    },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -112,6 +117,25 @@ pub enum Value {
         /// where the closure is later used
         service_net_id: ServiceNetId,
     },
+    List {
+        vals: Vec<Value>,
+    },
+    Range {
+        start: i32,
+        end: i32,
+    },
+}
+
+impl Value {
+    pub fn to_list_elements(&self) -> Option<Vec<Value>> {
+        match self {
+            Value::List { vals } => Some(vals.clone()),
+            Value::Range { start, end } => {
+                Some((*start..*end).map(|v| Value::Int { val: v }).collect())
+            }
+            _ => None,
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -190,6 +214,11 @@ pub enum Expr {
         column_name: Symbol,
         operation: Box<Expr>,
         identity: Box<Expr>,
+    },
+    List(Vec<Expr>),
+    Range {
+        start: Box<Expr>,
+        end: Box<Expr>,
     },
 }
 
@@ -302,6 +331,26 @@ impl Display for Value {
                     env_str, service_net_id.0, stmts
                 )
             }
+            Value::List { vals } => {
+                write!(f, "[")?;
+                for (i, val) in vals.iter().enumerate() {
+                    if i > 0 {
+                        write!(f, ", ")?;
+                    }
+                    write!(f, "{}", val)?;
+                }
+                write!(f, "]")
+            }
+            Value::Range { start, end } => {
+                write!(f, "[")?;
+                for (i, val) in (*start..*end).enumerate() {
+                    if i > 0 {
+                        write!(f, ", ")?;
+                    }
+                    write!(f, "{}", val)?;
+                }
+                write!(f, "]")
+            }
         }
     }
 }
@@ -389,6 +438,19 @@ impl Display for Expr {
                 write!(f, "]")
             }
             Expr::Fold { .. } => write!(f, "fold"),
+            Expr::List(exprs) => {
+                write!(f, "[")?;
+                for (i, expr) in exprs.iter().enumerate() {
+                    if i > 0 {
+                        write!(f, ", ")?;
+                    }
+                    write!(f, "{}", expr)?;
+                }
+                write!(f, "]")
+            }
+            Expr::Range { start, end } => {
+                write!(f, "{}..{}", start, end)
+            }
         }
     }
 }
@@ -419,6 +481,13 @@ impl Display for ActionStmt {
             ActionStmt::Assign { name, expr } => write!(f, "{} = {}", name, expr),
             ActionStmt::Insert { row, table_name } => {
                 write!(f, "insert into {} {}", table_name, row)
+            }
+            ActionStmt::For { var, range, body } => {
+                write!(f, "for {} in {} {{ ", var, range)?;
+                for stmt in body {
+                    write!(f, "{}; ", stmt)?;
+                }
+                write!(f, "}}")
             }
         }
     }

--- a/meerkat-lib/src/runtime/ast/mod.rs
+++ b/meerkat-lib/src/runtime/ast/mod.rs
@@ -484,7 +484,11 @@ impl Display for ActionStmt {
             ActionStmt::Insert { row, table_name } => {
                 write!(f, "insert into {} {}", table_name, row)
             }
-            ActionStmt::For { var, iterable, body } => {
+            ActionStmt::For {
+                var,
+                iterable,
+                body,
+            } => {
                 write!(f, "for {} in {} {{ ", var, iterable)?;
                 for stmt in body {
                     write!(f, "{}; ", stmt)?;

--- a/meerkat-lib/src/runtime/ast/mod.rs
+++ b/meerkat-lib/src/runtime/ast/mod.rs
@@ -52,7 +52,7 @@ pub enum ActionStmt {
     },
     For {
         var: Symbol,
-        range: Expr,
+        iterable: Expr,
         body: Vec<ActionStmt>,
     },
 }
@@ -484,8 +484,8 @@ impl Display for ActionStmt {
             ActionStmt::Insert { row, table_name } => {
                 write!(f, "insert into {} {}", table_name, row)
             }
-            ActionStmt::For { var, range, body } => {
-                write!(f, "for {} in {} {{ ", var, range)?;
+            ActionStmt::For { var, iterable, body } => {
+                write!(f, "for {} in {} {{ ", var, iterable)?;
                 for stmt in body {
                     write!(f, "{}; ", stmt)?;
                 }

--- a/meerkat-lib/src/runtime/ast/mod.rs
+++ b/meerkat-lib/src/runtime/ast/mod.rs
@@ -351,16 +351,7 @@ impl Display for Value {
                 }
                 write!(f, "]")
             }
-            Value::Range { start, end } => {
-                write!(f, "[")?;
-                for (i, val) in (*start..*end).enumerate() {
-                    if i > 0 {
-                        write!(f, ", ")?;
-                    }
-                    write!(f, "{}", val)?;
-                }
-                write!(f, "]")
-            }
+            Value::Range { start, end } => write!(f, "{}..{}", start, end),
         }
     }
 }

--- a/meerkat-lib/src/runtime/ast/printer.rs
+++ b/meerkat-lib/src/runtime/ast/printer.rs
@@ -213,6 +213,17 @@ impl<'a> AstPrinter<'a> {
                 );
                 self.print_expr(row, indent + 1);
             }
+            ActionStmt::For { var, range, body } => {
+                let var = *var;
+                println!(
+                    "For: {{ var: {} }}",
+                    self.format_symbol(var)
+                );
+                self.print_expr(range, indent + 1);
+                for stmt in body {
+                    self.print_action_stmt(stmt, indent + 1);
+                }
+            }
         }
     }
 
@@ -345,6 +356,17 @@ impl<'a> AstPrinter<'a> {
                 self.print_expr(operation, indent + 1);
                 self.print_expr(identity, indent + 1);
             }
+            Expr::List(exprs) => {
+                println!("List:");
+                for expr in exprs {
+                    self.print_expr(expr, indent + 1);
+                }
+            }
+            Expr::Range { start, end } => {
+                println!("Range:");
+                self.print_expr(start, indent + 1);
+                self.print_expr(end, indent + 1);
+            }
         }
     }
 
@@ -401,6 +423,15 @@ impl<'a> AstPrinter<'a> {
                 for stmt in stmts {
                     self.print_action_stmt(stmt, indent + 1);
                 }
+            }
+            Value::List { vals } => {
+                println!("List:");
+                for val in vals {
+                    self.print_value(val, indent + 1);
+                }
+            }
+            Value::Range { start, end } => {
+                println!("Range: {}..{}", start, end);
             }
         }
     }

--- a/meerkat-lib/src/runtime/ast/printer.rs
+++ b/meerkat-lib/src/runtime/ast/printer.rs
@@ -213,7 +213,11 @@ impl<'a> AstPrinter<'a> {
                 );
                 self.print_expr(row, indent + 1);
             }
-            ActionStmt::For { var, iterable, body } => {
+            ActionStmt::For {
+                var,
+                iterable,
+                body,
+            } => {
                 let var = *var;
                 println!("For: {{ var: {} }}", self.format_symbol(var));
                 self.print_expr(iterable, indent + 1);

--- a/meerkat-lib/src/runtime/ast/printer.rs
+++ b/meerkat-lib/src/runtime/ast/printer.rs
@@ -213,10 +213,10 @@ impl<'a> AstPrinter<'a> {
                 );
                 self.print_expr(row, indent + 1);
             }
-            ActionStmt::For { var, range, body } => {
+            ActionStmt::For { var, iterable, body } => {
                 let var = *var;
                 println!("For: {{ var: {} }}", self.format_symbol(var));
-                self.print_expr(range, indent + 1);
+                self.print_expr(iterable, indent + 1);
                 for stmt in body {
                     self.print_action_stmt(stmt, indent + 1);
                 }

--- a/meerkat-lib/src/runtime/ast/printer.rs
+++ b/meerkat-lib/src/runtime/ast/printer.rs
@@ -215,10 +215,7 @@ impl<'a> AstPrinter<'a> {
             }
             ActionStmt::For { var, range, body } => {
                 let var = *var;
-                println!(
-                    "For: {{ var: {} }}",
-                    self.format_symbol(var)
-                );
+                println!("For: {{ var: {} }}", self.format_symbol(var));
                 self.print_expr(range, indent + 1);
                 for stmt in body {
                     self.print_action_stmt(stmt, indent + 1);

--- a/meerkat-lib/src/runtime/interpreter/evaluator.rs
+++ b/meerkat-lib/src/runtime/interpreter/evaluator.rs
@@ -148,13 +148,8 @@ pub async fn eval(
                             val: s1 == s2 && e1 == e2,
                         });
                     }
-                    (
-                        Value::List { .. },
-                        Value::Range { .. },
-                    ) | (
-                        Value::Range { .. },
-                        Value::List { .. },
-                    ) => {
+                    (Value::List { .. }, Value::Range { .. })
+                    | (Value::Range { .. }, Value::List { .. }) => {
                         if let (Some(l1), Some(l2)) =
                             (val1.to_list_elements(), val2.to_list_elements())
                         {

--- a/meerkat-lib/src/runtime/interpreter/evaluator.rs
+++ b/meerkat-lib/src/runtime/interpreter/evaluator.rs
@@ -121,49 +121,53 @@ pub async fn eval(
         Expr::Binop { op, expr1, expr2 } => {
             let val1 = eval(expr1, env, ctx).await?;
             let val2 = eval(expr2, env, ctx).await?;
-            match (op, val1, val2) {
-                (BinOp::Add, Value::Int { val: v1 }, Value::Int { val: v2 }) => {
-                    Ok(Value::Int { val: v1 + v2 })
+            if let (BinOp::Eq, Some(l1), Some(l2)) = (op, val1.to_list_elements(), val2.to_list_elements()) {
+                Ok(Value::Bool { val: l1 == l2 })
+            } else {
+                match (op, val1, val2) {
+                    (BinOp::Add, Value::Int { val: v1 }, Value::Int { val: v2 }) => {
+                        Ok(Value::Int { val: v1 + v2 })
+                    }
+                    (BinOp::Sub, Value::Int { val: v1 }, Value::Int { val: v2 }) => {
+                        Ok(Value::Int { val: v1 - v2 })
+                    }
+                    (BinOp::Mul, Value::Int { val: v1 }, Value::Int { val: v2 }) => {
+                        Ok(Value::Int { val: v1 * v2 })
+                    }
+                    (BinOp::Div, Value::Int { val: v1 }, Value::Int { val: v2 }) => {
+                        // NOTE: Division by zero and division overflow (i32::MIN / -1) are the only
+                        // integer arithmetic operations that panic in Rust release mode.
+                        // If a modulo (%) operator is ever implemented in the future, it must
+                        // also include these identical bounds checks (x % 0 and i32::MIN % -1)
+                        // to prevent panics.
+                        let val = v1.checked_div(v2).ok_or_else(|| {
+                            EvalError::RuntimeError(if v2 == 0 {
+                                "Division by zero".to_string()
+                            } else {
+                                "Integer overflow".to_string()
+                            })
+                        })?;
+                        Ok(Value::Int { val })
+                    }
+                    (BinOp::Eq, Value::Int { val: v1 }, Value::Int { val: v2 }) => {
+                        Ok(Value::Bool { val: v1 == v2 })
+                    }
+                    (BinOp::Lt, Value::Int { val: v1 }, Value::Int { val: v2 }) => {
+                        Ok(Value::Bool { val: v1 < v2 })
+                    }
+                    (BinOp::Gt, Value::Int { val: v1 }, Value::Int { val: v2 }) => {
+                        Ok(Value::Bool { val: v1 > v2 })
+                    }
+                    (BinOp::And, Value::Bool { val: v1 }, Value::Bool { val: v2 }) => {
+                        Ok(Value::Bool { val: v1 && v2 })
+                    }
+                    (BinOp::Or, Value::Bool { val: v1 }, Value::Bool { val: v2 }) => {
+                        Ok(Value::Bool { val: v1 || v2 })
+                    }
+                    _ => Err(EvalError::TypeError(
+                        "Type error in binary operation".to_string(),
+                    )),
                 }
-                (BinOp::Sub, Value::Int { val: v1 }, Value::Int { val: v2 }) => {
-                    Ok(Value::Int { val: v1 - v2 })
-                }
-                (BinOp::Mul, Value::Int { val: v1 }, Value::Int { val: v2 }) => {
-                    Ok(Value::Int { val: v1 * v2 })
-                }
-                (BinOp::Div, Value::Int { val: v1 }, Value::Int { val: v2 }) => {
-                    // NOTE: Division by zero and division overflow (i32::MIN / -1) are the only
-                    // integer arithmetic operations that panic in Rust release mode.
-                    // If a modulo (%) operator is ever implemented in the future, it must
-                    // also include these identical bounds checks (x % 0 and i32::MIN % -1)
-                    // to prevent panics.
-                    let val = v1.checked_div(v2).ok_or_else(|| {
-                        EvalError::RuntimeError(if v2 == 0 {
-                            "Division by zero".to_string()
-                        } else {
-                            "Integer overflow".to_string()
-                        })
-                    })?;
-                    Ok(Value::Int { val })
-                }
-                (BinOp::Eq, Value::Int { val: v1 }, Value::Int { val: v2 }) => {
-                    Ok(Value::Bool { val: v1 == v2 })
-                }
-                (BinOp::Lt, Value::Int { val: v1 }, Value::Int { val: v2 }) => {
-                    Ok(Value::Bool { val: v1 < v2 })
-                }
-                (BinOp::Gt, Value::Int { val: v1 }, Value::Int { val: v2 }) => {
-                    Ok(Value::Bool { val: v1 > v2 })
-                }
-                (BinOp::And, Value::Bool { val: v1 }, Value::Bool { val: v2 }) => {
-                    Ok(Value::Bool { val: v1 && v2 })
-                }
-                (BinOp::Or, Value::Bool { val: v1 }, Value::Bool { val: v2 }) => {
-                    Ok(Value::Bool { val: v1 || v2 })
-                }
-                _ => Err(EvalError::TypeError(
-                    "Type error in binary operation".to_string(),
-                )),
             }
         }
 
@@ -266,6 +270,25 @@ pub async fn eval(
         | Expr::Select { .. }
         | Expr::Table { .. }
         | Expr::Fold { .. } => Err(EvalError::NotImplemented),
+        Expr::List(exprs) => {
+            let mut vals = Vec::new();
+            for expr in exprs {
+                vals.push(eval(expr, env, ctx).await?);
+            }
+            Ok(Value::List { vals })
+        }
+        Expr::Range { start, end } => {
+            let start_val = eval(start, env, ctx).await?;
+            let end_val = eval(end, env, ctx).await?;
+            match (start_val, end_val) {
+                (Value::Int { val: s }, Value::Int { val: e }) => {
+                    Ok(Value::Range { start: s, end: e })
+                }
+                _ => Err(EvalError::TypeError(
+                    "Range bounds must evaluate to integers".to_string(),
+                )),
+            }
+        }
     }
 }
 
@@ -460,5 +483,79 @@ mod tests {
             Err(EvalError::RuntimeError(ref s)) => assert_eq!(s, "Integer overflow"),
             other => panic!("Expected Err(EvalError::RuntimeError), got {:?}", other),
         }
+    }
+
+    #[tokio::test]
+    async fn test_list_and_range_evaluation() {
+        let mut manager = Manager::new(Interner::new());
+        let mut ctx = EvalContext {
+            manager: &mut manager,
+            service_name: Symbol::empty(),
+            txn: None,
+        };
+
+        // Test list literal [1, 2, 3]
+        let list_expr = Expr::List(vec![
+            Expr::Literal { val: Value::Int { val: 1 } },
+            Expr::Literal { val: Value::Int { val: 2 } },
+            Expr::Literal { val: Value::Int { val: 3 } },
+        ]);
+        let list_val = eval(&list_expr, &[], &mut ctx).await.unwrap();
+        assert_eq!(
+            list_val,
+            Value::List {
+                vals: vec![
+                    Value::Int { val: 1 },
+                    Value::Int { val: 2 },
+                    Value::Int { val: 3 },
+                ]
+            }
+        );
+
+        // Test range literal 0..3
+        let range_expr = Expr::Range {
+            start: Box::new(Expr::Literal { val: Value::Int { val: 0 } }),
+            end: Box::new(Expr::Literal { val: Value::Int { val: 3 } }),
+        };
+        let range_val = eval(&range_expr, &[], &mut ctx).await.unwrap();
+        assert_eq!(range_val, Value::Range { start: 0, end: 3 });
+
+        // Test range evaluates to list elements correctly
+        let elements = range_val.to_list_elements().unwrap();
+        assert_eq!(
+            elements,
+            vec![
+                Value::Int { val: 0 },
+                Value::Int { val: 1 },
+                Value::Int { val: 2 },
+            ]
+        );
+
+        // Test equality between list and range
+        let eq_expr = Expr::Binop {
+            op: BinOp::Eq,
+            expr1: Box::new(list_expr),
+            expr2: Box::new(range_expr),
+        };
+        let eq_val = eval(&eq_expr, &[], &mut ctx).await.unwrap();
+        assert_eq!(eq_val, Value::Bool { val: false });
+
+        // Test equality between range 1..4 and list [1, 2, 3]
+        let range_expr_2 = Expr::Range {
+            start: Box::new(Expr::Literal { val: Value::Int { val: 1 } }),
+            end: Box::new(Expr::Literal { val: Value::Int { val: 4 } }),
+        };
+        let list_expr_2 = Expr::List(vec![
+            Expr::Literal { val: Value::Int { val: 1 } },
+            Expr::Literal { val: Value::Int { val: 2 } },
+            Expr::Literal { val: Value::Int { val: 3 } },
+        ]);
+        let eq_expr_2 = Expr::Binop {
+            op: BinOp::Eq,
+            expr1: Box::new(list_expr_2),
+            expr2: Box::new(range_expr_2),
+        };
+        let eq_val_2 = eval(&eq_expr_2, &[], &mut ctx).await.unwrap();
+        assert_eq!(eq_val_2, Value::Bool { val: true });
     }
 }

--- a/meerkat-lib/src/runtime/interpreter/evaluator.rs
+++ b/meerkat-lib/src/runtime/interpreter/evaluator.rs
@@ -148,13 +148,20 @@ pub async fn eval(
                             val: s1 == s2 && e1 == e2,
                         });
                     }
-                    _ => {
+                    (
+                        Value::List { .. },
+                        Value::Range { .. },
+                    ) | (
+                        Value::Range { .. },
+                        Value::List { .. },
+                    ) => {
                         if let (Some(l1), Some(l2)) =
                             (val1.to_list_elements(), val2.to_list_elements())
                         {
                             return Ok(Value::Bool { val: l1 == l2 });
                         }
                     }
+                    _ => {}
                 }
             }
             match (op, val1, val2) {

--- a/meerkat-lib/src/runtime/interpreter/evaluator.rs
+++ b/meerkat-lib/src/runtime/interpreter/evaluator.rs
@@ -144,7 +144,9 @@ pub async fn eval(
                         return Ok(Value::Bool { val: v1 == v2 });
                     }
                     (Value::Range { start: s1, end: e1 }, Value::Range { start: s2, end: e2 }) => {
-                        return Ok(Value::Bool { val: s1 == s2 && e1 == e2 });
+                        return Ok(Value::Bool {
+                            val: s1 == s2 && e1 == e2,
+                        });
                     }
                     _ => {
                         if let (Some(l1), Some(l2)) =

--- a/meerkat-lib/src/runtime/interpreter/evaluator.rs
+++ b/meerkat-lib/src/runtime/interpreter/evaluator.rs
@@ -144,50 +144,50 @@ pub async fn eval(
                 }
             }
             match (op, val1, val2) {
-                    (BinOp::Add, Value::Int { val: v1 }, Value::Int { val: v2 }) => {
-                        Ok(Value::Int { val: v1 + v2 })
-                    }
-                    (BinOp::Sub, Value::Int { val: v1 }, Value::Int { val: v2 }) => {
-                        Ok(Value::Int { val: v1 - v2 })
-                    }
-                    (BinOp::Mul, Value::Int { val: v1 }, Value::Int { val: v2 }) => {
-                        Ok(Value::Int { val: v1 * v2 })
-                    }
-                    (BinOp::Div, Value::Int { val: v1 }, Value::Int { val: v2 }) => {
-                        // NOTE: Division by zero and division overflow (i32::MIN / -1) are the only
-                        // integer arithmetic operations that panic in Rust release mode.
-                        // If a modulo (%) operator is ever implemented in the future, it must
-                        // also include these identical bounds checks (x % 0 and i32::MIN % -1)
-                        // to prevent panics.
-                        let val = v1.checked_div(v2).ok_or_else(|| {
-                            EvalError::RuntimeError(if v2 == 0 {
-                                "Division by zero".to_string()
-                            } else {
-                                "Integer overflow".to_string()
-                            })
-                        })?;
-                        Ok(Value::Int { val })
-                    }
-                    (BinOp::Eq, Value::Int { val: v1 }, Value::Int { val: v2 }) => {
-                        Ok(Value::Bool { val: v1 == v2 })
-                    }
-                    (BinOp::Lt, Value::Int { val: v1 }, Value::Int { val: v2 }) => {
-                        Ok(Value::Bool { val: v1 < v2 })
-                    }
-                    (BinOp::Gt, Value::Int { val: v1 }, Value::Int { val: v2 }) => {
-                        Ok(Value::Bool { val: v1 > v2 })
-                    }
-                    (BinOp::And, Value::Bool { val: v1 }, Value::Bool { val: v2 }) => {
-                        Ok(Value::Bool { val: v1 && v2 })
-                    }
-                    (BinOp::Or, Value::Bool { val: v1 }, Value::Bool { val: v2 }) => {
-                        Ok(Value::Bool { val: v1 || v2 })
-                    }
-                    _ => Err(EvalError::TypeError(
-                        "Type error in binary operation".to_string(),
-                    )),
+                (BinOp::Add, Value::Int { val: v1 }, Value::Int { val: v2 }) => {
+                    Ok(Value::Int { val: v1 + v2 })
                 }
+                (BinOp::Sub, Value::Int { val: v1 }, Value::Int { val: v2 }) => {
+                    Ok(Value::Int { val: v1 - v2 })
+                }
+                (BinOp::Mul, Value::Int { val: v1 }, Value::Int { val: v2 }) => {
+                    Ok(Value::Int { val: v1 * v2 })
+                }
+                (BinOp::Div, Value::Int { val: v1 }, Value::Int { val: v2 }) => {
+                    // NOTE: Division by zero and division overflow (i32::MIN / -1) are the only
+                    // integer arithmetic operations that panic in Rust release mode.
+                    // If a modulo (%) operator is ever implemented in the future, it must
+                    // also include these identical bounds checks (x % 0 and i32::MIN % -1)
+                    // to prevent panics.
+                    let val = v1.checked_div(v2).ok_or_else(|| {
+                        EvalError::RuntimeError(if v2 == 0 {
+                            "Division by zero".to_string()
+                        } else {
+                            "Integer overflow".to_string()
+                        })
+                    })?;
+                    Ok(Value::Int { val })
+                }
+                (BinOp::Eq, Value::Int { val: v1 }, Value::Int { val: v2 }) => {
+                    Ok(Value::Bool { val: v1 == v2 })
+                }
+                (BinOp::Lt, Value::Int { val: v1 }, Value::Int { val: v2 }) => {
+                    Ok(Value::Bool { val: v1 < v2 })
+                }
+                (BinOp::Gt, Value::Int { val: v1 }, Value::Int { val: v2 }) => {
+                    Ok(Value::Bool { val: v1 > v2 })
+                }
+                (BinOp::And, Value::Bool { val: v1 }, Value::Bool { val: v2 }) => {
+                    Ok(Value::Bool { val: v1 && v2 })
+                }
+                (BinOp::Or, Value::Bool { val: v1 }, Value::Bool { val: v2 }) => {
+                    Ok(Value::Bool { val: v1 || v2 })
+                }
+                _ => Err(EvalError::TypeError(
+                    "Type error in binary operation".to_string(),
+                )),
             }
+        }
 
         Expr::Unop { op, expr } => {
             let val = eval(expr, env, ctx).await?;
@@ -527,9 +527,15 @@ mod tests {
 
         // Test list literal [1, 2, 3]
         let list_expr = Expr::List(vec![
-            Expr::Literal { val: Value::Int { val: 1 } },
-            Expr::Literal { val: Value::Int { val: 2 } },
-            Expr::Literal { val: Value::Int { val: 3 } },
+            Expr::Literal {
+                val: Value::Int { val: 1 },
+            },
+            Expr::Literal {
+                val: Value::Int { val: 2 },
+            },
+            Expr::Literal {
+                val: Value::Int { val: 3 },
+            },
         ]);
         let list_val = eval(&list_expr, &[], &mut ctx).await.unwrap();
         assert_eq!(
@@ -545,8 +551,12 @@ mod tests {
 
         // Test range literal 0..3
         let range_expr = Expr::Range {
-            start: Box::new(Expr::Literal { val: Value::Int { val: 0 } }),
-            end: Box::new(Expr::Literal { val: Value::Int { val: 3 } }),
+            start: Box::new(Expr::Literal {
+                val: Value::Int { val: 0 },
+            }),
+            end: Box::new(Expr::Literal {
+                val: Value::Int { val: 3 },
+            }),
         };
         let range_val = eval(&range_expr, &[], &mut ctx).await.unwrap();
         assert_eq!(range_val, Value::Range { start: 0, end: 3 });
@@ -573,13 +583,23 @@ mod tests {
 
         // Test equality between range 1..4 and list [1, 2, 3]
         let range_expr_2 = Expr::Range {
-            start: Box::new(Expr::Literal { val: Value::Int { val: 1 } }),
-            end: Box::new(Expr::Literal { val: Value::Int { val: 4 } }),
+            start: Box::new(Expr::Literal {
+                val: Value::Int { val: 1 },
+            }),
+            end: Box::new(Expr::Literal {
+                val: Value::Int { val: 4 },
+            }),
         };
         let list_expr_2 = Expr::List(vec![
-            Expr::Literal { val: Value::Int { val: 1 } },
-            Expr::Literal { val: Value::Int { val: 2 } },
-            Expr::Literal { val: Value::Int { val: 3 } },
+            Expr::Literal {
+                val: Value::Int { val: 1 },
+            },
+            Expr::Literal {
+                val: Value::Int { val: 2 },
+            },
+            Expr::Literal {
+                val: Value::Int { val: 3 },
+            },
         ]);
         let eq_expr_2 = Expr::Binop {
             op: BinOp::Eq,

--- a/meerkat-lib/src/runtime/interpreter/evaluator.rs
+++ b/meerkat-lib/src/runtime/interpreter/evaluator.rs
@@ -139,8 +139,20 @@ pub async fn eval(
             let val1 = eval(expr1, env, ctx).await?;
             let val2 = eval(expr2, env, ctx).await?;
             if *op == BinOp::Eq {
-                if let (Some(l1), Some(l2)) = (val1.to_list_elements(), val2.to_list_elements()) {
-                    return Ok(Value::Bool { val: l1 == l2 });
+                match (&val1, &val2) {
+                    (Value::List { vals: v1 }, Value::List { vals: v2 }) => {
+                        return Ok(Value::Bool { val: v1 == v2 });
+                    }
+                    (Value::Range { start: s1, end: e1 }, Value::Range { start: s2, end: e2 }) => {
+                        return Ok(Value::Bool { val: s1 == s2 && e1 == e2 });
+                    }
+                    _ => {
+                        if let (Some(l1), Some(l2)) =
+                            (val1.to_list_elements(), val2.to_list_elements())
+                        {
+                            return Ok(Value::Bool { val: l1 == l2 });
+                        }
+                    }
                 }
             }
             match (op, val1, val2) {

--- a/meerkat-lib/src/runtime/interpreter/evaluator.rs
+++ b/meerkat-lib/src/runtime/interpreter/evaluator.rs
@@ -138,10 +138,12 @@ pub async fn eval(
         Expr::Binop { op, expr1, expr2 } => {
             let val1 = eval(expr1, env, ctx).await?;
             let val2 = eval(expr2, env, ctx).await?;
-            if let (BinOp::Eq, Some(l1), Some(l2)) = (op, val1.to_list_elements(), val2.to_list_elements()) {
-                Ok(Value::Bool { val: l1 == l2 })
-            } else {
-                match (op, val1, val2) {
+            if *op == BinOp::Eq {
+                if let (Some(l1), Some(l2)) = (val1.to_list_elements(), val2.to_list_elements()) {
+                    return Ok(Value::Bool { val: l1 == l2 });
+                }
+            }
+            match (op, val1, val2) {
                     (BinOp::Add, Value::Int { val: v1 }, Value::Int { val: v2 }) => {
                         Ok(Value::Int { val: v1 + v2 })
                     }
@@ -186,7 +188,6 @@ pub async fn eval(
                     )),
                 }
             }
-        }
 
         Expr::Unop { op, expr } => {
             let val = eval(expr, env, ctx).await?;

--- a/meerkat-lib/src/runtime/interpreter/executor.rs
+++ b/meerkat-lib/src/runtime/interpreter/executor.rs
@@ -108,7 +108,9 @@ pub async fn execute(
                 Value::Int { .. }
                 | Value::String { .. }
                 | Value::Closure { .. }
-                | Value::ActionClosure { .. } => {
+                | Value::ActionClosure { .. }
+                | Value::List { .. }
+                | Value::Range { .. } => {
                     Err(EvalError::TypeError("assert expects a boolean".to_string()))
                 }
             }
@@ -140,6 +142,34 @@ pub async fn execute(
             Ok(ExecuteEffect::ExprValue(val))
         }
         ActionStmt::Insert { .. } => Err(EvalError::NotImplemented),
+        ActionStmt::For { var, range, body } => {
+            let range_val = eval(
+                range,
+                env,
+                &mut EvalContext {
+                    manager,
+                    service_name,
+                    txn: txn.as_deref_mut(),
+                },
+            )
+            .await?;
+            let elements = range_val.to_list_elements().ok_or_else(|| {
+                EvalError::TypeError("for loop range must be a list or range".to_string())
+            })?;
+            for elem in elements {
+                let mut loop_env = env.to_vec();
+                loop_env.push((*var, elem));
+                for s in body {
+                    if let ExecuteEffect::Binding(name, val) =
+                        execute(s, &loop_env, manager, service_name, txn.as_deref_mut())
+                            .await?
+                    {
+                        loop_env.push((name, val));
+                    }
+                }
+            }
+            Ok(ExecuteEffect::None)
+        }
     }
 }
 

--- a/meerkat-lib/src/runtime/interpreter/executor.rs
+++ b/meerkat-lib/src/runtime/interpreter/executor.rs
@@ -143,7 +143,11 @@ pub async fn execute(
             Ok(ExecuteEffect::ExprValue(val))
         }
         ActionStmt::Insert { .. } => Err(EvalError::NotImplemented),
-        ActionStmt::For { var, iterable, body } => {
+        ActionStmt::For {
+            var,
+            iterable,
+            body,
+        } => {
             let iterable_val = eval(
                 iterable,
                 env,

--- a/meerkat-lib/src/runtime/interpreter/executor.rs
+++ b/meerkat-lib/src/runtime/interpreter/executor.rs
@@ -143,9 +143,9 @@ pub async fn execute(
             Ok(ExecuteEffect::ExprValue(val))
         }
         ActionStmt::Insert { .. } => Err(EvalError::NotImplemented),
-        ActionStmt::For { var, range, body } => {
-            let range_val = eval(
-                range,
+        ActionStmt::For { var, iterable, body } => {
+            let iterable_val = eval(
+                iterable,
                 env,
                 &mut EvalContext {
                     manager,
@@ -154,11 +154,21 @@ pub async fn execute(
                 },
             )
             .await?;
-            let elements = range_val.to_list_elements().ok_or_else(|| {
-                EvalError::TypeError("for loop range must be a list or range".to_string())
-            })?;
+            let elements: Box<dyn Iterator<Item = Value> + Send> = match iterable_val {
+                Value::List { vals } => Box::new(vals.into_iter()),
+                Value::Range { start, end } => {
+                    Box::new((start..end).map(|v| Value::Int { val: v }))
+                }
+                _ => {
+                    return Err(EvalError::TypeError(
+                        "for loop iterable must be a list or range".to_string(),
+                    ))
+                }
+            };
+            let mut loop_env = env.to_vec();
+            let base_len = loop_env.len();
             for elem in elements {
-                let mut loop_env = env.to_vec();
+                loop_env.truncate(base_len);
                 loop_env.push((*var, elem));
                 for s in body {
                     if let ExecuteEffect::Binding(name, val) =

--- a/meerkat-lib/src/runtime/interpreter/executor.rs
+++ b/meerkat-lib/src/runtime/interpreter/executor.rs
@@ -162,8 +162,7 @@ pub async fn execute(
                 loop_env.push((*var, elem));
                 for s in body {
                     if let ExecuteEffect::Binding(name, val) =
-                        execute(s, &loop_env, manager, service_name, txn.as_deref_mut())
-                            .await?
+                        execute(s, &loop_env, manager, service_name, txn.as_deref_mut()).await?
                     {
                         loop_env.push((name, val));
                     }

--- a/meerkat-lib/src/runtime/parser/lex.rs
+++ b/meerkat-lib/src/runtime/parser/lex.rs
@@ -192,6 +192,14 @@ pub enum Token<'a> {
     UNIT_KW,
     #[token("watch")]
     WATCH_KW,
+    #[token("list")]
+    LIST_KW,
+    #[token("for")]
+    FOR_KW,
+    #[token("in")]
+    IN_KW,
+    #[token("..")]
+    DotDot,
 
     #[regex(r"\s*", logos::skip)]
     #[regex(r#"(//)[^\n]*"#, logos::skip)] // Regex for a single line comment

--- a/meerkat-lib/src/runtime/parser/meerkat.lalrpop
+++ b/meerkat-lib/src/runtime/parser/meerkat.lalrpop
@@ -127,7 +127,7 @@ ActionStmt: ActionStmt = {
     },
     <i:Ident> "=" <e:Expr> ";" => ActionStmt::Assign { name: i, expr: e },
     "for" <i:Ident> "in" <e:Expr> "{" <stmts: ActionStmts> "}" => {
-        ActionStmt::For { var: i, range: e, body: stmts }
+        ActionStmt::For { var: i, iterable: e, body: stmts }
     },
     <e:Expr> ";" => ActionStmt::Expr(e),
 }

--- a/meerkat-lib/src/runtime/parser/meerkat.lalrpop
+++ b/meerkat-lib/src/runtime/parser/meerkat.lalrpop
@@ -42,6 +42,10 @@ extern {
         "unit" => Token::UNIT_KW,
         "let" => Token::LET_KW,
         "watch" => Token::WATCH_KW,
+        "list" => Token::LIST_KW,
+        "for" => Token::FOR_KW,
+        "in" => Token::IN_KW,
+        ".." => Token::DotDot,
         ";" => Token::Semicolon,
         "." => Token::Dot,
         "=" => Token::Assgn,
@@ -121,6 +125,9 @@ ActionStmt: ActionStmt = {
         ActionStmt::Insert {row: e, table_name: t}
     },
     <i:Ident> "=" <e:Expr> ";" => ActionStmt::Assign { name: i, expr: e },
+    "for" <i:Ident> "in" <e:Expr> "{" <stmts: ActionStmts> "}" => {
+        ActionStmt::For { var: i, range: e, body: stmts }
+    },
     <e:Expr> ";" => ActionStmt::Expr(e),
 }
 
@@ -170,6 +177,7 @@ SimpleType: Type = {
     "string" => Type::String,
     "bool" => Type::Bool,
     "unit" => Type::Unit,
+    <t:SimpleType> "list" => Type::List(Box::new(t)),
     "(" <t:Type> <mut ts:("," <Type>)*> ")" =>? {
         if ts.is_empty() {
             Ok(t)
@@ -221,6 +229,7 @@ SubExpr: Expr = {
     <s: "strlit"> => Expr::Literal { val: Value::String { val: s.to_owned() } },
     <i:Ident> => Expr::Variable { name: i },
     "{" <args: Args> "}" => Expr::Tuple {val: args},
+    "[" <args: Args> "]" => Expr::List(args),
     "(" <Expr> ")" => <>,
     
     <expr:SubExpr> "(" <args:Args> ")" => 
@@ -280,6 +289,14 @@ Expr: Expr = {
     },
 
     #[precedence(level="4")] #[assoc(side="left")]
+    <e1:Expr> ".." <e2:Expr> => {
+        Expr::Range {
+            start: Box::new(e1),
+            end: Box::new(e2),
+        }
+    },
+
+    #[precedence(level="5")] #[assoc(side="left")]
     <e1:Expr> "==" <e2:Expr> => {
         Expr::Binop { 
             expr1: Box::new(e1), 
@@ -302,7 +319,7 @@ Expr: Expr = {
         }
     },
 
-    #[precedence(level="5")] #[assoc(side="left")]
+    #[precedence(level="6")] #[assoc(side="left")]
     <e1:Expr> "&&" <e2:Expr> => {
         Expr::Binop { 
             expr1: Box::new(e1), 
@@ -311,7 +328,7 @@ Expr: Expr = {
         }
     },
 
-    #[precedence(level="6")] #[assoc(side="left")]
+    #[precedence(level="7")] #[assoc(side="left")]
     <e1:Expr> "||" <e2:Expr> => {
         Expr::Binop { 
             expr1: Box::new(e1), 
@@ -320,7 +337,7 @@ Expr: Expr = {
         }
     },
 
-    #[precedence(level="7")] #[assoc(side="left")]
+    #[precedence(level="8")] #[assoc(side="left")]
     "if" <e1:Expr> "then" <e2:Expr> "else" <e3:Expr> => {
         Expr::If { 
             cond: Box::new(e1),
@@ -329,7 +346,7 @@ Expr: Expr = {
         }    
     },
 
-    #[precedence(level="8")] #[assoc(side="left")]
+    #[precedence(level="9")] #[assoc(side="left")]
     "fn" <params:Params> "=>" <e:Expr> => {
         // The `return_ty` is set to `None` here because return types
         // are inferred by a later pass instead of being parsed

--- a/meerkat-lib/src/runtime/semantic_analysis/var_analysis/alpha_rename.rs
+++ b/meerkat-lib/src/runtime/semantic_analysis/var_analysis/alpha_rename.rs
@@ -77,6 +77,15 @@ impl Expr {
                 operation.alpha_rename(var_binded, renames);
                 identity.alpha_rename(var_binded, renames);
             }
+            Expr::List(val) => {
+                for item in val {
+                    item.alpha_rename(var_binded, renames);
+                }
+            }
+            Expr::Range { start, end } => {
+                start.alpha_rename(var_binded, renames);
+                end.alpha_rename(var_binded, renames);
+            }
         }
     }
 }

--- a/meerkat-lib/src/runtime/semantic_analysis/var_analysis/read_write.rs
+++ b/meerkat-lib/src/runtime/semantic_analysis/var_analysis/read_write.rs
@@ -156,8 +156,12 @@ impl Expr {
             }
             Expr::Action(stmts) => {
                 let mut free_vars = HashSet::new();
+                let mut action_binds = var_binded.clone();
                 for stmt in stmts {
-                    free_vars.extend(free_vars_in_action_stmt(stmt, reactive_names, var_binded));
+                    let (stmt_free_vars, new_binds) =
+                        free_vars_in_action_stmt(stmt, reactive_names, &action_binds);
+                    free_vars.extend(stmt_free_vars);
+                    action_binds = new_binds;
                 }
                 free_vars.difference(reactive_names).cloned().collect()
             }
@@ -204,8 +208,8 @@ fn free_vars_in_action_stmt(
     stmt: &ActionStmt,
     reactive_names: &HashSet<Symbol>,
     var_binded: &HashSet<Symbol>,
-) -> HashSet<Symbol> {
-    match stmt {
+) -> (HashSet<Symbol>, HashSet<Symbol>) {
+    let free_vars = match stmt {
         ActionStmt::Assign { expr, .. } => expr.free_var(reactive_names, var_binded),
         ActionStmt::Do(expr) => expr.free_var(reactive_names, var_binded),
         ActionStmt::Assert(expr, _) => expr.free_var(reactive_names, var_binded),
@@ -221,11 +225,21 @@ fn free_vars_in_action_stmt(
             let mut body_binds = var_binded.clone();
             body_binds.insert(*var);
             for s in body {
-                free_vars.extend(free_vars_in_action_stmt(s, reactive_names, &body_binds));
+                let (stmt_free_vars, new_binds) =
+                    free_vars_in_action_stmt(s, reactive_names, &body_binds);
+                free_vars.extend(stmt_free_vars);
+                body_binds = new_binds;
             }
             free_vars
         }
+    };
+
+    let mut new_binds = var_binded.clone();
+    if let ActionStmt::Let { name, .. } = stmt {
+        new_binds.insert(*name);
     }
+
+    (free_vars, new_binds)
 }
 
 fn cross_service_deps_in_action_stmt(stmt: &ActionStmt) -> HashSet<(Symbol, Symbol)> {

--- a/meerkat-lib/src/runtime/semantic_analysis/var_analysis/read_write.rs
+++ b/meerkat-lib/src/runtime/semantic_analysis/var_analysis/read_write.rs
@@ -212,7 +212,11 @@ fn free_vars_in_action_stmt(
         ActionStmt::Let { expr, .. } => expr.free_var(reactive_names, var_binded),
         ActionStmt::Expr(expr) => expr.free_var(reactive_names, var_binded),
         ActionStmt::Insert { row, .. } => row.free_var(reactive_names, var_binded),
-        ActionStmt::For { var, iterable, body } => {
+        ActionStmt::For {
+            var,
+            iterable,
+            body,
+        } => {
             let mut free_vars = iterable.free_var(reactive_names, var_binded);
             let mut body_binds = var_binded.clone();
             body_binds.insert(*var);

--- a/meerkat-lib/src/runtime/semantic_analysis/var_analysis/read_write.rs
+++ b/meerkat-lib/src/runtime/semantic_analysis/var_analysis/read_write.rs
@@ -212,8 +212,8 @@ fn free_vars_in_action_stmt(
         ActionStmt::Let { expr, .. } => expr.free_var(reactive_names, var_binded),
         ActionStmt::Expr(expr) => expr.free_var(reactive_names, var_binded),
         ActionStmt::Insert { row, .. } => row.free_var(reactive_names, var_binded),
-        ActionStmt::For { var, range, body } => {
-            let mut free_vars = range.free_var(reactive_names, var_binded);
+        ActionStmt::For { var, iterable, body } => {
+            let mut free_vars = iterable.free_var(reactive_names, var_binded);
             let mut body_binds = var_binded.clone();
             body_binds.insert(*var);
             for s in body {
@@ -232,8 +232,8 @@ fn cross_service_deps_in_action_stmt(stmt: &ActionStmt) -> HashSet<(Symbol, Symb
         ActionStmt::Assert(expr, _) => expr.cross_service_deps(),
         ActionStmt::Assign { expr, .. } => expr.cross_service_deps(),
         ActionStmt::Insert { row, .. } => row.cross_service_deps(),
-        ActionStmt::For { range, body, .. } => {
-            let mut deps = range.cross_service_deps();
+        ActionStmt::For { iterable, body, .. } => {
+            let mut deps = iterable.cross_service_deps();
             for s in body {
                 deps.extend(cross_service_deps_in_action_stmt(s));
             }

--- a/meerkat-lib/src/runtime/semantic_analysis/var_analysis/read_write.rs
+++ b/meerkat-lib/src/runtime/semantic_analysis/var_analysis/read_write.rs
@@ -68,30 +68,7 @@ impl Expr {
             Expr::Action(stmts) => {
                 let mut free_vars = HashSet::new();
                 for stmt in stmts {
-                    match stmt {
-                        ActionStmt::Assign { name: _, expr } => {
-                            free_vars.extend(expr.free_var(reactive_names, var_binded));
-                        }
-                        ActionStmt::Do(expr) => {
-                            free_vars.extend(expr.free_var(reactive_names, var_binded));
-                        }
-                        ActionStmt::Assert(expr, _) => {
-                            free_vars.extend(expr.free_var(reactive_names, var_binded));
-                        }
-                        ActionStmt::Let {
-                            name: _,
-                            ty: _,
-                            expr,
-                        } => {
-                            free_vars.extend(expr.free_var(reactive_names, var_binded));
-                        }
-                        ActionStmt::Expr(expr) => {
-                            free_vars.extend(expr.free_var(reactive_names, var_binded));
-                        }
-                        ActionStmt::Insert { row, .. } => {
-                            free_vars.extend(row.free_var(reactive_names, var_binded));
-                        }
-                    }
+                    free_vars.extend(free_vars_in_action_stmt(stmt, reactive_names, var_binded));
                 }
                 free_vars.difference(reactive_names).cloned().collect()
             }
@@ -118,6 +95,42 @@ impl Expr {
                 free_vars.extend(identity.free_var(reactive_names, var_binded));
                 free_vars
             }
+            Expr::List(val) => {
+                let mut free_vars = HashSet::new();
+                for item in val {
+                    free_vars.extend(item.free_var(reactive_names, var_binded));
+                }
+                free_vars
+            }
+            Expr::Range { start, end } => {
+                let mut free_vars = start.free_var(reactive_names, var_binded);
+                free_vars.extend(end.free_var(reactive_names, var_binded));
+                free_vars
+            }
+        }
+    }
+}
+
+fn free_vars_in_action_stmt(
+    stmt: &ActionStmt,
+    reactive_names: &HashSet<Symbol>,
+    var_binded: &HashSet<Symbol>,
+) -> HashSet<Symbol> {
+    match stmt {
+        ActionStmt::Assign { expr, .. } => expr.free_var(reactive_names, var_binded),
+        ActionStmt::Do(expr) => expr.free_var(reactive_names, var_binded),
+        ActionStmt::Assert(expr, _) => expr.free_var(reactive_names, var_binded),
+        ActionStmt::Let { expr, .. } => expr.free_var(reactive_names, var_binded),
+        ActionStmt::Expr(expr) => expr.free_var(reactive_names, var_binded),
+        ActionStmt::Insert { row, .. } => row.free_var(reactive_names, var_binded),
+        ActionStmt::For { var, range, body } => {
+            let mut free_vars = range.free_var(reactive_names, var_binded);
+            let mut body_binds = var_binded.clone();
+            body_binds.insert(*var);
+            for s in body {
+                free_vars.extend(free_vars_in_action_stmt(s, reactive_names, &body_binds));
+            }
+            free_vars
         }
     }
 }

--- a/meerkat-lib/src/runtime/tt/types.rs
+++ b/meerkat-lib/src/runtime/tt/types.rs
@@ -17,6 +17,7 @@ pub enum Type {
     Unit,
     Tuple(TupleType),
     Func(Box<Type>, Box<Type>),
+    List(Box<Type>),
 }
 
 /// A tuple type wrapping a list of types of arity 2 or greater
@@ -110,9 +111,15 @@ impl std::fmt::Display for Type {
                         write!(f, "({}) -> {}", t1, t2)
                     }
                     Type::Unit => write!(f, "() -> {}", t2),
-                    Type::Int | Type::String | Type::Bool | Type::Tuple(_) => {
+                    Type::Int | Type::String | Type::Bool | Type::Tuple(_) | Type::List(_) => {
                         write!(f, "{} -> {}", t1, t2)
                     }
+                }
+            }
+            Type::List(t) => {
+                match t.as_ref() {
+                    Type::Func(..) => write!(f, "({}) list", t),
+                    _ => write!(f, "{} list", t),
                 }
             }
         }

--- a/meerkat-lib/src/runtime/tt/types.rs
+++ b/meerkat-lib/src/runtime/tt/types.rs
@@ -116,12 +116,10 @@ impl std::fmt::Display for Type {
                     }
                 }
             }
-            Type::List(t) => {
-                match t.as_ref() {
-                    Type::Func(..) => write!(f, "({}) list", t),
-                    _ => write!(f, "{} list", t),
-                }
-            }
+            Type::List(t) => match t.as_ref() {
+                Type::Func(..) => write!(f, "({}) list", t),
+                _ => write!(f, "{} list", t),
+            },
         }
     }
 }

--- a/meerkat/tests/test_lists.mkt
+++ b/meerkat/tests/test_lists.mkt
@@ -1,0 +1,19 @@
+service list_test {
+    var total = 0;
+}
+
+@test(list_test) {
+    // Test list literal
+    let xs = [1, 2, 3];
+    assert(xs == [1, 2, 3]);
+
+    // Test range literal
+    let r = 1..4;
+    assert(r == [1, 2, 3]);
+
+    // Test for loop summing elements
+    for i in 0..3 {
+        total = total + i;
+    }
+    assert(total == 3);  // 0 + 1 + 2
+}


### PR DESCRIPTION
Implemented the Benchmarking Support features from issue [#122](https://github.com/meerkat-lang/meerkat/issues/112)

**New Features**

- int list type, [1, 2, 3] list literals
- 1..5 integer range literals
- for x in expr { } loops

Tests: unit test in evaluator.rs + meerkat/tests/test_lists.mkt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added list literals (`[ ... ]`), range expressions (`start..end`), `for ... in ... { ... }` loops, and `list` types.
  * Extended equality (`==`) to compare lists and ranges, including range-to-list expansion.
  * Added pretty-printing for the new list/range/loop constructs.
  * Updated network AST serialization/codec to support the new forms.
* **Bug Fixes**
  * Strengthened `assert` to reject non-boolean values, including list and range inputs.
* **Tests**
  * Added coverage for list equality, range expansion, and `for` loop summation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->