### PR TITLE
Now with an option (-j) to enter interactive mode in a client

### DIFF
--- a/meerkat/src/main.rs
+++ b/meerkat/src/main.rs
@@ -48,6 +48,10 @@ struct Args {
     /// Emit AST to `stdout`
     #[arg(long = "ast", default_value_t = false)]
     ast: bool,
+
+    /// Launch interactive REPL after executing input file (default: false)
+    #[arg(short = 'j', long = "interactive", default_value_t = false)]
+    interactive: bool,
 }
 
 #[tokio::main]
@@ -103,7 +107,7 @@ pub async fn main() -> Result<(), Box<dyn Error>> {
             if args.server {
                 run_server(prog, remote_url_map, args.port, args.local, interner).await
             } else {
-                run_client(prog, file, remote_url_map, args.local, interner).await
+                run_client(prog, file, remote_url_map, args.local, interner, args.interactive).await
             }
         }
         None => {
@@ -535,6 +539,7 @@ async fn run_client(
     remote_url_map: std::collections::HashMap<String, String>,
     local: bool,
     interner: Interner,
+    interactive: bool,
 ) -> Result<(), Box<dyn Error>> {
     let mut manager = Manager::new(interner);
     manager.local = local;
@@ -635,5 +640,10 @@ async fn run_client(
         }
     }
 
-    Ok(())
+    if interactive {
+        println!("Entering interactive REPL mode. Type 'exit' or Ctrl+D to quit.");
+        repl::run_repl(manager, remote_url_map).await
+    } else {
+        Ok(())
+    }
 }

--- a/meerkat/tests/dist_s1_client.mkt
+++ b/meerkat/tests/dist_s1_client.mkt
@@ -10,5 +10,5 @@ service s1 {
 
 @test(s1) {
     do update_both;
-    assert(x == 1);
+    assert(x == 2);
 }


### PR DESCRIPTION
Updating with new developments

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an `--interactive` command-line option to control whether the interactive REPL opens after program execution.
  * Non-interactive runs now exit immediately after completing the input program.

* **Bug Fixes**
  * Updated test expectations to reflect the correct value produced by the `s1`/`s2` interaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->