### PR TITLE
feat: bidirectional type checking

### DIFF
--- a/meerkat-lib/src/net/codec.rs
+++ b/meerkat-lib/src/net/codec.rs
@@ -229,6 +229,9 @@ fn encode_type_internal(ty: &Type, depth: usize) -> Result<NetType> {
             let et = encode_type_internal(t, depth + 1)?;
             Ok(NetType::List(Box::new(et)))
         }
+        Type::UnresolvedService(_) => Err(Error::Message(
+            "Cannot serialize unresolved service type".to_string(),
+        )),
     }
 }
 

--- a/meerkat-lib/src/runtime/node.rs
+++ b/meerkat-lib/src/runtime/node.rs
@@ -10,7 +10,7 @@ use crate::error::{Error, Result};
 use crate::runtime::ast::Stmt;
 use crate::runtime::interner::Interner;
 use crate::runtime::tt::types::ServiceType;
-use crate::runtime::{nameres, Env, Manager};
+use crate::runtime::{nameres, tt, Env, Manager};
 
 /// Root manager for compiling and executing a Meerkat node
 pub struct Node<'a> {
@@ -48,7 +48,7 @@ impl<'a> Node<'a> {
     ///
     /// Returns:
     ///     `Result<()>`: Ok if checks pass, or an error
-    pub fn check(&self, program: &[Stmt]) -> Result<()> {
+    pub fn check(&mut self, program: &'a [Stmt]) -> Result<()> {
         nameres::resolve(program).map_err(|e| match e {
             nameres::Error::UnknownIdentifier {
                 name,
@@ -79,7 +79,10 @@ impl<'a> Node<'a> {
                 Error::Message(msg)
             }
             nameres::Error::DepthLimit => Error::Message(e.to_string()),
-        })
+        })?;
+
+        tt::check(program, &mut self.service_classes)
+            .map_err(|e| Error::Message(format!("Type check error: {}", e)))
     }
 
     /// Start the runtime manager consuming this Node

--- a/meerkat-lib/src/runtime/node.rs
+++ b/meerkat-lib/src/runtime/node.rs
@@ -15,7 +15,7 @@ use crate::runtime::{nameres, tt, Env, Manager};
 /// Root manager for compiling and executing a Meerkat node
 pub struct Node<'a> {
     /// Reserved for the `Node` migration documented in `Issue 106`
-    pub service_classes: Env<'a, ServiceType<'a>>,
+    pub local_services: Env<'a, ServiceType<'a>>,
     pub interner: Interner,
 }
 
@@ -23,7 +23,7 @@ impl<'a> Node<'a> {
     /// Create a new empty Node representing the process context
     pub fn new() -> Self {
         Node {
-            service_classes: Env::new(None),
+            local_services: Env::new(None),
             interner: Interner::new(),
         }
     }
@@ -81,7 +81,7 @@ impl<'a> Node<'a> {
             nameres::Error::DepthLimit => Error::Message(e.to_string()),
         })?;
 
-        tt::check(program, &mut self.service_classes)
+        tt::check(program, &mut self.local_services)
             .map_err(|e| Error::Message(format!("Type check error: {}", e)))
     }
 

--- a/meerkat-lib/src/runtime/tt/check.rs
+++ b/meerkat-lib/src/runtime/tt/check.rs
@@ -704,7 +704,7 @@ impl<'a, 'b> Context<'a, 'b> {
                     Ok(Type::Bool)
                 }
                 BinOp::Eq => {
-                    let ty1 = self.infer(expr1, env, 1)?;
+                    let ty1 = self.infer(expr1, env, type_depth)?;
                     self.check_expr(expr2, &ty1, env)?;
                     Ok(Type::Bool)
                 }
@@ -721,7 +721,7 @@ impl<'a, 'b> Context<'a, 'b> {
                 return_ty,
             } => self.infer_function_type(params, body, return_ty.as_ref(), env, type_depth),
             Expr::Call { func, args } => {
-                let func_ty = self.infer(func, env, 1)?;
+                let func_ty = self.infer(func, env, type_depth)?;
                 if let Type::Func(param_ty, ret_ty) = func_ty {
                     if args.is_empty() {
                         if *param_ty != Type::Unit {
@@ -817,7 +817,6 @@ impl<'a, 'b> Context<'a, 'b> {
         let mut param_types = Vec::new();
         for param in params {
             if let Some(p_ty) = &param.ty {
-                check_type(p_ty, 1)?;
                 local_env.bind(param.name, p_ty.clone());
                 param_types.push(p_ty.clone());
             } else {
@@ -832,8 +831,9 @@ impl<'a, 'b> Context<'a, 'b> {
             let tuple_ty = TupleType::new(param_types).map_err(|_| Error::InvalidTupleArity)?;
             Type::Tuple(tuple_ty)
         };
+        check_type(&p_ty, type_depth + 1)?;
         let r_ty = if let Some(annotated_ret) = return_ty {
-            check_type(annotated_ret, 1)?;
+            check_type(annotated_ret, type_depth + 1)?;
             self.check_expr(body, annotated_ret, &mut local_env)?;
             annotated_ret.clone()
         } else {
@@ -902,6 +902,8 @@ impl<'a, 'b> Context<'a, 'b> {
                             TupleType::new(param_types).map_err(|_| Error::InvalidTupleArity)?;
                         Type::Tuple(tuple_ty)
                     };
+                    check_type(&expected_param, type_depth + 1)?;
+                    check_type(ret_ty, type_depth + 1)?;
                     Ok(Type::Func(
                         Box::new(expected_param),
                         Box::new(ret_ty.clone()),

--- a/meerkat-lib/src/runtime/tt/check.rs
+++ b/meerkat-lib/src/runtime/tt/check.rs
@@ -199,7 +199,27 @@ impl<'a, 'b> Context<'a, 'b> {
                     let mut local_env = Env::new(None);
                     self.check_action_stmt(action, &mut local_env)?;
                 }
-                _ => {}
+                Stmt::Watch { expr } => {
+                    let mut local_env = Env::new(None);
+                    self.infer(expr, &mut local_env, 1)?;
+                }
+                Stmt::Update { .. } => {
+                    // TODO(Issue #156): Implement static checks
+                    // (deferred per Issue #34)
+                    println!(
+                        "warning: tt/check: ignoring 'update' \
+                         checks as not yet implemented"
+                    );
+                }
+                Stmt::Import { .. } => {
+                    // TODO(Issue #156): Implement static checks
+                    // (deferred per Issue #34)
+                    println!(
+                        "warning: tt/check: ignoring 'import' \
+                         checks as not yet implemented"
+                    );
+                }
+                Stmt::Connect { .. } | Stmt::Service { .. } => {}
             }
         }
 
@@ -217,6 +237,8 @@ impl<'a, 'b> Context<'a, 'b> {
     /// Raises:
     ///     Error::UnboundVariable: If service is not found
     fn find_service_decls(&self, service_name: Symbol) -> Result<&'a [Decl], Error> {
+        // TODO(Issue #156): Support looking up declarations
+        // from Stmt::Update (deferred per Issue #34)
         for stmt in self.program {
             if let Stmt::Service { name, decls } = stmt {
                 if *name == service_name {
@@ -321,7 +343,14 @@ impl<'a, 'b> Context<'a, 'b> {
                 Decl::VarDecl { name, .. } | Decl::DefDecl { name, .. } => {
                     self.type_of_member(service_name, *name)?;
                 }
-                Decl::TableDecl { .. } => {}
+                Decl::TableDecl { .. } => {
+                    // TODO(Issue #156): Implement Table type schema
+                    // validation (deferred per Issue #34)
+                    println!(
+                        "warning: tt/check: ignoring 'table' \
+                         schema checks as not yet implemented"
+                    );
+                }
             }
         }
         Ok(())
@@ -411,6 +440,12 @@ impl<'a, 'b> Context<'a, 'b> {
                 Ok(())
             }
             ActionStmt::Insert { row, .. } => {
+                // TODO(Issue #156): Validate inserted row against
+                // table schema (deferred per Issue #34)
+                println!(
+                    "warning: tt/check: ignoring 'insert' \
+                     checks as not yet implemented"
+                );
                 self.infer(row, env, 1)?;
                 Ok(())
             }
@@ -602,7 +637,19 @@ impl<'a, 'b> Context<'a, 'b> {
                     return_ty,
                     ..
                 } => self.infer_function_type(params, body, return_ty.as_ref(), env, type_depth),
-                _ => self.infer_value(val, type_depth),
+                Value::ActionClosure { stmts, .. } => {
+                    let mut action_env = Env::new(Some(env));
+                    for stmt in stmts {
+                        self.check_action_stmt(stmt, &mut action_env)?;
+                    }
+                    Ok(Type::Unit)
+                }
+                Value::Int { .. }
+                | Value::Bool { .. }
+                | Value::String { .. }
+                | Value::Html(..)
+                | Value::List { .. }
+                | Value::Range { .. } => self.infer_value(val, type_depth),
             },
             Expr::Html(_) => Ok(Type::String),
             Expr::Variable { name } => {
@@ -811,7 +858,7 @@ impl<'a, 'b> Context<'a, 'b> {
             Value::Int { .. } => Ok(Type::Int),
             Value::Bool { .. } => Ok(Type::Bool),
             Value::String { .. } => Ok(Type::String),
-            Value::Html { .. } => Ok(Type::String),
+            Value::Html(..) => Ok(Type::String),
             Value::List { vals } => {
                 if vals.is_empty() {
                     Err(Error::CannotInferType)
@@ -830,7 +877,39 @@ impl<'a, 'b> Context<'a, 'b> {
                 }
             }
             Value::Range { .. } => Ok(Type::List(Box::new(Type::Int))),
-            _ => Err(Error::CannotInferType),
+            Value::ActionClosure { .. } => Ok(Type::Unit),
+            Value::Closure {
+                params, return_ty, ..
+            } => {
+                if let Some(ret_ty) = return_ty {
+                    let mut param_types = Vec::new();
+                    for param in params {
+                        if let Some(param_ty) = &param.ty {
+                            param_types.push(param_ty.clone());
+                        } else {
+                            // If any parameter lacks type annotation,
+                            // we cannot statically infer the closure's
+                            // full type signature without an env.
+                            return Err(Error::CannotInferType);
+                        }
+                    }
+                    let expected_param = if param_types.is_empty() {
+                        Type::Unit
+                    } else if param_types.len() == 1 {
+                        param_types[0].clone()
+                    } else {
+                        let tuple_ty =
+                            TupleType::new(param_types).map_err(|_| Error::InvalidTupleArity)?;
+                        Type::Tuple(tuple_ty)
+                    };
+                    Ok(Type::Func(
+                        Box::new(expected_param),
+                        Box::new(ret_ty.clone()),
+                    ))
+                } else {
+                    Err(Error::CannotInferType)
+                }
+            }
         }
     }
 }

--- a/meerkat-lib/src/runtime/tt/check.rs
+++ b/meerkat-lib/src/runtime/tt/check.rs
@@ -66,7 +66,7 @@ fn check_type(ty: &Type, depth: usize) -> Result<(), Error> {
         return Err(Error::DepthLimitExceeded);
     }
     match ty {
-        Type::Int | Type::String | Type::Bool | Type::Unit => Ok(()),
+        Type::Int | Type::String | Type::Bool | Type::Unit | Type::UnresolvedService(_) => Ok(()),
         Type::Tuple(ts) => {
             for t in ts.iter() {
                 check_type(t, depth + 1)?;
@@ -296,7 +296,7 @@ impl<'a, 'b> Context<'a, 'b> {
                 "warning: tt/check: skipping member type check for \
                  imported service (type unknown at compile time)"
             );
-            return Ok(Type::Unit);
+            return Ok(Type::UnresolvedService(service_name));
         }
 
         let key = (service_name, member_name);
@@ -627,7 +627,13 @@ impl<'a, 'b> Context<'a, 'b> {
             }
             (e, t) => {
                 let inferred = self.infer(e, env, 1)?;
-                if inferred == *t {
+                // Structural equality bridge: if either the inferred type or
+                // the expected type is an UnresolvedService sentinel, we bypass
+                // the check, treating it as a dynamic/any type
+                if inferred == *t
+                    || matches!(inferred, Type::UnresolvedService(_))
+                    || matches!(t, Type::UnresolvedService(_))
+                {
                     Ok(())
                 } else {
                     Err(Error::TypeMismatch {
@@ -736,14 +742,7 @@ impl<'a, 'b> Context<'a, 'b> {
                 }
                 BinOp::Eq => {
                     let ty1 = self.infer(expr1, env, type_depth)?;
-                    // If the left side resolved to `Unit`, it is the sentinel
-                    // type used for imported service members whose concrete
-                    // types are not known at compile time. Skip checking the
-                    // right side to avoid false type errors cascading from
-                    // the import bypass
-                    if ty1 != Type::Unit {
-                        self.check_expr(expr2, &ty1, env)?;
-                    }
+                    self.check_expr(expr2, &ty1, env)?;
                     Ok(Type::Bool)
                 }
             },

--- a/meerkat-lib/src/runtime/tt/check.rs
+++ b/meerkat-lib/src/runtime/tt/check.rs
@@ -487,10 +487,18 @@ impl<'a, 'b> Context<'a, 'b> {
                 Expr::Func {
                     params,
                     body,
-                    return_ty: _,
+                    return_ty,
                 },
                 Type::Func(expected_param, expected_ret),
             ) => {
+                if let Some(ret_ty) = return_ty {
+                    if ret_ty != expected_ret.as_ref() {
+                        return Err(Error::TypeMismatch {
+                            expected: (**expected_ret).clone(),
+                            found: ret_ty.clone(),
+                        });
+                    }
+                }
                 let mut local_env = Env::new(Some(env));
                 if params.is_empty() {
                     if **expected_param != Type::Unit {
@@ -500,13 +508,29 @@ impl<'a, 'b> Context<'a, 'b> {
                         });
                     }
                 } else if params.len() == 1 {
+                    if let Some(param_ty) = &params[0].ty {
+                        if param_ty != expected_param.as_ref() {
+                            return Err(Error::TypeMismatch {
+                                expected: (**expected_param).clone(),
+                                found: param_ty.clone(),
+                            });
+                        }
+                    }
                     local_env.bind(params[0].name, (**expected_param).clone());
                 } else {
-                    if let Type::Tuple(ts) = &**expected_param {
+                    if let Type::Tuple(ts) = expected_param.as_ref() {
                         if params.len() != ts.len() {
                             return Err(Error::InvalidTupleArity);
                         }
                         for (i, param) in params.iter().enumerate() {
+                            if let Some(param_ty) = &param.ty {
+                                if param_ty != &ts[i] {
+                                    return Err(Error::TypeMismatch {
+                                        expected: ts[i].clone(),
+                                        found: param_ty.clone(),
+                                    });
+                                }
+                            }
                             local_env.bind(param.name, ts[i].clone());
                         }
                     } else {

--- a/meerkat-lib/src/runtime/tt/check.rs
+++ b/meerkat-lib/src/runtime/tt/check.rs
@@ -469,11 +469,11 @@ impl<'a, 'b> Context<'a, 'b> {
                 if val.is_empty() {
                     Ok(())
                 } else {
+                    let types = val.iter().map(|_| Type::Unit).collect();
+                    let tuple_ty = TupleType::new(types).map_err(|_| Error::InvalidTupleArity)?;
                     Err(Error::TypeMismatch {
                         expected: Type::Unit,
-                        found: Type::Tuple(
-                            TupleType::new(val.iter().map(|_| Type::Unit).collect()).unwrap(),
-                        ),
+                        found: Type::Tuple(tuple_ty),
                     })
                 }
             }
@@ -510,12 +510,12 @@ impl<'a, 'b> Context<'a, 'b> {
                             local_env.bind(param.name, ts[i].clone());
                         }
                     } else {
+                        let types = params.iter().map(|_| Type::Unit).collect();
+                        let tuple_ty =
+                            TupleType::new(types).map_err(|_| Error::InvalidTupleArity)?;
                         return Err(Error::TypeMismatch {
                             expected: (**expected_param).clone(),
-                            found: Type::Tuple(
-                                TupleType::new(params.iter().map(|_| Type::Unit).collect())
-                                    .unwrap(),
-                            ),
+                            found: Type::Tuple(tuple_ty),
                         });
                     }
                 }
@@ -616,7 +616,9 @@ impl<'a, 'b> Context<'a, 'b> {
                     } else if param_types.len() == 1 {
                         param_types[0].clone()
                     } else {
-                        Type::Tuple(TupleType::new(param_types).unwrap())
+                        let tuple_ty =
+                            TupleType::new(param_types).map_err(|_| Error::InvalidTupleArity)?;
+                        Type::Tuple(tuple_ty)
                     };
                     let r_ty = if let Some(annotated_ret) = return_ty {
                         check_type(annotated_ret, 1)?;
@@ -650,7 +652,8 @@ impl<'a, 'b> Context<'a, 'b> {
                     for elem in val {
                         types.push(self.infer(elem, env, type_depth + 1)?);
                     }
-                    Ok(Type::Tuple(TupleType::new(types).unwrap()))
+                    let tuple_ty = TupleType::new(types).map_err(|_| Error::InvalidTupleArity)?;
+                    Ok(Type::Tuple(tuple_ty))
                 }
             }
             Expr::KeyVal { value, .. } => self.infer(value, env, type_depth),
@@ -713,7 +716,9 @@ impl<'a, 'b> Context<'a, 'b> {
                 } else if param_types.len() == 1 {
                     param_types[0].clone()
                 } else {
-                    Type::Tuple(TupleType::new(param_types).unwrap())
+                    let tuple_ty =
+                        TupleType::new(param_types).map_err(|_| Error::InvalidTupleArity)?;
+                    Type::Tuple(tuple_ty)
                 };
                 let r_ty = if let Some(annotated_ret) = return_ty {
                     check_type(annotated_ret, 1)?;
@@ -745,12 +750,12 @@ impl<'a, 'b> Context<'a, 'b> {
                                 self.check_expr(arg, &ts[i], env)?;
                             }
                         } else {
+                            let types = args.iter().map(|_| Type::Unit).collect();
+                            let tuple_ty =
+                                TupleType::new(types).map_err(|_| Error::InvalidTupleArity)?;
                             return Err(Error::TypeMismatch {
                                 expected: *param_ty,
-                                found: Type::Tuple(
-                                    TupleType::new(args.iter().map(|_| Type::Unit).collect())
-                                        .unwrap(),
-                                ),
+                                found: Type::Tuple(tuple_ty),
                             });
                         }
                     }

--- a/meerkat-lib/src/runtime/tt/check.rs
+++ b/meerkat-lib/src/runtime/tt/check.rs
@@ -1,0 +1,838 @@
+//! Augmented bi-directional type checking.
+//!
+//! This module implements type validation and type inference by
+//! propagating expected types downward through expressions, or
+//! synthesizing types upward from sub-expressions.
+//!
+//! # High-Level Design
+//!
+//! The algorithm splits type validation into two mutually recursive
+//! procedures:
+//!
+//! - Checking mode (`check_expr`): Validates an expression against
+//!   a known expected type. Used for constructors (introduction
+//!   forms) like lambdas, lists, and tuples where pushing the
+//!   expected type down prevents ambiguity
+//! - Synthesis mode (`infer`): Computes the type of an expression
+//!   independently. Used for eliminators (destructors) like
+//!   function calls, operators, and literals
+//!
+//! # The Bridge Rule
+//!
+//! When checking an expression that naturally synthesizes its type
+//! (e.g., a function call or literal), the checker delegates to
+//! `infer` and asserts structural equality between the synthesized
+//! and expected types:
+//!
+//! `check(e, expected) = (infer(e) == expected)`
+//!
+//! # Augmented BDTC Relaxations
+//!
+//! Standard bidirectional typing is strictly polarized. We relax
+//! this rigidity in two ways:
+//!
+//! - Synthesizing Constructors: We allow inferring types of lists,
+//!   tuples, and annotated lambdas directly
+//! - Flexible Bindings: Type annotations on `let`, `var`, and `def`
+//!   can be omitted, falling back to `infer` on the right-hand side.
+//!   However, context-free unannotated closures (e.g. `fn x => x`)
+//!   will fail to infer; they require an annotation on either the
+//!   parameter or the binding to push expected types down
+//!
+//! # Security & Resource Bounds
+//!
+//! - Recursion depth limit: Enforces `limits::MAX_SCOPE_DEPTH`
+//! - Type structure depth limit: Enforces `limits::MAX_TYPE_DEPTH`
+
+use crate::runtime::ast::{ActionStmt, BinOp, Decl, Expr, Stmt, UnOp, Value};
+use crate::runtime::interner::Symbol;
+use crate::runtime::tt::types::{ServiceType, TupleType, Type};
+use crate::runtime::Env;
+
+/// Helper to calculate the nesting depth of a type representation
+///
+/// Args:
+///     ty (&Type): The type to evaluate
+///
+/// Returns:
+///     usize: The maximum nesting depth of the type structure
+fn type_depth(ty: &Type) -> usize {
+    match ty {
+        Type::Int | Type::String | Type::Bool | Type::Unit => 1,
+        Type::Tuple(ts) => {
+            let max_inner = ts.iter().map(type_depth).max().unwrap_or(0);
+            1 + max_inner
+        }
+        Type::Func(t1, t2) => 1 + std::cmp::max(type_depth(t1), type_depth(t2)),
+        Type::List(inner) => 1 + type_depth(inner),
+    }
+}
+
+/// Type checking errors in Meerkat
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Error {
+    UnboundVariable(Symbol),
+    TypeMismatch { expected: Type, found: Type },
+    CannotInferType,
+    DepthLimitExceeded,
+    InvalidTupleArity,
+    NotAFunction,
+}
+
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Error::UnboundVariable(s) => {
+                write!(f, "Unbound variable: {:?}", s)
+            }
+            Error::TypeMismatch { expected, found } => {
+                write!(f, "Type mismatch: expected {}, found {}", expected, found)
+            }
+            Error::CannotInferType => {
+                write!(f, "Cannot infer type")
+            }
+            Error::DepthLimitExceeded => {
+                write!(f, "Depth limit exceeded")
+            }
+            Error::InvalidTupleArity => {
+                write!(f, "Invalid tuple arity")
+            }
+            Error::NotAFunction => {
+                write!(f, "Not a function")
+            }
+        }
+    }
+}
+
+/// Type checking context containing environment and limits tracking
+pub struct Context<'a, 'b> {
+    depth: usize,
+    program: &'a [Stmt],
+    service_classes: &'b mut Env<'a, ServiceType<'a>>,
+    checking_stack: Vec<(Symbol, Symbol)>,
+    current_service: Option<Symbol>,
+}
+
+impl<'a, 'b> Context<'a, 'b> {
+    /// Create a new type checking context
+    ///
+    /// Args:
+    ///     program (&'a [Stmt]): Slices of parsed statements
+    ///     service_classes (&'b mut Env<'a, ServiceType<'a>>): Service classes
+    ///
+    /// Returns:
+    ///     Self: The Context instance
+    fn new(program: &'a [Stmt], service_classes: &'b mut Env<'a, ServiceType<'a>>) -> Self {
+        Self {
+            depth: 0,
+            program,
+            service_classes,
+            checking_stack: Vec::new(),
+            current_service: None,
+        }
+    }
+
+    /// Increment depth counter and check against the recursion limit
+    ///
+    /// Returns:
+    ///     Result<(), Error>: Ok if within bounds
+    ///
+    /// Raises:
+    ///     Error::DepthLimitExceeded: If scope depth limit is exceeded
+    fn inc_depth(&mut self) -> Result<(), Error> {
+        self.depth += 1;
+        if self.depth > crate::runtime::limits::MAX_SCOPE_DEPTH {
+            Err(Error::DepthLimitExceeded)
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Decrement depth counter
+    fn dec_depth(&mut self) {
+        if self.depth > 0 {
+            self.depth -= 1;
+        }
+    }
+
+    /// Execute type checking on all program statements
+    ///
+    /// Returns:
+    ///     Result<(), Error>: Ok on success
+    pub fn check_all(&mut self) -> Result<(), Error> {
+        for stmt in self.program {
+            if let Stmt::Service { name, .. } = stmt {
+                if self.service_classes.find(*name).is_none() {
+                    self.service_classes.bind(*name, ServiceType::default());
+                }
+            }
+        }
+
+        for stmt in self.program {
+            if let Stmt::Service { name, .. } = stmt {
+                self.check_service(*name)?;
+            }
+        }
+
+        for stmt in self.program {
+            match stmt {
+                Stmt::Test {
+                    service_name,
+                    stmts,
+                } => {
+                    self.check_test(*service_name, stmts)?;
+                }
+                Stmt::ActionStmt(action) => {
+                    let mut local_env = Env::new(None);
+                    self.check_action_stmt(action, &mut local_env)?;
+                }
+                _ => {}
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Find the declarations of a service in the program
+    ///
+    /// Args:
+    ///     service_name (Symbol): The service name symbol
+    ///
+    /// Returns:
+    ///     Result<&'a [Decl], Error>: Slice of declarations
+    ///
+    /// Raises:
+    ///     Error::UnboundVariable: If service is not found
+    fn find_service_decls(&self, service_name: Symbol) -> Result<&'a [Decl], Error> {
+        for stmt in self.program {
+            if let Stmt::Service { name, decls } = stmt {
+                if *name == service_name {
+                    return Ok(decls);
+                }
+            }
+        }
+        Err(Error::UnboundVariable(service_name))
+    }
+
+    /// Retrieve or compute the type of a service member on-demand
+    ///
+    /// Args:
+    ///     service_name (Symbol): The service name
+    ///     member_name (Symbol): The member field name
+    ///
+    /// Returns:
+    ///     Result<Type, Error>: The type of the member
+    ///
+    /// Raises:
+    ///     Error::CannotInferType: On cyclic dependencies
+    ///     Error::UnboundVariable: If member is not found
+    fn type_of_member(&mut self, service_name: Symbol, member_name: Symbol) -> Result<Type, Error> {
+        if let Some(st) = self.service_classes.find(service_name) {
+            if let Some(ty) = st.fields().find(member_name) {
+                return Ok(ty.clone());
+            }
+        }
+
+        let key = (service_name, member_name);
+        if self.checking_stack.contains(&key) {
+            return Err(Error::CannotInferType);
+        }
+        self.checking_stack.push(key);
+
+        let decls = self.find_service_decls(service_name)?;
+        let decl = decls
+            .iter()
+            .find(|d| match d {
+                Decl::VarDecl { name, .. } | Decl::DefDecl { name, .. } => *name == member_name,
+                Decl::TableDecl { name, .. } => *name == member_name,
+            })
+            .ok_or(Error::UnboundVariable(member_name))?;
+
+        let ty = match decl {
+            Decl::VarDecl {
+                ty: annotated, val, ..
+            }
+            | Decl::DefDecl {
+                ty: annotated, val, ..
+            } => {
+                let mut env = Env::new(None);
+                for prev in decls {
+                    match prev {
+                        Decl::VarDecl { name, .. } | Decl::DefDecl { name, .. } => {
+                            if *name == member_name {
+                                break;
+                            }
+                            let prev_ty = self.type_of_member(service_name, *name)?;
+                            env.bind(*name, prev_ty);
+                        }
+                        Decl::TableDecl { .. } => {}
+                    }
+                }
+
+                let prev_service = self.current_service;
+                self.current_service = Some(service_name);
+                let res = if let Some(expected) = annotated {
+                    if type_depth(expected) > crate::runtime::limits::MAX_TYPE_DEPTH {
+                        return Err(Error::DepthLimitExceeded);
+                    }
+                    self.check_expr(val, expected, &mut env)?;
+                    expected.clone()
+                } else {
+                    let inferred = self.infer(val, &mut env)?;
+                    if type_depth(&inferred) > crate::runtime::limits::MAX_TYPE_DEPTH {
+                        return Err(Error::DepthLimitExceeded);
+                    }
+                    inferred
+                };
+                self.current_service = prev_service;
+                res
+            }
+            Decl::TableDecl { .. } => Type::Unit,
+        };
+
+        self.checking_stack.pop();
+
+        if let Some(mut st) = self.service_classes.remove(service_name) {
+            let _ = st.add_field(member_name, ty.clone());
+            self.service_classes.bind(service_name, st);
+        }
+
+        Ok(ty)
+    }
+
+    /// Type check all declarations within a service
+    ///
+    /// Args:
+    ///     service_name (Symbol): The service name
+    ///
+    /// Returns:
+    ///     Result<(), Error>: Ok on success
+    fn check_service(&mut self, service_name: Symbol) -> Result<(), Error> {
+        let decls = self.find_service_decls(service_name)?;
+        for decl in decls {
+            match decl {
+                Decl::VarDecl { name, .. } | Decl::DefDecl { name, .. } => {
+                    self.type_of_member(service_name, *name)?;
+                }
+                Decl::TableDecl { .. } => {}
+            }
+        }
+        Ok(())
+    }
+
+    /// Type check a test block associated with a service
+    ///
+    /// Args:
+    ///     service_name (Symbol): The service name
+    ///     stmts (&[ActionStmt]): The action statements inside the test
+    ///
+    /// Returns:
+    ///     Result<(), Error>: Ok on success
+    fn check_test(&mut self, service_name: Symbol, stmts: &[ActionStmt]) -> Result<(), Error> {
+        let mut test_env = Env::new(None);
+        if let Some(st) = self.service_classes.find(service_name) {
+            for name in st.field_order() {
+                if let Some(ty) = st.fields().find(*name) {
+                    test_env.bind(*name, ty.clone());
+                }
+            }
+        }
+
+        let prev_service = self.current_service;
+        self.current_service = Some(service_name);
+        for stmt in stmts {
+            self.check_action_stmt(stmt, &mut test_env)?;
+        }
+        self.current_service = prev_service;
+        Ok(())
+    }
+
+    /// Type check an action statement
+    ///
+    /// Args:
+    ///     stmt (&ActionStmt): The action statement to check
+    ///     env (&mut Env<'_, Type>): The local types environment
+    ///
+    /// Returns:
+    ///     Result<(), Error>: Ok on success
+    fn check_action_stmt(
+        &mut self,
+        stmt: &ActionStmt,
+        env: &mut Env<'_, Type>,
+    ) -> Result<(), Error> {
+        self.inc_depth()?;
+        let res = match stmt {
+            ActionStmt::Let { name, ty, expr } => {
+                if let Some(expected) = ty {
+                    if type_depth(expected) > crate::runtime::limits::MAX_TYPE_DEPTH {
+                        return Err(Error::DepthLimitExceeded);
+                    }
+                    self.check_expr(expr, expected, env)?;
+                    env.bind(*name, expected.clone());
+                } else {
+                    let inferred = self.infer(expr, env)?;
+                    if type_depth(&inferred) > crate::runtime::limits::MAX_TYPE_DEPTH {
+                        return Err(Error::DepthLimitExceeded);
+                    }
+                    env.bind(*name, inferred);
+                }
+                Ok(())
+            }
+            ActionStmt::Expr(expr) => {
+                self.infer(expr, env)?;
+                Ok(())
+            }
+            ActionStmt::Do(expr) => {
+                self.infer(expr, env)?;
+                Ok(())
+            }
+            ActionStmt::Assert(expr, _) => {
+                self.check_expr(expr, &Type::Bool, env)?;
+                Ok(())
+            }
+            ActionStmt::Assign { name, expr } => {
+                let ty = if let Some(local_ty) = env.find(*name) {
+                    local_ty.clone()
+                } else if let Some(svc) = self.current_service {
+                    if let Some(st) = self.service_classes.find(svc) {
+                        st.fields()
+                            .find(*name)
+                            .ok_or(Error::UnboundVariable(*name))?
+                            .clone()
+                    } else {
+                        return Err(Error::UnboundVariable(*name));
+                    }
+                } else {
+                    return Err(Error::UnboundVariable(*name));
+                };
+                self.check_expr(expr, &ty, env)?;
+                Ok(())
+            }
+            ActionStmt::Insert { row, .. } => {
+                self.infer(row, env)?;
+                Ok(())
+            }
+            ActionStmt::For {
+                var,
+                iterable,
+                body,
+            } => {
+                let iter_ty = self.infer(iterable, env)?;
+                if let Type::List(elem_ty) = iter_ty {
+                    let mut for_env = Env::new(Some(env));
+                    for_env.bind(*var, (*elem_ty).clone());
+                    for b_stmt in body {
+                        self.check_action_stmt(b_stmt, &mut for_env)?;
+                    }
+                    Ok(())
+                } else {
+                    Err(Error::TypeMismatch {
+                        expected: Type::List(Box::new(Type::Unit)),
+                        found: iter_ty,
+                    })
+                }
+            }
+        };
+        self.dec_depth();
+        res
+    }
+
+    /// Type check an expression against an expected type
+    ///
+    /// Args:
+    ///     expr (&Expr): The expression to check
+    ///     expected (&Type): The expected type target
+    ///     env (&mut Env<'_, Type>): The local environment
+    ///
+    /// Returns:
+    ///     Result<(), Error>: Ok if expression checks successfully
+    fn check_expr(
+        &mut self,
+        expr: &Expr,
+        expected: &Type,
+        env: &mut Env<'_, Type>,
+    ) -> Result<(), Error> {
+        self.inc_depth()?;
+        let res = match (expr, expected) {
+            (Expr::Tuple { val }, Type::Tuple(tuple_ty)) => {
+                if val.len() != tuple_ty.len() {
+                    return Err(Error::InvalidTupleArity);
+                }
+                for (i, elem) in val.iter().enumerate() {
+                    self.check_expr(elem, &tuple_ty[i], env)?;
+                }
+                Ok(())
+            }
+            (Expr::Tuple { val }, Type::Unit) => {
+                if val.is_empty() {
+                    Ok(())
+                } else {
+                    Err(Error::TypeMismatch {
+                        expected: Type::Unit,
+                        found: Type::Tuple(
+                            TupleType::new(val.iter().map(|_| Type::Unit).collect()).unwrap(),
+                        ),
+                    })
+                }
+            }
+            (Expr::List(elems), Type::List(inner)) => {
+                for elem in elems {
+                    self.check_expr(elem, inner, env)?;
+                }
+                Ok(())
+            }
+            (
+                Expr::Func {
+                    params,
+                    body,
+                    return_ty: _,
+                },
+                Type::Func(expected_param, expected_ret),
+            ) => {
+                let mut local_env = Env::new(Some(env));
+                if params.is_empty() {
+                    if **expected_param != Type::Unit {
+                        return Err(Error::TypeMismatch {
+                            expected: (**expected_param).clone(),
+                            found: Type::Unit,
+                        });
+                    }
+                } else if params.len() == 1 {
+                    local_env.bind(params[0].name, (**expected_param).clone());
+                } else {
+                    if let Type::Tuple(ts) = &**expected_param {
+                        if params.len() != ts.len() {
+                            return Err(Error::InvalidTupleArity);
+                        }
+                        for (i, param) in params.iter().enumerate() {
+                            local_env.bind(param.name, ts[i].clone());
+                        }
+                    } else {
+                        return Err(Error::TypeMismatch {
+                            expected: (**expected_param).clone(),
+                            found: Type::Tuple(
+                                TupleType::new(params.iter().map(|_| Type::Unit).collect())
+                                    .unwrap(),
+                            ),
+                        });
+                    }
+                }
+                self.check_expr(body, expected_ret, &mut local_env)?;
+                Ok(())
+            }
+            (Expr::Action(stmts), Type::Unit) => {
+                let mut action_env = Env::new(Some(env));
+                for stmt in stmts {
+                    self.check_action_stmt(stmt, &mut action_env)?;
+                }
+                Ok(())
+            }
+            (Expr::If { cond, expr1, expr2 }, _) => {
+                self.check_expr(cond, &Type::Bool, env)?;
+                self.check_expr(expr1, expected, env)?;
+                self.check_expr(expr2, expected, env)?;
+                Ok(())
+            }
+            (e, t) => {
+                let inferred = self.infer(e, env)?;
+                if inferred == *t {
+                    Ok(())
+                } else {
+                    Err(Error::TypeMismatch {
+                        expected: t.clone(),
+                        found: inferred,
+                    })
+                }
+            }
+        };
+        self.dec_depth();
+        res
+    }
+
+    /// Synthesize the type of an expression
+    ///
+    /// Args:
+    ///     expr (&Expr): The expression to evaluate
+    ///     env (&mut Env<'_, Type>): The local environment
+    ///
+    /// Returns:
+    ///     Result<Type, Error>: The synthesized type on success
+    fn infer(&mut self, expr: &Expr, env: &mut Env<'_, Type>) -> Result<Type, Error> {
+        self.inc_depth()?;
+        let res = match expr {
+            Expr::Literal { val } => match val {
+                Value::Int { .. } => Ok(Type::Int),
+                Value::Bool { .. } => Ok(Type::Bool),
+                Value::String { .. } => Ok(Type::String),
+                Value::Html { .. } => Ok(Type::String),
+                Value::List { vals } => {
+                    if vals.is_empty() {
+                        Err(Error::CannotInferType)
+                    } else {
+                        let inner = self.infer_value(&vals[0])?;
+                        for v in vals {
+                            let v_ty = self.infer_value(v)?;
+                            if v_ty != inner {
+                                return Err(Error::TypeMismatch {
+                                    expected: inner,
+                                    found: v_ty,
+                                });
+                            }
+                        }
+                        Ok(Type::List(Box::new(inner)))
+                    }
+                }
+                Value::Range { .. } => Ok(Type::List(Box::new(Type::Int))),
+                Value::Closure {
+                    params,
+                    body,
+                    return_ty,
+                    ..
+                } => {
+                    let mut local_env = Env::new(Some(env));
+                    let mut param_types = Vec::new();
+                    for param in params {
+                        if let Some(p_ty) = &param.ty {
+                            local_env.bind(param.name, p_ty.clone());
+                            param_types.push(p_ty.clone());
+                        } else {
+                            return Err(Error::CannotInferType);
+                        }
+                    }
+                    let p_ty = if param_types.is_empty() {
+                        Type::Unit
+                    } else if param_types.len() == 1 {
+                        param_types[0].clone()
+                    } else {
+                        Type::Tuple(TupleType::new(param_types).unwrap())
+                    };
+                    let r_ty = if let Some(annotated_ret) = return_ty {
+                        self.check_expr(body, annotated_ret, &mut local_env)?;
+                        annotated_ret.clone()
+                    } else {
+                        self.infer(body, &mut local_env)?
+                    };
+                    Ok(Type::Func(Box::new(p_ty), Box::new(r_ty)))
+                }
+                _ => Err(Error::CannotInferType),
+            },
+            Expr::Html(_) => Ok(Type::String),
+            Expr::Variable { name } => {
+                if let Some(ty) = env.find(*name) {
+                    Ok(ty.clone())
+                } else if let Some(svc) = self.current_service {
+                    let ty = self.type_of_member(svc, *name)?;
+                    Ok(ty)
+                } else {
+                    Err(Error::UnboundVariable(*name))
+                }
+            }
+            Expr::Tuple { val } => {
+                if val.is_empty() {
+                    Ok(Type::Unit)
+                } else if val.len() < 2 {
+                    Err(Error::InvalidTupleArity)
+                } else {
+                    let mut types = Vec::new();
+                    for elem in val {
+                        types.push(self.infer(elem, env)?);
+                    }
+                    Ok(Type::Tuple(TupleType::new(types).unwrap()))
+                }
+            }
+            Expr::KeyVal { value, .. } => self.infer(value, env),
+            Expr::Unop { op, expr } => match op {
+                UnOp::Neg => {
+                    self.check_expr(expr, &Type::Int, env)?;
+                    Ok(Type::Int)
+                }
+                UnOp::Not => {
+                    self.check_expr(expr, &Type::Bool, env)?;
+                    Ok(Type::Bool)
+                }
+            },
+            Expr::Binop { op, expr1, expr2 } => match op {
+                BinOp::Add | BinOp::Sub | BinOp::Mul | BinOp::Div => {
+                    self.check_expr(expr1, &Type::Int, env)?;
+                    self.check_expr(expr2, &Type::Int, env)?;
+                    Ok(Type::Int)
+                }
+                BinOp::Lt | BinOp::Gt => {
+                    self.check_expr(expr1, &Type::Int, env)?;
+                    self.check_expr(expr2, &Type::Int, env)?;
+                    Ok(Type::Bool)
+                }
+                BinOp::And | BinOp::Or => {
+                    self.check_expr(expr1, &Type::Bool, env)?;
+                    self.check_expr(expr2, &Type::Bool, env)?;
+                    Ok(Type::Bool)
+                }
+                BinOp::Eq => {
+                    let ty1 = self.infer(expr1, env)?;
+                    self.check_expr(expr2, &ty1, env)?;
+                    Ok(Type::Bool)
+                }
+            },
+            Expr::If { cond, expr1, expr2 } => {
+                self.check_expr(cond, &Type::Bool, env)?;
+                let ty1 = self.infer(expr1, env)?;
+                self.check_expr(expr2, &ty1, env)?;
+                Ok(ty1)
+            }
+            Expr::Func {
+                params,
+                body,
+                return_ty,
+            } => {
+                let mut local_env = Env::new(Some(env));
+                let mut param_types = Vec::new();
+                for param in params {
+                    if let Some(p_ty) = &param.ty {
+                        local_env.bind(param.name, p_ty.clone());
+                        param_types.push(p_ty.clone());
+                    } else {
+                        return Err(Error::CannotInferType);
+                    }
+                }
+                let p_ty = if param_types.is_empty() {
+                    Type::Unit
+                } else if param_types.len() == 1 {
+                    param_types[0].clone()
+                } else {
+                    Type::Tuple(TupleType::new(param_types).unwrap())
+                };
+                let r_ty = if let Some(annotated_ret) = return_ty {
+                    self.check_expr(body, annotated_ret, &mut local_env)?;
+                    annotated_ret.clone()
+                } else {
+                    self.infer(body, &mut local_env)?
+                };
+                Ok(Type::Func(Box::new(p_ty), Box::new(r_ty)))
+            }
+            Expr::Call { func, args } => {
+                let func_ty = self.infer(func, env)?;
+                if let Type::Func(param_ty, ret_ty) = func_ty {
+                    if args.is_empty() {
+                        if *param_ty != Type::Unit {
+                            return Err(Error::TypeMismatch {
+                                expected: *param_ty,
+                                found: Type::Unit,
+                            });
+                        }
+                    } else if args.len() == 1 {
+                        self.check_expr(&args[0], &param_ty, env)?;
+                    } else {
+                        if let Type::Tuple(ts) = &*param_ty {
+                            if args.len() != ts.len() {
+                                return Err(Error::InvalidTupleArity);
+                            }
+                            for (i, arg) in args.iter().enumerate() {
+                                self.check_expr(arg, &ts[i], env)?;
+                            }
+                        } else {
+                            return Err(Error::TypeMismatch {
+                                expected: *param_ty,
+                                found: Type::Tuple(
+                                    TupleType::new(args.iter().map(|_| Type::Unit).collect())
+                                        .unwrap(),
+                                ),
+                            });
+                        }
+                    }
+                    Ok(*ret_ty)
+                } else {
+                    Err(Error::NotAFunction)
+                }
+            }
+            Expr::Action(stmts) => {
+                let mut action_env = Env::new(Some(env));
+                for stmt in stmts {
+                    self.check_action_stmt(stmt, &mut action_env)?;
+                }
+                Ok(Type::Unit)
+            }
+            Expr::MemberAccess {
+                service_name,
+                member_name,
+            } => self.type_of_member(*service_name, *member_name),
+            Expr::Select { .. } => Ok(Type::List(Box::new(Type::Unit))),
+            Expr::Table { .. } => Ok(Type::Unit),
+            Expr::Fold { .. } => Ok(Type::Unit),
+            Expr::List(elems) => {
+                if elems.is_empty() {
+                    Err(Error::CannotInferType)
+                } else {
+                    let first_ty = self.infer(&elems[0], env)?;
+                    for elem in elems {
+                        self.check_expr(elem, &first_ty, env)?;
+                    }
+                    Ok(Type::List(Box::new(first_ty)))
+                }
+            }
+            Expr::Range { start, end } => {
+                self.check_expr(start, &Type::Int, env)?;
+                self.check_expr(end, &Type::Int, env)?;
+                Ok(Type::List(Box::new(Type::Int)))
+            }
+        };
+        self.dec_depth();
+        res
+    }
+
+    /// Helper to infer type from Value literals directly
+    ///
+    /// Args:
+    ///     val (&Value): The value to infer
+    ///
+    /// Returns:
+    ///     Result<Type, Error>: Inferred type
+    fn infer_value(&mut self, val: &Value) -> Result<Type, Error> {
+        match val {
+            Value::Int { .. } => Ok(Type::Int),
+            Value::Bool { .. } => Ok(Type::Bool),
+            Value::String { .. } => Ok(Type::String),
+            Value::Html { .. } => Ok(Type::String),
+            Value::List { vals } => {
+                if vals.is_empty() {
+                    Err(Error::CannotInferType)
+                } else {
+                    let inner = self.infer_value(&vals[0])?;
+                    for v in vals {
+                        let v_ty = self.infer_value(v)?;
+                        if v_ty != inner {
+                            return Err(Error::TypeMismatch {
+                                expected: inner,
+                                found: v_ty,
+                            });
+                        }
+                    }
+                    Ok(Type::List(Box::new(inner)))
+                }
+            }
+            Value::Range { .. } => Ok(Type::List(Box::new(Type::Int))),
+            _ => Err(Error::CannotInferType),
+        }
+    }
+}
+
+/// Type check the entire parsed program and populate service classes
+///
+/// Args:
+///     program (&[Stmt]): Slices of parsed statements
+///     service_classes (&mut Env<'_, ServiceType<'_>>): Service environment
+///
+/// Returns:
+///     Result<(), Error>: Ok on success
+///
+/// Raises:
+///     Error: Any type error encountered during resolution
+pub fn check<'a>(
+    program: &'a [Stmt],
+    service_classes: &mut Env<'a, ServiceType<'a>>,
+) -> Result<(), Error> {
+    let mut context = Context::new(program, service_classes);
+    context.check_all()
+}
+
+#[cfg(test)]
+mod tests;

--- a/meerkat-lib/src/runtime/tt/check.rs
+++ b/meerkat-lib/src/runtime/tt/check.rs
@@ -46,7 +46,7 @@
 
 use crate::runtime::ast::{ActionStmt, BinOp, Decl, Expr, Stmt, UnOp, Value};
 use crate::runtime::interner::Symbol;
-use crate::runtime::tt::types::{ServiceType, TupleType, Type};
+use crate::runtime::tt::types::{Param, ServiceType, TupleType, Type};
 use crate::runtime::Env;
 
 /// Validate the structural depth of a type representation
@@ -596,64 +596,13 @@ impl<'a, 'b> Context<'a, 'b> {
         self.inc_depth()?;
         let res = match expr {
             Expr::Literal { val } => match val {
-                Value::Int { .. } => Ok(Type::Int),
-                Value::Bool { .. } => Ok(Type::Bool),
-                Value::String { .. } => Ok(Type::String),
-                Value::Html { .. } => Ok(Type::String),
-                Value::List { vals } => {
-                    if vals.is_empty() {
-                        Err(Error::CannotInferType)
-                    } else {
-                        let inner = self.infer_value(&vals[0], type_depth + 1)?;
-                        for v in vals {
-                            let v_ty = self.infer_value(v, type_depth + 1)?;
-                            if v_ty != inner {
-                                return Err(Error::TypeMismatch {
-                                    expected: inner,
-                                    found: v_ty,
-                                });
-                            }
-                        }
-                        Ok(Type::List(Box::new(inner)))
-                    }
-                }
-                Value::Range { .. } => Ok(Type::List(Box::new(Type::Int))),
                 Value::Closure {
                     params,
                     body,
                     return_ty,
                     ..
-                } => {
-                    let mut local_env = Env::new(Some(env));
-                    let mut param_types = Vec::new();
-                    for param in params {
-                        if let Some(p_ty) = &param.ty {
-                            check_type(p_ty, 1)?;
-                            local_env.bind(param.name, p_ty.clone());
-                            param_types.push(p_ty.clone());
-                        } else {
-                            return Err(Error::CannotInferType);
-                        }
-                    }
-                    let p_ty = if param_types.is_empty() {
-                        Type::Unit
-                    } else if param_types.len() == 1 {
-                        param_types[0].clone()
-                    } else {
-                        let tuple_ty =
-                            TupleType::new(param_types).map_err(|_| Error::InvalidTupleArity)?;
-                        Type::Tuple(tuple_ty)
-                    };
-                    let r_ty = if let Some(annotated_ret) = return_ty {
-                        check_type(annotated_ret, 1)?;
-                        self.check_expr(body, annotated_ret, &mut local_env)?;
-                        annotated_ret.clone()
-                    } else {
-                        self.infer(body, &mut local_env, type_depth + 1)?
-                    };
-                    Ok(Type::Func(Box::new(p_ty), Box::new(r_ty)))
-                }
-                _ => Err(Error::CannotInferType),
+                } => self.infer_function_type(params, body, return_ty.as_ref(), env, type_depth),
+                _ => self.infer_value(val, type_depth),
             },
             Expr::Html(_) => Ok(Type::String),
             Expr::Variable { name } => {
@@ -723,36 +672,7 @@ impl<'a, 'b> Context<'a, 'b> {
                 params,
                 body,
                 return_ty,
-            } => {
-                let mut local_env = Env::new(Some(env));
-                let mut param_types = Vec::new();
-                for param in params {
-                    if let Some(p_ty) = &param.ty {
-                        check_type(p_ty, 1)?;
-                        local_env.bind(param.name, p_ty.clone());
-                        param_types.push(p_ty.clone());
-                    } else {
-                        return Err(Error::CannotInferType);
-                    }
-                }
-                let p_ty = if param_types.is_empty() {
-                    Type::Unit
-                } else if param_types.len() == 1 {
-                    param_types[0].clone()
-                } else {
-                    let tuple_ty =
-                        TupleType::new(param_types).map_err(|_| Error::InvalidTupleArity)?;
-                    Type::Tuple(tuple_ty)
-                };
-                let r_ty = if let Some(annotated_ret) = return_ty {
-                    check_type(annotated_ret, 1)?;
-                    self.check_expr(body, annotated_ret, &mut local_env)?;
-                    annotated_ret.clone()
-                } else {
-                    self.infer(body, &mut local_env, type_depth + 1)?
-                };
-                Ok(Type::Func(Box::new(p_ty), Box::new(r_ty)))
-            }
+            } => self.infer_function_type(params, body, return_ty.as_ref(), env, type_depth),
             Expr::Call { func, args } => {
                 let func_ty = self.infer(func, env, 1)?;
                 if let Type::Func(param_ty, ret_ty) = func_ty {
@@ -821,6 +741,58 @@ impl<'a, 'b> Context<'a, 'b> {
         };
         self.dec_depth();
         res
+    }
+
+    /// Infer the type of a function or closure
+    ///
+    /// Args:
+    ///     `params` (`&[Param]`): The function `Param` list
+    ///     `body` (`&Expr`): The function body `Expr`
+    ///     `return_ty` (`Option<&Type>`): The optional return
+    ///         `Type` annotation
+    ///     `env` (`&mut Env<'_, Type>`): The local `Env` environment
+    ///     `type_depth` (`usize`): The current type depth
+    ///
+    /// Returns:
+    ///     `Result<Type, Error>`: The inferred function `Type`
+    ///
+    /// Raises:
+    ///     `Error`: If type check fails or recursion limit exceeded
+    fn infer_function_type(
+        &mut self,
+        params: &[Param],
+        body: &Expr,
+        return_ty: Option<&Type>,
+        env: &mut Env<'_, Type>,
+        type_depth: usize,
+    ) -> Result<Type, Error> {
+        let mut local_env = Env::new(Some(env));
+        let mut param_types = Vec::new();
+        for param in params {
+            if let Some(p_ty) = &param.ty {
+                check_type(p_ty, 1)?;
+                local_env.bind(param.name, p_ty.clone());
+                param_types.push(p_ty.clone());
+            } else {
+                return Err(Error::CannotInferType);
+            }
+        }
+        let p_ty = if param_types.is_empty() {
+            Type::Unit
+        } else if param_types.len() == 1 {
+            param_types[0].clone()
+        } else {
+            let tuple_ty = TupleType::new(param_types).map_err(|_| Error::InvalidTupleArity)?;
+            Type::Tuple(tuple_ty)
+        };
+        let r_ty = if let Some(annotated_ret) = return_ty {
+            check_type(annotated_ret, 1)?;
+            self.check_expr(body, annotated_ret, &mut local_env)?;
+            annotated_ret.clone()
+        } else {
+            self.infer(body, &mut local_env, type_depth + 1)?
+        };
+        Ok(Type::Func(Box::new(p_ty), Box::new(r_ty)))
     }
 
     /// Helper to infer type from Value literals directly

--- a/meerkat-lib/src/runtime/tt/check.rs
+++ b/meerkat-lib/src/runtime/tt/check.rs
@@ -48,6 +48,7 @@ use crate::runtime::ast::{ActionStmt, BinOp, Decl, Expr, Stmt, UnOp, Value};
 use crate::runtime::interner::Symbol;
 use crate::runtime::tt::types::{Param, ServiceType, TupleType, Type};
 use crate::runtime::Env;
+use std::collections::HashSet;
 
 /// Validate the structural depth of a type representation
 ///
@@ -121,7 +122,11 @@ impl std::fmt::Display for Error {
 pub struct Context<'a, 'b> {
     depth: usize,
     program: &'a [Stmt],
-    service_classes: &'b mut Env<'a, ServiceType<'a>>,
+    /// Type environments for services that are declared locally in this program
+    local_services: &'b mut Env<'a, ServiceType<'a>>,
+    /// Names of services brought in via `import` statements; their member
+    /// types are unknown at compile time and are skipped by the checker
+    import_services: HashSet<Symbol>,
     checking_stack: Vec<(Symbol, Symbol)>,
     current_service: Option<Symbol>,
 }
@@ -130,16 +135,19 @@ impl<'a, 'b> Context<'a, 'b> {
     /// Create a new type checking context
     ///
     /// Args:
-    ///     program (&'a [Stmt]): Slices of parsed statements
-    ///     service_classes (&'b mut Env<'a, ServiceType<'a>>): Service classes
+    ///     `program` (`&'a [Stmt]`): Slices of parsed statements
+    ///     `local_services` (`&'b mut Env<'a, ServiceType<'a>>`): Mutable
+    ///         environment mapping locally-declared service names to their
+    ///         accumulated `ServiceType` records
     ///
     /// Returns:
-    ///     Self: The Context instance
-    fn new(program: &'a [Stmt], service_classes: &'b mut Env<'a, ServiceType<'a>>) -> Self {
+    ///     `Self`: The `Context` instance
+    fn new(program: &'a [Stmt], local_services: &'b mut Env<'a, ServiceType<'a>>) -> Self {
         Self {
             depth: 0,
             program,
-            service_classes,
+            local_services,
+            import_services: HashSet::new(),
             checking_stack: Vec::new(),
             current_service: None,
         }
@@ -171,13 +179,23 @@ impl<'a, 'b> Context<'a, 'b> {
     /// Execute type checking on all program statements
     ///
     /// Returns:
-    ///     Result<(), Error>: Ok on success
+    ///     `Result<(), Error>`: Ok on success
     pub fn check_all(&mut self) -> Result<(), Error> {
+        // First pass: register all locally-declared service names so that
+        // forward-reference lookups within `type_of_member` can find them,
+        // and collect all imported service names so that cross-service member
+        // accesses can be skipped rather than hard-errored
         for stmt in self.program {
-            if let Stmt::Service { name, .. } = stmt {
-                if self.service_classes.find(*name).is_none() {
-                    self.service_classes.bind(*name, ServiceType::default());
+            match stmt {
+                Stmt::Service { name, .. } => {
+                    if self.local_services.find(*name).is_none() {
+                        self.local_services.bind(*name, ServiceType::default());
+                    }
                 }
+                Stmt::Import { service_name, .. } => {
+                    self.import_services.insert(*service_name);
+                }
+                _ => {}
             }
         }
 
@@ -262,10 +280,23 @@ impl<'a, 'b> Context<'a, 'b> {
     ///     Error::CannotInferType: On cyclic dependencies
     ///     Error::UnboundVariable: If member is not found
     fn type_of_member(&mut self, service_name: Symbol, member_name: Symbol) -> Result<Type, Error> {
-        if let Some(st) = self.service_classes.find(service_name) {
+        // Fast path: member type already cached from a prior check
+        if let Some(st) = self.local_services.find(service_name) {
             if let Some(ty) = st.fields().find(member_name) {
                 return Ok(ty.clone());
             }
+        }
+
+        // If the service was brought in via `import`, its declarations are
+        // not present in this compilation unit and cannot be type-checked.
+        // Emit a warning and treat the member as `Unit` (unchecked) so that
+        // the program is not prevented from running
+        if self.import_services.contains(&service_name) {
+            println!(
+                "warning: tt/check: skipping member type check for \
+                 imported service (type unknown at compile time)"
+            );
+            return Ok(Type::Unit);
         }
 
         let key = (service_name, member_name);
@@ -321,9 +352,9 @@ impl<'a, 'b> Context<'a, 'b> {
 
         self.checking_stack.pop();
 
-        if let Some(mut st) = self.service_classes.remove(service_name) {
+        if let Some(mut st) = self.local_services.remove(service_name) {
             let _ = st.add_field(member_name, ty.clone());
-            self.service_classes.bind(service_name, st);
+            self.local_services.bind(service_name, st);
         }
 
         Ok(ty)
@@ -366,7 +397,7 @@ impl<'a, 'b> Context<'a, 'b> {
     ///     Result<(), Error>: Ok on success
     fn check_test(&mut self, service_name: Symbol, stmts: &[ActionStmt]) -> Result<(), Error> {
         let mut test_env = Env::new(None);
-        if let Some(st) = self.service_classes.find(service_name) {
+        if let Some(st) = self.local_services.find(service_name) {
             for name in st.field_order() {
                 if let Some(ty) = st.fields().find(*name) {
                     test_env.bind(*name, ty.clone());
@@ -425,7 +456,7 @@ impl<'a, 'b> Context<'a, 'b> {
                 let ty = if let Some(local_ty) = env.find(*name) {
                     local_ty.clone()
                 } else if let Some(svc) = self.current_service {
-                    if let Some(st) = self.service_classes.find(svc) {
+                    if let Some(st) = self.local_services.find(svc) {
                         st.fields()
                             .find(*name)
                             .ok_or(Error::UnboundVariable(*name))?
@@ -705,7 +736,14 @@ impl<'a, 'b> Context<'a, 'b> {
                 }
                 BinOp::Eq => {
                     let ty1 = self.infer(expr1, env, type_depth)?;
-                    self.check_expr(expr2, &ty1, env)?;
+                    // If the left side resolved to `Unit`, it is the sentinel
+                    // type used for imported service members whose concrete
+                    // types are not known at compile time. Skip checking the
+                    // right side to avoid false type errors cascading from
+                    // the import bypass
+                    if ty1 != Type::Unit {
+                        self.check_expr(expr2, &ty1, env)?;
+                    }
                     Ok(Type::Bool)
                 }
             },
@@ -916,22 +954,24 @@ impl<'a, 'b> Context<'a, 'b> {
     }
 }
 
-/// Type check the entire parsed program and populate service classes
+/// Type check the entire parsed program and populate local service types
 ///
 /// Args:
-///     program (&[Stmt]): Slices of parsed statements
-///     service_classes (&mut Env<'_, ServiceType<'_>>): Service environment
+///     `program` (`&[Stmt]`): Slices of parsed statements
+///     `local_services` (`&mut Env<'_, ServiceType<'_>>`): Mutable
+///         environment that accumulates type information for each
+///         locally-declared service; imported services are skipped
 ///
 /// Returns:
-///     Result<(), Error>: Ok on success
+///     `Result<(), Error>`: Ok on success
 ///
 /// Raises:
-///     Error: Any type error encountered during resolution
+///     `Error`: Any type error encountered during resolution
 pub fn check<'a>(
     program: &'a [Stmt],
-    service_classes: &mut Env<'a, ServiceType<'a>>,
+    local_services: &mut Env<'a, ServiceType<'a>>,
 ) -> Result<(), Error> {
-    let mut context = Context::new(program, service_classes);
+    let mut context = Context::new(program, local_services);
     context.check_all()
 }
 

--- a/meerkat-lib/src/runtime/tt/check.rs
+++ b/meerkat-lib/src/runtime/tt/check.rs
@@ -49,22 +49,35 @@ use crate::runtime::interner::Symbol;
 use crate::runtime::tt::types::{ServiceType, TupleType, Type};
 use crate::runtime::Env;
 
-/// Helper to calculate the nesting depth of a type representation
+/// Validate the structural depth of a type representation
 ///
 /// Args:
 ///     ty (&Type): The type to evaluate
+///     depth (usize): The current depth in the type tree
 ///
 /// Returns:
-///     usize: The maximum nesting depth of the type structure
-fn type_depth(ty: &Type) -> usize {
+///     Result<(), Error>: Ok if depth limits are not exceeded
+///
+/// Raises:
+///     Error::DepthLimitExceeded: If type depth limit is exceeded
+fn check_type(ty: &Type, depth: usize) -> Result<(), Error> {
+    if depth > crate::runtime::limits::MAX_TYPE_DEPTH {
+        return Err(Error::DepthLimitExceeded);
+    }
     match ty {
-        Type::Int | Type::String | Type::Bool | Type::Unit => 1,
+        Type::Int | Type::String | Type::Bool | Type::Unit => Ok(()),
         Type::Tuple(ts) => {
-            let max_inner = ts.iter().map(type_depth).max().unwrap_or(0);
-            1 + max_inner
+            for t in ts.iter() {
+                check_type(t, depth + 1)?;
+            }
+            Ok(())
         }
-        Type::Func(t1, t2) => 1 + std::cmp::max(type_depth(t1), type_depth(t2)),
-        Type::List(inner) => 1 + type_depth(inner),
+        Type::Func(t1, t2) => {
+            check_type(t1, depth + 1)?;
+            check_type(t2, depth + 1)?;
+            Ok(())
+        }
+        Type::List(inner) => check_type(inner, depth + 1),
     }
 }
 
@@ -272,17 +285,11 @@ impl<'a, 'b> Context<'a, 'b> {
                 let prev_service = self.current_service;
                 self.current_service = Some(service_name);
                 let res = if let Some(expected) = annotated {
-                    if type_depth(expected) > crate::runtime::limits::MAX_TYPE_DEPTH {
-                        return Err(Error::DepthLimitExceeded);
-                    }
+                    check_type(expected, 1)?;
                     self.check_expr(val, expected, &mut env)?;
                     expected.clone()
                 } else {
-                    let inferred = self.infer(val, &mut env)?;
-                    if type_depth(&inferred) > crate::runtime::limits::MAX_TYPE_DEPTH {
-                        return Err(Error::DepthLimitExceeded);
-                    }
-                    inferred
+                    self.infer(val, &mut env, 1)?
                 };
                 self.current_service = prev_service;
                 res
@@ -364,26 +371,21 @@ impl<'a, 'b> Context<'a, 'b> {
         let res = match stmt {
             ActionStmt::Let { name, ty, expr } => {
                 if let Some(expected) = ty {
-                    if type_depth(expected) > crate::runtime::limits::MAX_TYPE_DEPTH {
-                        return Err(Error::DepthLimitExceeded);
-                    }
+                    check_type(expected, 1)?;
                     self.check_expr(expr, expected, env)?;
                     env.bind(*name, expected.clone());
                 } else {
-                    let inferred = self.infer(expr, env)?;
-                    if type_depth(&inferred) > crate::runtime::limits::MAX_TYPE_DEPTH {
-                        return Err(Error::DepthLimitExceeded);
-                    }
+                    let inferred = self.infer(expr, env, 1)?;
                     env.bind(*name, inferred);
                 }
                 Ok(())
             }
             ActionStmt::Expr(expr) => {
-                self.infer(expr, env)?;
+                self.infer(expr, env, 1)?;
                 Ok(())
             }
             ActionStmt::Do(expr) => {
-                self.infer(expr, env)?;
+                self.infer(expr, env, 1)?;
                 Ok(())
             }
             ActionStmt::Assert(expr, _) => {
@@ -409,7 +411,7 @@ impl<'a, 'b> Context<'a, 'b> {
                 Ok(())
             }
             ActionStmt::Insert { row, .. } => {
-                self.infer(row, env)?;
+                self.infer(row, env, 1)?;
                 Ok(())
             }
             ActionStmt::For {
@@ -417,7 +419,7 @@ impl<'a, 'b> Context<'a, 'b> {
                 iterable,
                 body,
             } => {
-                let iter_ty = self.infer(iterable, env)?;
+                let iter_ty = self.infer(iterable, env, 1)?;
                 if let Type::List(elem_ty) = iter_ty {
                     let mut for_env = Env::new(Some(env));
                     for_env.bind(*var, (*elem_ty).clone());
@@ -534,7 +536,7 @@ impl<'a, 'b> Context<'a, 'b> {
                 Ok(())
             }
             (e, t) => {
-                let inferred = self.infer(e, env)?;
+                let inferred = self.infer(e, env, 1)?;
                 if inferred == *t {
                     Ok(())
                 } else {
@@ -554,10 +556,19 @@ impl<'a, 'b> Context<'a, 'b> {
     /// Args:
     ///     expr (&Expr): The expression to evaluate
     ///     env (&mut Env<'_, Type>): The local environment
+    ///     type_depth (usize): The current type depth
     ///
     /// Returns:
     ///     Result<Type, Error>: The synthesized type on success
-    fn infer(&mut self, expr: &Expr, env: &mut Env<'_, Type>) -> Result<Type, Error> {
+    fn infer(
+        &mut self,
+        expr: &Expr,
+        env: &mut Env<'_, Type>,
+        type_depth: usize,
+    ) -> Result<Type, Error> {
+        if type_depth > crate::runtime::limits::MAX_TYPE_DEPTH {
+            return Err(Error::DepthLimitExceeded);
+        }
         self.inc_depth()?;
         let res = match expr {
             Expr::Literal { val } => match val {
@@ -569,9 +580,9 @@ impl<'a, 'b> Context<'a, 'b> {
                     if vals.is_empty() {
                         Err(Error::CannotInferType)
                     } else {
-                        let inner = self.infer_value(&vals[0])?;
+                        let inner = self.infer_value(&vals[0], type_depth + 1)?;
                         for v in vals {
-                            let v_ty = self.infer_value(v)?;
+                            let v_ty = self.infer_value(v, type_depth + 1)?;
                             if v_ty != inner {
                                 return Err(Error::TypeMismatch {
                                     expected: inner,
@@ -593,6 +604,7 @@ impl<'a, 'b> Context<'a, 'b> {
                     let mut param_types = Vec::new();
                     for param in params {
                         if let Some(p_ty) = &param.ty {
+                            check_type(p_ty, 1)?;
                             local_env.bind(param.name, p_ty.clone());
                             param_types.push(p_ty.clone());
                         } else {
@@ -607,10 +619,11 @@ impl<'a, 'b> Context<'a, 'b> {
                         Type::Tuple(TupleType::new(param_types).unwrap())
                     };
                     let r_ty = if let Some(annotated_ret) = return_ty {
+                        check_type(annotated_ret, 1)?;
                         self.check_expr(body, annotated_ret, &mut local_env)?;
                         annotated_ret.clone()
                     } else {
-                        self.infer(body, &mut local_env)?
+                        self.infer(body, &mut local_env, type_depth + 1)?
                     };
                     Ok(Type::Func(Box::new(p_ty), Box::new(r_ty)))
                 }
@@ -635,12 +648,12 @@ impl<'a, 'b> Context<'a, 'b> {
                 } else {
                     let mut types = Vec::new();
                     for elem in val {
-                        types.push(self.infer(elem, env)?);
+                        types.push(self.infer(elem, env, type_depth + 1)?);
                     }
                     Ok(Type::Tuple(TupleType::new(types).unwrap()))
                 }
             }
-            Expr::KeyVal { value, .. } => self.infer(value, env),
+            Expr::KeyVal { value, .. } => self.infer(value, env, type_depth),
             Expr::Unop { op, expr } => match op {
                 UnOp::Neg => {
                     self.check_expr(expr, &Type::Int, env)?;
@@ -668,14 +681,14 @@ impl<'a, 'b> Context<'a, 'b> {
                     Ok(Type::Bool)
                 }
                 BinOp::Eq => {
-                    let ty1 = self.infer(expr1, env)?;
+                    let ty1 = self.infer(expr1, env, 1)?;
                     self.check_expr(expr2, &ty1, env)?;
                     Ok(Type::Bool)
                 }
             },
             Expr::If { cond, expr1, expr2 } => {
                 self.check_expr(cond, &Type::Bool, env)?;
-                let ty1 = self.infer(expr1, env)?;
+                let ty1 = self.infer(expr1, env, type_depth)?;
                 self.check_expr(expr2, &ty1, env)?;
                 Ok(ty1)
             }
@@ -688,6 +701,7 @@ impl<'a, 'b> Context<'a, 'b> {
                 let mut param_types = Vec::new();
                 for param in params {
                     if let Some(p_ty) = &param.ty {
+                        check_type(p_ty, 1)?;
                         local_env.bind(param.name, p_ty.clone());
                         param_types.push(p_ty.clone());
                     } else {
@@ -702,15 +716,16 @@ impl<'a, 'b> Context<'a, 'b> {
                     Type::Tuple(TupleType::new(param_types).unwrap())
                 };
                 let r_ty = if let Some(annotated_ret) = return_ty {
+                    check_type(annotated_ret, 1)?;
                     self.check_expr(body, annotated_ret, &mut local_env)?;
                     annotated_ret.clone()
                 } else {
-                    self.infer(body, &mut local_env)?
+                    self.infer(body, &mut local_env, type_depth + 1)?
                 };
                 Ok(Type::Func(Box::new(p_ty), Box::new(r_ty)))
             }
             Expr::Call { func, args } => {
-                let func_ty = self.infer(func, env)?;
+                let func_ty = self.infer(func, env, 1)?;
                 if let Type::Func(param_ty, ret_ty) = func_ty {
                     if args.is_empty() {
                         if *param_ty != Type::Unit {
@@ -762,7 +777,7 @@ impl<'a, 'b> Context<'a, 'b> {
                 if elems.is_empty() {
                     Err(Error::CannotInferType)
                 } else {
-                    let first_ty = self.infer(&elems[0], env)?;
+                    let first_ty = self.infer(&elems[0], env, type_depth + 1)?;
                     for elem in elems {
                         self.check_expr(elem, &first_ty, env)?;
                     }
@@ -783,10 +798,14 @@ impl<'a, 'b> Context<'a, 'b> {
     ///
     /// Args:
     ///     val (&Value): The value to infer
+    ///     type_depth (usize): The current type depth
     ///
     /// Returns:
     ///     Result<Type, Error>: Inferred type
-    fn infer_value(&mut self, val: &Value) -> Result<Type, Error> {
+    fn infer_value(&mut self, val: &Value, type_depth: usize) -> Result<Type, Error> {
+        if type_depth > crate::runtime::limits::MAX_TYPE_DEPTH {
+            return Err(Error::DepthLimitExceeded);
+        }
         match val {
             Value::Int { .. } => Ok(Type::Int),
             Value::Bool { .. } => Ok(Type::Bool),
@@ -796,9 +815,9 @@ impl<'a, 'b> Context<'a, 'b> {
                 if vals.is_empty() {
                     Err(Error::CannotInferType)
                 } else {
-                    let inner = self.infer_value(&vals[0])?;
+                    let inner = self.infer_value(&vals[0], type_depth + 1)?;
                     for v in vals {
-                        let v_ty = self.infer_value(v)?;
+                        let v_ty = self.infer_value(v, type_depth + 1)?;
                         if v_ty != inner {
                             return Err(Error::TypeMismatch {
                                 expected: inner,

--- a/meerkat-lib/src/runtime/tt/check/tests.rs
+++ b/meerkat-lib/src/runtime/tt/check/tests.rs
@@ -776,3 +776,104 @@ fn test_tuple_single_element_checking() {
     let res = check(&program, &mut classes);
     assert_eq!(res, Err(Error::InvalidTupleArity))
 }
+
+/// Verify that contradictory return and parameter type annotations on
+/// lambdas in checking mode are rejected
+#[test]
+fn test_lambda_annotations_in_checking_mode() {
+    let mut classes = Env::new(None);
+    let mut interner = Interner::new();
+    let name_s = interner.insert("s");
+    // Test contradictory return type: expected int -> int,
+    // annotated int -> string
+    let program1 = vec![Stmt::Service {
+        name: name_s,
+        decls: vec![Decl::VarDecl {
+            name: interner.insert("f"),
+            ty: Some(Type::Func(Box::new(Type::Int), Box::new(Type::Int))),
+            val: Expr::Func {
+                params: vec![Param {
+                    name: interner.insert("x"),
+                    ty: Some(Type::Int),
+                }],
+                body: Box::new(Expr::Literal {
+                    val: Value::Int { val: 5 },
+                }),
+                return_ty: Some(Type::String),
+            },
+        }],
+    }];
+    let res1 = check(&program1, &mut classes);
+    assert_eq!(
+        res1,
+        Err(Error::TypeMismatch {
+            expected: Type::Int,
+            found: Type::String,
+        })
+    );
+    // Test contradictory parameter type: expected int -> int,
+    // annotated string -> int
+    let program2 = vec![Stmt::Service {
+        name: name_s,
+        decls: vec![Decl::VarDecl {
+            name: interner.insert("g"),
+            ty: Some(Type::Func(Box::new(Type::Int), Box::new(Type::Int))),
+            val: Expr::Func {
+                params: vec![Param {
+                    name: interner.insert("x"),
+                    ty: Some(Type::String),
+                }],
+                body: Box::new(Expr::Literal {
+                    val: Value::Int { val: 5 },
+                }),
+                return_ty: Some(Type::Int),
+            },
+        }],
+    }];
+    let res2 = check(&program2, &mut classes);
+    assert_eq!(
+        res2,
+        Err(Error::TypeMismatch {
+            expected: Type::Int,
+            found: Type::String,
+        })
+    );
+    // Test contradictory tuple parameter type: expected
+    // (int, int) -> int, annotated (string, int) -> int
+    let program3 = vec![Stmt::Service {
+        name: name_s,
+        decls: vec![Decl::VarDecl {
+            name: interner.insert("h"),
+            ty: Some(Type::Func(
+                Box::new(Type::Tuple(
+                    TupleType::new(vec![Type::Int, Type::Int]).unwrap(),
+                )),
+                Box::new(Type::Int),
+            )),
+            val: Expr::Func {
+                params: vec![
+                    Param {
+                        name: interner.insert("x"),
+                        ty: Some(Type::String),
+                    },
+                    Param {
+                        name: interner.insert("y"),
+                        ty: Some(Type::Int),
+                    },
+                ],
+                body: Box::new(Expr::Literal {
+                    val: Value::Int { val: 5 },
+                }),
+                return_ty: Some(Type::Int),
+            },
+        }],
+    }];
+    let res3 = check(&program3, &mut classes);
+    assert_eq!(
+        res3,
+        Err(Error::TypeMismatch {
+            expected: Type::Int,
+            found: Type::String,
+        })
+    );
+}

--- a/meerkat-lib/src/runtime/tt/check/tests.rs
+++ b/meerkat-lib/src/runtime/tt/check/tests.rs
@@ -1,6 +1,7 @@
 use super::*;
 use crate::runtime::html::HtmlTemplateBuilder;
 use crate::runtime::interner::Interner;
+use crate::runtime::limits::{MAX_SCOPE_DEPTH, MAX_TYPE_DEPTH};
 use crate::runtime::tt::Param;
 
 /// Verify that type checking empty program passes
@@ -22,27 +23,48 @@ fn test_type_depth_calculation() {
     assert!(check_type(&func, 1).is_ok());
 }
 
-/// Verify that pathologically deep type annotations are rejected
+/// Verify that type annotations at the exact depth limit
+/// are accepted, while those exceeding the limit
+/// `MAX_TYPE_DEPTH` are rejected
 #[test]
 fn test_deep_annotation_rejected() {
     let mut interner = Interner::new();
     let name_s = interner.insert("my_service");
     let var_x = interner.insert("x");
-    let mut deep_ty = Type::Int;
-    for _ in 0..17 {
-        deep_ty = Type::List(Box::new(deep_ty));
+
+    // Exact limit succeeds: depth == `MAX_TYPE_DEPTH`
+    let mut ok_ty = Type::Int;
+    for _ in 0..(MAX_TYPE_DEPTH - 1) {
+        ok_ty = Type::List(Box::new(ok_ty));
     }
-    let decls = vec![Decl::VarDecl {
+    let decls_ok = vec![Decl::VarDecl {
         name: var_x,
-        ty: Some(deep_ty),
+        ty: Some(ok_ty),
         val: Expr::List(vec![]),
     }];
-    let program = vec![Stmt::Service {
+    let program_ok = vec![Stmt::Service {
         name: name_s,
-        decls,
+        decls: decls_ok,
     }];
     let mut classes = Env::new(None);
-    let res = check(&program, &mut classes);
+    assert!(check(&program_ok, &mut classes).is_ok());
+
+    // Exceeding limit fails: depth == `MAX_TYPE_DEPTH` + `1`
+    let mut fail_ty = Type::Int;
+    for _ in 0..MAX_TYPE_DEPTH {
+        fail_ty = Type::List(Box::new(fail_ty));
+    }
+    let decls_fail = vec![Decl::VarDecl {
+        name: var_x,
+        ty: Some(fail_ty),
+        val: Expr::List(vec![]),
+    }];
+    let program_fail = vec![Stmt::Service {
+        name: name_s,
+        decls: decls_fail,
+    }];
+    let mut classes = Env::new(None);
+    let res = check(&program_fail, &mut classes);
     assert_eq!(res, Err(Error::DepthLimitExceeded));
 }
 
@@ -162,7 +184,7 @@ fn test_scope_depth_limit() {
     let name_s = interner.insert("s");
     let name_x = interner.insert("x");
     let mut ty = Type::Int;
-    for _ in 0..=crate::runtime::limits::MAX_TYPE_DEPTH {
+    for _ in 0..=MAX_TYPE_DEPTH {
         ty = Type::List(Box::new(ty));
     }
     let decls = vec![Decl::VarDecl {
@@ -190,7 +212,7 @@ fn test_expression_depth_limit() {
     let mut expr = Expr::Literal {
         val: Value::Int { val: 1 },
     };
-    for _ in 0..=crate::runtime::limits::MAX_SCOPE_DEPTH {
+    for _ in 0..=MAX_SCOPE_DEPTH {
         expr = Expr::Unop {
             op: UnOp::Neg,
             expr: Box::new(expr),

--- a/meerkat-lib/src/runtime/tt/check/tests.rs
+++ b/meerkat-lib/src/runtime/tt/check/tests.rs
@@ -899,3 +899,69 @@ fn test_lambda_annotations_in_checking_mode() {
         })
     );
 }
+
+/// Verify that a local service referencing a member of an imported service
+/// does not produce a type error. The type checker cannot know the member
+/// types of remote services, so it must skip the check and allow the
+/// program to proceed to runtime
+#[test]
+fn test_import_member_access_is_skipped() {
+    let mut interner = Interner::new();
+    let remote_svc = interner.insert("na");
+    let local_svc = interner.insert("nb");
+    let remote_member = interner.insert("get_x");
+    let local_val = interner.insert("val");
+
+    // Program: `import na` then `service nb { pub def val = na.get_x; }`
+    let program = vec![
+        Stmt::Import {
+            path: "na".to_string(),
+            service_name: remote_svc,
+        },
+        Stmt::Service {
+            name: local_svc,
+            decls: vec![Decl::DefDecl {
+                name: local_val,
+                ty: None,
+                is_pub: false,
+                val: Expr::MemberAccess {
+                    service_name: remote_svc,
+                    member_name: remote_member,
+                },
+            }],
+        },
+    ];
+    let mut classes = Env::new(None);
+    let res = check(&program, &mut classes);
+    assert!(res.is_ok())
+}
+
+/// Verify that a `MemberAccess` expression targeting a service that is
+/// neither declared locally nor imported still produces a hard error.
+/// This is the negative/defensive case ensuring the import bypass is
+/// precisely scoped to services registered via `Stmt::Import`
+#[test]
+fn test_unknown_service_member_access_errors() {
+    let mut interner = Interner::new();
+    let ghost_svc = interner.insert("ghost");
+    let local_svc = interner.insert("nb");
+    let ghost_member = interner.insert("val");
+    let local_def = interner.insert("x");
+
+    // Program: `service nb { pub def x = ghost.val; }` — `ghost` is not imported
+    let program = vec![Stmt::Service {
+        name: local_svc,
+        decls: vec![Decl::DefDecl {
+            name: local_def,
+            ty: None,
+            is_pub: false,
+            val: Expr::MemberAccess {
+                service_name: ghost_svc,
+                member_name: ghost_member,
+            },
+        }],
+    }];
+    let mut classes = Env::new(None);
+    let res = check(&program, &mut classes);
+    assert_eq!(res, Err(Error::UnboundVariable(ghost_svc)))
+}

--- a/meerkat-lib/src/runtime/tt/check/tests.rs
+++ b/meerkat-lib/src/runtime/tt/check/tests.rs
@@ -11,15 +11,39 @@ fn test_empty_program() {
     assert!(res.is_ok())
 }
 
-/// Verify that type depth calculations match expectations
+/// Verify that type depth verification works as expected
 #[test]
 fn test_type_depth_calculation() {
-    assert_eq!(type_depth(&Type::Int), 1);
+    assert!(check_type(&Type::Int, 1).is_ok());
     let func = Type::Func(
         Box::new(Type::Int),
         Box::new(Type::Func(Box::new(Type::Bool), Box::new(Type::String))),
     );
-    assert_eq!(type_depth(&func), 3)
+    assert!(check_type(&func, 1).is_ok());
+}
+
+/// Verify that pathologically deep type annotations are rejected
+#[test]
+fn test_deep_annotation_rejected() {
+    let mut interner = Interner::new();
+    let name_s = interner.insert("my_service");
+    let var_x = interner.insert("x");
+    let mut deep_ty = Type::Int;
+    for _ in 0..17 {
+        deep_ty = Type::List(Box::new(deep_ty));
+    }
+    let decls = vec![Decl::VarDecl {
+        name: var_x,
+        ty: Some(deep_ty),
+        val: Expr::List(vec![]),
+    }];
+    let program = vec![Stmt::Service {
+        name: name_s,
+        decls,
+    }];
+    let mut classes = Env::new(None);
+    let res = check(&program, &mut classes);
+    assert_eq!(res, Err(Error::DepthLimitExceeded));
 }
 
 /// Verify basic primitive assignments

--- a/meerkat-lib/src/runtime/tt/check/tests.rs
+++ b/meerkat-lib/src/runtime/tt/check/tests.rs
@@ -753,3 +753,26 @@ fn test_tuple_single_element_inference() {
     let res = check(&program, &mut classes);
     assert_eq!(res, Err(Error::InvalidTupleArity))
 }
+
+/// Verify tuple with single element is checked against Type::Unit
+/// and rejected
+#[test]
+fn test_tuple_single_element_checking() {
+    let mut classes = Env::new(None);
+    let mut interner = Interner::new();
+    let name_s = interner.insert("s");
+    let program = vec![Stmt::Service {
+        name: name_s,
+        decls: vec![Decl::VarDecl {
+            name: interner.insert("t"),
+            ty: Some(Type::Unit),
+            val: Expr::Tuple {
+                val: vec![Expr::Literal {
+                    val: Value::Int { val: 1 },
+                }],
+            },
+        }],
+    }];
+    let res = check(&program, &mut classes);
+    assert_eq!(res, Err(Error::InvalidTupleArity))
+}

--- a/meerkat-lib/src/runtime/tt/check/tests.rs
+++ b/meerkat-lib/src/runtime/tt/check/tests.rs
@@ -1,0 +1,731 @@
+use super::*;
+use crate::runtime::html::HtmlTemplateBuilder;
+use crate::runtime::interner::Interner;
+use crate::runtime::tt::Param;
+
+/// Verify that type checking empty program passes
+#[test]
+fn test_empty_program() {
+    let mut classes = Env::new(None);
+    let res = check(&[], &mut classes);
+    assert!(res.is_ok())
+}
+
+/// Verify that type depth calculations match expectations
+#[test]
+fn test_type_depth_calculation() {
+    assert_eq!(type_depth(&Type::Int), 1);
+    let func = Type::Func(
+        Box::new(Type::Int),
+        Box::new(Type::Func(Box::new(Type::Bool), Box::new(Type::String))),
+    );
+    assert_eq!(type_depth(&func), 3)
+}
+
+/// Verify basic primitive assignments
+#[test]
+fn test_primitive_checking() {
+    let mut interner = Interner::new();
+    let name_s = interner.insert("my_service");
+    let var_x = interner.insert("x");
+    let decls = vec![Decl::VarDecl {
+        name: var_x,
+        ty: Some(Type::Int),
+        val: Expr::Literal {
+            val: Value::Int { val: 42 },
+        },
+    }];
+    let program = vec![Stmt::Service {
+        name: name_s,
+        decls,
+    }];
+    let mut classes = Env::new(None);
+    let res = check(&program, &mut classes);
+    assert!(res.is_ok());
+    let st = classes.find(name_s).unwrap();
+    assert_eq!(st.fields().find(var_x), Some(&Type::Int))
+}
+
+/// Verify type mismatches are rejected
+#[test]
+fn test_primitive_mismatch() {
+    let mut interner = Interner::new();
+    let name_s = interner.insert("my_service");
+    let var_x = interner.insert("x");
+    let decls = vec![Decl::VarDecl {
+        name: var_x,
+        ty: Some(Type::Int),
+        val: Expr::Literal {
+            val: Value::String {
+                val: "bad".to_string(),
+            },
+        },
+    }];
+    let program = vec![Stmt::Service {
+        name: name_s,
+        decls,
+    }];
+    let mut classes = Env::new(None);
+    let res = check(&program, &mut classes);
+    assert_eq!(
+        res,
+        Err(Error::TypeMismatch {
+            expected: Type::Int,
+            found: Type::String,
+        })
+    )
+}
+
+/// Verify annotated function type checking and calls
+#[test]
+fn test_function_calls() {
+    let mut interner = Interner::new();
+    let name_s = interner.insert("my_service");
+    let var_f = interner.insert("f");
+    let var_x = interner.insert("x");
+    let decls = vec![
+        Decl::VarDecl {
+            name: var_f,
+            ty: Some(Type::Func(Box::new(Type::Int), Box::new(Type::Int))),
+            val: Expr::Func {
+                params: vec![Param {
+                    name: interner.insert("a"),
+                    ty: Some(Type::Int),
+                }],
+                body: Box::new(Expr::Variable {
+                    name: interner.insert("a"),
+                }),
+                return_ty: Some(Type::Int),
+            },
+        },
+        Decl::VarDecl {
+            name: var_x,
+            ty: Some(Type::Int),
+            val: Expr::Call {
+                func: Box::new(Expr::Variable { name: var_f }),
+                args: vec![Expr::Literal {
+                    val: Value::Int { val: 10 },
+                }],
+            },
+        },
+    ];
+    let program = vec![Stmt::Service {
+        name: name_s,
+        decls,
+    }];
+    let mut classes = Env::new(None);
+    let res = check(&program, &mut classes);
+    assert!(res.is_ok())
+}
+
+/// Verify Error formatting produces expected messages
+#[test]
+fn test_error_display() {
+    assert_eq!(
+        Error::DepthLimitExceeded.to_string(),
+        "Depth limit exceeded"
+    );
+    assert_eq!(Error::CannotInferType.to_string(), "Cannot infer type");
+    assert_eq!(Error::InvalidTupleArity.to_string(), "Invalid tuple arity");
+    assert_eq!(Error::NotAFunction.to_string(), "Not a function");
+}
+
+/// Verify deeply nested type structures fail depth checking
+#[test]
+fn test_scope_depth_limit() {
+    let mut classes = Env::new(None);
+    let mut interner = Interner::new();
+    let name_s = interner.insert("s");
+    let name_x = interner.insert("x");
+    let mut ty = Type::Int;
+    for _ in 0..=crate::runtime::limits::MAX_TYPE_DEPTH {
+        ty = Type::List(Box::new(ty));
+    }
+    let decls = vec![Decl::VarDecl {
+        name: name_x,
+        ty: Some(ty),
+        val: Expr::Literal {
+            val: Value::Int { val: 42 },
+        },
+    }];
+    let program = vec![Stmt::Service {
+        name: name_s,
+        decls,
+    }];
+    let res = check(&program, &mut classes);
+    assert_eq!(res, Err(Error::DepthLimitExceeded))
+}
+
+/// Verify deeply nested expressions trigger DepthLimitExceeded
+#[test]
+fn test_expression_depth_limit() {
+    let mut classes = Env::new(None);
+    let mut interner = Interner::new();
+    let name_s = interner.insert("s");
+    let name_x = interner.insert("x");
+    let mut expr = Expr::Literal {
+        val: Value::Int { val: 1 },
+    };
+    for _ in 0..=crate::runtime::limits::MAX_SCOPE_DEPTH {
+        expr = Expr::Unop {
+            op: UnOp::Neg,
+            expr: Box::new(expr),
+        };
+    }
+    let decls = vec![Decl::VarDecl {
+        name: name_x,
+        ty: Some(Type::Int),
+        val: expr,
+    }];
+    let program = vec![Stmt::Service {
+        name: name_s,
+        decls,
+    }];
+    let res = check(&program, &mut classes);
+    assert_eq!(res, Err(Error::DepthLimitExceeded))
+}
+
+/// Verify checking of action statements
+#[test]
+fn test_action_statements() {
+    let mut classes = Env::new(None);
+    let mut interner = Interner::new();
+    let name_s = interner.insert("s");
+    let program = vec![
+        Stmt::Service {
+            name: name_s,
+            decls: vec![Decl::VarDecl {
+                name: interner.insert("v"),
+                ty: Some(Type::Int),
+                val: Expr::Literal {
+                    val: Value::Int { val: 1 },
+                },
+            }],
+        },
+        Stmt::Test {
+            service_name: name_s,
+            stmts: vec![
+                ActionStmt::Let {
+                    name: interner.insert("x"),
+                    ty: None,
+                    expr: Expr::Literal {
+                        val: Value::Bool { val: true },
+                    },
+                },
+                ActionStmt::Assert(
+                    Expr::Variable {
+                        name: interner.insert("x"),
+                    },
+                    "x".to_string(),
+                ),
+                ActionStmt::Assign {
+                    name: interner.insert("v"),
+                    expr: Expr::Literal {
+                        val: Value::Int { val: 10 },
+                    },
+                },
+                ActionStmt::For {
+                    var: interner.insert("i"),
+                    iterable: Expr::Range {
+                        start: Box::new(Expr::Literal {
+                            val: Value::Int { val: 0 },
+                        }),
+                        end: Box::new(Expr::Literal {
+                            val: Value::Int { val: 5 },
+                        }),
+                    },
+                    body: vec![ActionStmt::Expr(Expr::Variable {
+                        name: interner.insert("i"),
+                    })],
+                },
+            ],
+        },
+    ];
+    let res = check(&program, &mut classes);
+    assert!(res.is_ok())
+}
+
+/// Verify that invalid assign to unbound variable is rejected
+#[test]
+fn test_action_assign_unbound() {
+    let mut classes = Env::new(None);
+    let mut interner = Interner::new();
+    let name_s = interner.insert("s");
+    let program = vec![
+        Stmt::Service {
+            name: name_s,
+            decls: vec![],
+        },
+        Stmt::Test {
+            service_name: name_s,
+            stmts: vec![ActionStmt::Assign {
+                name: interner.insert("unbound"),
+                expr: Expr::Literal {
+                    val: Value::Int { val: 1 },
+                },
+            }],
+        },
+    ];
+    let res = check(&program, &mut classes);
+    assert_eq!(res, Err(Error::UnboundVariable(interner.insert("unbound"))))
+}
+
+/// Verify for loop rejects non-iterable values
+#[test]
+fn test_for_loop_non_iterable() {
+    let mut classes = Env::new(None);
+    let mut interner = Interner::new();
+    let name_s = interner.insert("s");
+    let program = vec![
+        Stmt::Service {
+            name: name_s,
+            decls: vec![],
+        },
+        Stmt::Test {
+            service_name: name_s,
+            stmts: vec![ActionStmt::For {
+                var: interner.insert("i"),
+                iterable: Expr::Literal {
+                    val: Value::Int { val: 42 },
+                },
+                body: vec![],
+            }],
+        },
+    ];
+    let res = check(&program, &mut classes);
+    assert!(res.is_err())
+}
+
+/// Verify unary and binary operations checking
+#[test]
+fn test_operator_checking() {
+    let mut classes = Env::new(None);
+    let mut interner = Interner::new();
+    let name_s = interner.insert("s");
+    let program = vec![Stmt::Service {
+        name: name_s,
+        decls: vec![
+            Decl::VarDecl {
+                name: interner.insert("v1"),
+                ty: Some(Type::Bool),
+                val: Expr::Unop {
+                    op: UnOp::Not,
+                    expr: Box::new(Expr::Literal {
+                        val: Value::Bool { val: false },
+                    }),
+                },
+            },
+            Decl::VarDecl {
+                name: interner.insert("v2"),
+                ty: Some(Type::Int),
+                val: Expr::Binop {
+                    op: BinOp::Sub,
+                    expr1: Box::new(Expr::Literal {
+                        val: Value::Int { val: 10 },
+                    }),
+                    expr2: Box::new(Expr::Literal {
+                        val: Value::Int { val: 5 },
+                    }),
+                },
+            },
+            Decl::VarDecl {
+                name: interner.insert("v3"),
+                ty: Some(Type::Bool),
+                val: Expr::Binop {
+                    op: BinOp::Eq,
+                    expr1: Box::new(Expr::Literal {
+                        val: Value::Int { val: 5 },
+                    }),
+                    expr2: Box::new(Expr::Literal {
+                        val: Value::Int { val: 5 },
+                    }),
+                },
+            },
+        ],
+    }];
+    let res = check(&program, &mut classes);
+    assert!(res.is_ok())
+}
+
+/// Verify type checking of conditional expressions
+#[test]
+fn test_if_expression() {
+    let mut classes = Env::new(None);
+    let mut interner = Interner::new();
+    let name_s = interner.insert("s");
+    let program = vec![Stmt::Service {
+        name: name_s,
+        decls: vec![Decl::VarDecl {
+            name: interner.insert("v"),
+            ty: Some(Type::Int),
+            val: Expr::If {
+                cond: Box::new(Expr::Literal {
+                    val: Value::Bool { val: true },
+                }),
+                expr1: Box::new(Expr::Literal {
+                    val: Value::Int { val: 1 },
+                }),
+                expr2: Box::new(Expr::Literal {
+                    val: Value::Int { val: 2 },
+                }),
+            },
+        }],
+    }];
+    let res = check(&program, &mut classes);
+    assert!(res.is_ok())
+}
+
+/// Verify list checking and empty list failures
+#[test]
+fn test_list_checking() {
+    let mut classes = Env::new(None);
+    let mut interner = Interner::new();
+    let name_s = interner.insert("s");
+    let program = vec![Stmt::Service {
+        name: name_s,
+        decls: vec![Decl::VarDecl {
+            name: interner.insert("xs"),
+            ty: None,
+            val: Expr::List(vec![]),
+        }],
+    }];
+    let res = check(&program, &mut classes);
+    assert_eq!(res, Err(Error::CannotInferType));
+
+    let program2 = vec![Stmt::Service {
+        name: name_s,
+        decls: vec![Decl::VarDecl {
+            name: interner.insert("xs"),
+            ty: Some(Type::List(Box::new(Type::Int))),
+            val: Expr::List(vec![]),
+        }],
+    }];
+    let mut classes2 = Env::new(None);
+    assert!(check(&program2, &mut classes2).is_ok());
+}
+
+/// Verify tuple arity mismatch is rejected
+#[test]
+fn test_tuple_arity_mismatch() {
+    let mut classes = Env::new(None);
+    let mut interner = Interner::new();
+    let name_s = interner.insert("s");
+    let program = vec![Stmt::Service {
+        name: name_s,
+        decls: vec![Decl::VarDecl {
+            name: interner.insert("t"),
+            ty: Some(Type::Tuple(
+                TupleType::new(vec![Type::Int, Type::Int]).unwrap(),
+            )),
+            val: Expr::Tuple {
+                val: vec![Expr::Literal {
+                    val: Value::Int { val: 1 },
+                }],
+            },
+        }],
+    }];
+    let res = check(&program, &mut classes);
+    assert_eq!(res, Err(Error::InvalidTupleArity))
+}
+
+/// Verify member dependencies that are cyclic fail inference
+#[test]
+fn test_circular_dependency() {
+    let mut classes = Env::new(None);
+    let mut interner = Interner::new();
+    let name_s = interner.insert("s");
+    let name_a = interner.insert("a");
+    let name_b = interner.insert("b");
+    let program = vec![Stmt::Service {
+        name: name_s,
+        decls: vec![
+            Decl::VarDecl {
+                name: name_a,
+                ty: None,
+                val: Expr::Variable { name: name_b },
+            },
+            Decl::VarDecl {
+                name: name_b,
+                ty: None,
+                val: Expr::Variable { name: name_a },
+            },
+        ],
+    }];
+    let res = check(&program, &mut classes);
+    assert_eq!(res, Err(Error::CannotInferType))
+}
+
+/// Verify member access across different services
+#[test]
+fn test_cross_service_member_access() {
+    let mut classes = Env::new(None);
+    let mut interner = Interner::new();
+    let s1 = interner.insert("s1");
+    let s2 = interner.insert("s2");
+    let val_x = interner.insert("x");
+    let program = vec![
+        Stmt::Service {
+            name: s1,
+            decls: vec![Decl::VarDecl {
+                name: val_x,
+                ty: Some(Type::Int),
+                val: Expr::Literal {
+                    val: Value::Int { val: 42 },
+                },
+            }],
+        },
+        Stmt::Service {
+            name: s2,
+            decls: vec![Decl::VarDecl {
+                name: interner.insert("y"),
+                ty: Some(Type::Int),
+                val: Expr::MemberAccess {
+                    service_name: s1,
+                    member_name: val_x,
+                },
+            }],
+        },
+    ];
+    let res = check(&program, &mut classes);
+    assert!(res.is_ok())
+}
+
+/// Verify html expressions are typed as string
+#[test]
+fn test_html_expression() {
+    let mut classes = Env::new(None);
+    let mut interner = Interner::new();
+    let name_s = interner.insert("s");
+    let mut builder = HtmlTemplateBuilder::new();
+    builder.push_text("hello");
+    let program = vec![Stmt::Service {
+        name: name_s,
+        decls: vec![Decl::VarDecl {
+            name: interner.insert("h"),
+            ty: Some(Type::String),
+            val: Expr::Html(builder.build()),
+        }],
+    }];
+    let res = check(&program, &mut classes);
+    assert!(res.is_ok())
+}
+
+/// Verify select table and fold placeholders type check
+#[test]
+fn test_placeholder_expressions() {
+    let mut classes = Env::new(None);
+    let mut interner = Interner::new();
+    let name_s = interner.insert("s");
+    let program = vec![Stmt::Service {
+        name: name_s,
+        decls: vec![
+            Decl::VarDecl {
+                name: interner.insert("sel"),
+                ty: Some(Type::List(Box::new(Type::Unit))),
+                val: Expr::Select {
+                    table_name: interner.insert("t"),
+                    column_names: vec![],
+                    where_clause: Box::new(Expr::Literal {
+                        val: Value::Bool { val: true },
+                    }),
+                },
+            },
+            Decl::VarDecl {
+                name: interner.insert("tab"),
+                ty: Some(Type::Unit),
+                val: Expr::Table {
+                    schema: vec![],
+                    records: vec![],
+                },
+            },
+            Decl::VarDecl {
+                name: interner.insert("fld"),
+                ty: Some(Type::Unit),
+                val: Expr::Fold {
+                    table_name: interner.insert("t"),
+                    column_name: interner.insert("c"),
+                    operation: Box::new(Expr::Literal {
+                        val: Value::Int { val: 0 },
+                    }),
+                    identity: Box::new(Expr::Literal {
+                        val: Value::Int { val: 0 },
+                    }),
+                },
+            },
+        ],
+    }];
+    let res = check(&program, &mut classes);
+    assert!(res.is_ok())
+}
+
+/// Verify that invalid function parameters trigger errors
+#[test]
+fn test_function_parameter_mismatches() {
+    let mut classes = Env::new(None);
+    let mut interner = Interner::new();
+    let name_s = interner.insert("s");
+    let p1 = vec![Stmt::Service {
+        name: name_s,
+        decls: vec![Decl::VarDecl {
+            name: interner.insert("f"),
+            ty: Some(Type::Func(Box::new(Type::Int), Box::new(Type::Int))),
+            val: Expr::Func {
+                params: vec![],
+                body: Box::new(Expr::Literal {
+                    val: Value::Int { val: 42 },
+                }),
+                return_ty: None,
+            },
+        }],
+    }];
+    assert!(check(&p1, &mut classes).is_err());
+
+    let p2 = vec![Stmt::Service {
+        name: name_s,
+        decls: vec![Decl::VarDecl {
+            name: interner.insert("f"),
+            ty: Some(Type::Func(Box::new(Type::Int), Box::new(Type::Int))),
+            val: Expr::Func {
+                params: vec![
+                    Param {
+                        name: interner.insert("a"),
+                        ty: None,
+                    },
+                    Param {
+                        name: interner.insert("b"),
+                        ty: None,
+                    },
+                ],
+                body: Box::new(Expr::Literal {
+                    val: Value::Int { val: 42 },
+                }),
+                return_ty: None,
+            },
+        }],
+    }];
+    assert!(check(&p2, &mut classes).is_err());
+}
+
+/// Verify function call arguments and function types are validated
+#[test]
+fn test_call_mismatches() {
+    let mut classes = Env::new(None);
+    let mut interner = Interner::new();
+    let name_s = interner.insert("s");
+    let p1 = vec![Stmt::Service {
+        name: name_s,
+        decls: vec![Decl::VarDecl {
+            name: interner.insert("x"),
+            ty: None,
+            val: Expr::Call {
+                func: Box::new(Expr::Literal {
+                    val: Value::Int { val: 42 },
+                }),
+                args: vec![],
+            },
+        }],
+    }];
+    assert_eq!(check(&p1, &mut classes), Err(Error::NotAFunction));
+
+    let p2 = vec![Stmt::Service {
+        name: name_s,
+        decls: vec![
+            Decl::VarDecl {
+                name: interner.insert("f"),
+                ty: Some(Type::Func(Box::new(Type::Unit), Box::new(Type::Int))),
+                val: Expr::Func {
+                    params: vec![],
+                    body: Box::new(Expr::Literal {
+                        val: Value::Int { val: 42 },
+                    }),
+                    return_ty: None,
+                },
+            },
+            Decl::VarDecl {
+                name: interner.insert("x"),
+                ty: None,
+                val: Expr::Call {
+                    func: Box::new(Expr::Variable {
+                        name: interner.insert("f"),
+                    }),
+                    args: vec![Expr::Literal {
+                        val: Value::Int { val: 1 },
+                    }],
+                },
+            },
+        ],
+    }];
+    assert!(check(&p2, &mut classes).is_err());
+}
+
+/// Verify that mixed lists yield a type mismatch error
+#[test]
+fn test_mixed_list_values() {
+    let mut classes = Env::new(None);
+    let mut interner = Interner::new();
+    let name_s = interner.insert("s");
+    let program = vec![Stmt::Service {
+        name: name_s,
+        decls: vec![Decl::VarDecl {
+            name: interner.insert("xs"),
+            ty: None,
+            val: Expr::Literal {
+                val: Value::List {
+                    vals: vec![
+                        Value::Int { val: 1 },
+                        Value::String {
+                            val: "bad".to_string(),
+                        },
+                    ],
+                },
+            },
+        }],
+    }];
+    let res = check(&program, &mut classes);
+    assert!(res.is_err())
+}
+
+/// Verify keyval expression type inference
+#[test]
+fn test_keyval_expression() {
+    let mut classes = Env::new(None);
+    let mut interner = Interner::new();
+    let name_s = interner.insert("s");
+    let program = vec![Stmt::Service {
+        name: name_s,
+        decls: vec![Decl::VarDecl {
+            name: interner.insert("kv"),
+            ty: Some(Type::Int),
+            val: Expr::KeyVal {
+                name: interner.insert("k"),
+                value: Box::new(Expr::Literal {
+                    val: Value::Int { val: 1 },
+                }),
+            },
+        }],
+    }];
+    let res = check(&program, &mut classes);
+    assert!(res.is_ok())
+}
+
+/// Verify tuple with single element is rejected during inference
+#[test]
+fn test_tuple_single_element_inference() {
+    let mut classes = Env::new(None);
+    let mut interner = Interner::new();
+    let name_s = interner.insert("s");
+    let program = vec![Stmt::Service {
+        name: name_s,
+        decls: vec![Decl::VarDecl {
+            name: interner.insert("t"),
+            ty: None,
+            val: Expr::Tuple {
+                val: vec![Expr::Literal {
+                    val: Value::Int { val: 1 },
+                }],
+            },
+        }],
+    }];
+    let res = check(&program, &mut classes);
+    assert_eq!(res, Err(Error::InvalidTupleArity))
+}

--- a/meerkat-lib/src/runtime/tt/mod.rs
+++ b/meerkat-lib/src/runtime/tt/mod.rs
@@ -1,7 +1,10 @@
-//! Type system module
+//! Module for the type system
 
+pub mod check;
 pub mod types;
 
+pub use check::check;
+pub use check::Error;
 pub use types::Param;
 pub use types::ServiceType;
 pub use types::TupleType;

--- a/meerkat-lib/src/runtime/tt/types.rs
+++ b/meerkat-lib/src/runtime/tt/types.rs
@@ -20,6 +20,7 @@ pub enum Type {
     Tuple(TupleType),
     Func(Box<Type>, Box<Type>),
     List(Box<Type>),
+    UnresolvedService(Symbol),
 }
 
 /// Type representation of a Meerkat service
@@ -251,7 +252,12 @@ impl std::fmt::Display for Type {
                         write!(f, "({}) -> {}", t1, t2)
                     }
                     Type::Unit => write!(f, "() -> {}", t2),
-                    Type::Int | Type::String | Type::Bool | Type::Tuple(_) | Type::List(_) => {
+                    Type::Int
+                    | Type::String
+                    | Type::Bool
+                    | Type::Tuple(_)
+                    | Type::List(_)
+                    | Type::UnresolvedService(_) => {
                         write!(f, "{} -> {}", t1, t2)
                     }
                 }
@@ -260,6 +266,7 @@ impl std::fmt::Display for Type {
                 Type::Func(..) => write!(f, "({}) list", t),
                 _ => write!(f, "{} list", t),
             },
+            Type::UnresolvedService(s) => write!(f, "unresolved_service({})", s),
         }
     }
 }

--- a/meerkat-lib/tests/types_integration_test.rs
+++ b/meerkat-lib/tests/types_integration_test.rs
@@ -885,3 +885,21 @@ fn test_integration_indirect_member_reference() {
     ";
     assert!(check_program(input).is_ok())
 }
+
+/// Verify that a well-typed watch statement passes checks
+#[test]
+fn test_integration_watch_well_typed() {
+    let input = "
+        watch 1 + 2;
+    ";
+    assert!(check_program(input).is_ok())
+}
+
+/// Verify that an ill-typed watch statement is rejected
+#[test]
+fn test_integration_watch_ill_typed() {
+    let input = "
+        watch 1 + \"hello\";
+    ";
+    assert!(check_program(input).is_err())
+}

--- a/meerkat-lib/tests/types_integration_test.rs
+++ b/meerkat-lib/tests/types_integration_test.rs
@@ -1,0 +1,887 @@
+//! Static type checking integration tests
+
+use meerkat_lib::runtime::{node::Node, parser::parse_string};
+
+/// Helper to parse and type check a string program
+fn check_program(input: &str) -> Result<(), String> {
+    let mut node = Node::new();
+    let prog = parse_string(input, &mut node.interner)
+        .map_err(|e| format!("Parse error: {}", e))
+        .unwrap();
+    node.check(&prog).map_err(|e| e.to_string())
+}
+
+/// Verify that basic primitive types check correctly
+#[test]
+fn test_integration_primitive_types() {
+    let input = "
+        service employee_db {
+            def base: int = 5000;
+            def name: string = \"Alice Smith\";
+            def active: bool = true;
+            def get_salary: (int, bool) -> int =
+                fn (bonus: int, manager: bool) =>
+                    if active && manager then base + bonus * 2 else base;
+        }
+    ";
+    let res = check_program(input);
+    assert!(res.is_ok())
+}
+
+/// Verify that type mismatches on primitives are rejected
+#[test]
+fn test_integration_primitive_mismatch() {
+    let input = "
+        service employee_db {
+            def base: int = 5000;
+            def name: string = \"Alice Smith\";
+            def bad_salary: (string) -> int =
+                fn (bonus: string) => base + bonus;
+        }
+    ";
+    let res = check_program(input);
+    assert!(res.is_err());
+    let err = res.unwrap_err();
+    assert!(err.contains("Type check error"))
+}
+
+/// Verify annotated function parameters and return types
+#[test]
+fn test_integration_function_checking() {
+    let input = "
+        service calc_pipeline {
+            def pipeline: ((int) -> int, (int) -> bool) -> (int) -> bool =
+                fn (f: (int) -> int, g: (int) -> bool) =>
+                    fn (x: int) => g(f(x));
+        }
+    ";
+    let res = check_program(input);
+    assert!(res.is_ok())
+}
+
+/// Verify incorrect function call argument types are rejected
+#[test]
+fn test_integration_function_call_mismatch() {
+    let input = "
+        service calc_pipeline {
+            def f: (int) -> bool = fn (x: int) => x > 0;
+            def bad_call: bool = f(\"not_an_int\");
+        }
+    ";
+    let res = check_program(input);
+    assert!(res.is_err())
+}
+
+/// Verify unannotated closures fail if params cannot be inferred
+#[test]
+fn test_integration_unannotated_closure_fails() {
+    let input = "
+        service inference_fail_service {
+            def run = fn x => fn y => x + y;
+        }
+    ";
+    let res = check_program(input);
+    assert!(res.is_err())
+}
+
+/// Verify unannotated closures succeed with annotated bindings
+#[test]
+fn test_integration_unannotated_closure_with_annotated_binding() {
+    let input = "
+        service inference_success_service {
+            def run: (int) -> (int) -> int =
+                fn x => fn y => x + y;
+        }
+    ";
+    let res = check_program(input);
+    assert!(res.is_ok())
+}
+
+/// Verify list constructors check elements against inner type
+#[test]
+fn test_integration_list_checking() {
+    let input = "
+        service list_service {
+            def matrix: int list list = [
+                [1, 2, 3],
+                [4 + 5, 6 / 2],
+                [10 * 3]
+            ];
+        }
+    ";
+    let res = check_program(input);
+    assert!(res.is_ok())
+}
+
+/// Verify list elements violating expected type are rejected
+#[test]
+fn test_integration_list_element_mismatch() {
+    let input = "
+        service list_service {
+            def matrix: int list list = [
+                [1, 2],
+                [\"bad\", 4]
+            ];
+        }
+    ";
+    let res = check_program(input);
+    assert!(res.is_err())
+}
+
+/// Verify that tuples are checked and element arity is validated
+#[test]
+fn test_integration_tuple_checking() {
+    let input = "
+        service tuple_service {
+            def data: ((int, bool), string, unit) =
+                {{42, true}, \"ok\", {}};
+        }
+    ";
+    let res = check_program(input);
+    assert!(res.is_ok())
+}
+
+/// Verify that tuple element type mismatch is rejected
+#[test]
+fn test_integration_tuple_element_mismatch() {
+    let input = "
+        service tuple_service {
+            def data: ((int, bool), string, unit) =
+                {{42, \"bad_bool\"}, \"ok\", {}};
+        }
+    ";
+    let res = check_program(input);
+    assert!(res.is_err())
+}
+
+/// Verify compound arithmetic binary operations
+#[test]
+fn test_integration_arithmetic_operators() {
+    let input = "
+        service calc {
+            def complex_calc: (int, int) -> int =
+                fn (x: int, y: int) =>
+                    (x + y) * (x - y) / (x + 10);
+        }
+    ";
+    assert!(check_program(input).is_ok())
+}
+
+/// Verify addition with type mismatch is rejected
+#[test]
+fn test_integration_binop_add_mismatch() {
+    let input = "
+        service calc {
+            def complex_add: (int) -> int =
+                fn (x: int) => x + \"invalid\";
+        }
+    ";
+    assert!(check_program(input).is_err())
+}
+
+/// Verify comparison operators produce boolean output
+#[test]
+fn test_integration_comparison_operators() {
+    let input = "
+        service calc {
+            def check: (int, int) -> bool =
+                fn (x: int, y: int) =>
+                    (x < y) && (x > 0);
+        }
+    ";
+    assert!(check_program(input).is_ok())
+}
+
+/// Verify boolean equality check
+#[test]
+fn test_integration_binop_eq_bool() {
+    let input = "
+        service calc {
+            def is_equal: bool = (true && false) == (false || true);
+        }
+    ";
+    assert!(check_program(input).is_ok())
+}
+
+/// Verify equality check mismatch is rejected
+#[test]
+fn test_integration_binop_eq_mismatch() {
+    let input = "
+        service logic {
+            def check: (bool, int) -> bool =
+                fn (a: bool, x: int) => a == x;
+        }
+    ";
+    assert!(check_program(input).is_err())
+}
+
+/// Verify logical conjunction and disjunction operators
+#[test]
+fn test_integration_logic_operators() {
+    let input = "
+        service logic {
+            def check: (bool, bool, bool) -> bool =
+                fn (a: bool, b: bool, c: bool) =>
+                    (a && b) || (b && c) || !a;
+        }
+    ";
+    assert!(check_program(input).is_ok())
+}
+
+/// Verify logical conjunction mismatch is rejected
+#[test]
+fn test_integration_binop_and_mismatch() {
+    let input = "
+        service logic {
+            def check: (bool) -> bool =
+                fn (a: bool) => a && 42;
+        }
+    ";
+    assert!(check_program(input).is_err())
+}
+
+/// Verify logical negation checks as bool
+#[test]
+fn test_integration_unop_not() {
+    let input = "
+        service logic {
+            def invert: (bool) -> bool =
+                fn (a: bool) => !(!a && a);
+        }
+    ";
+    assert!(check_program(input).is_ok())
+}
+
+/// Verify logical negation mismatch is rejected
+#[test]
+fn test_integration_unop_not_mismatch() {
+    let input = "
+        service logic {
+            def invert: (int) -> bool =
+                fn (x: int) => !x;
+        }
+    ";
+    assert!(check_program(input).is_err())
+}
+
+/// Verify arithmetic negation checks as int
+#[test]
+fn test_integration_unop_neg() {
+    let input = "
+        service calc {
+            def neg: (int) -> int =
+                fn (x: int) => -(-x + 10) * -5;
+        }
+    ";
+    assert!(check_program(input).is_ok())
+}
+
+/// Verify arithmetic negation mismatch is rejected
+#[test]
+fn test_integration_unop_neg_mismatch() {
+    let input = "
+        service calc {
+            def neg: (string) -> int =
+                fn (s: string) => -s;
+        }
+    ";
+    assert!(check_program(input).is_err())
+}
+
+/// Verify empty tuple checks as unit
+#[test]
+fn test_integration_empty_tuple() {
+    let input = "
+        service tuple_service {
+            def empty: () -> unit =
+                fn () => {};
+        }
+    ";
+    assert!(check_program(input).is_ok())
+}
+
+/// Verify nesting of tuple types
+#[test]
+fn test_integration_nested_tuple() {
+    let input = "
+        service tuple_service {
+            def transform: (((int, bool), string)) -> ((int, bool), string) =
+                fn (x: ((int, bool), string)) => x;
+        }
+    ";
+    assert!(check_program(input).is_ok())
+}
+
+/// Verify checking of tertiary tuple
+#[test]
+fn test_integration_tuple_arity_three() {
+    let input = "
+        service tuple_service {
+            def transform: ((int, bool, string)) -> (int, bool, string) =
+                fn (x: (int, bool, string)) => x;
+        }
+    ";
+    assert!(check_program(input).is_ok())
+}
+
+/// Verify that mismatch in tuple arity is rejected
+#[test]
+fn test_integration_tuple_arity_mismatch_three() {
+    let input = "
+        service tuple_service {
+            def transform: ((int, bool, string)) -> (int, bool) =
+                fn (x: (int, bool, string)) => x;
+        }
+    ";
+    assert!(check_program(input).is_err())
+}
+
+/// Verify nesting of list types
+#[test]
+fn test_integration_nested_lists() {
+    let input = "
+        service list_service {
+            def check_list: (int list list list) -> int list list list =
+                fn (xs: int list list list) => xs;
+        }
+    ";
+    assert!(check_program(input).is_ok())
+}
+
+/// Verify empty list without annotation fails inference
+#[test]
+fn test_integration_list_empty_inference_fail() {
+    let input = "
+        service list_service {
+            def bad = fn x => [x, []];
+        }
+    ";
+    assert!(check_program(input).is_err())
+}
+
+/// Verify empty list with annotation checks successfully
+#[test]
+fn test_integration_list_empty_annotation() {
+    let input = "
+        service list_service {
+            def empty: (int list) -> int list =
+                fn (xs: int list) => [];
+        }
+    ";
+    assert!(check_program(input).is_ok())
+}
+
+/// Verify nullary function call checks correctly
+#[test]
+fn test_integration_nullary_function_call() {
+    let input = "
+        service fun_service {
+            def make_generator: (int) -> () -> int =
+                fn (x: int) => fn () => x;
+            def test_call: int = make_generator(42)();
+        }
+    ";
+    assert!(check_program(input).is_ok())
+}
+
+/// Verify nullary function call with arguments is rejected
+#[test]
+fn test_integration_nullary_function_call_with_args() {
+    let input = "
+        service fun_service {
+            def make_generator: (int) -> () -> int =
+                fn (x: int) => fn () => x;
+            def test_call: int = make_generator(42)(10);
+        }
+    ";
+    assert!(check_program(input).is_err())
+}
+
+/// Verify multi argument function call
+#[test]
+fn test_integration_multi_arg_function_call() {
+    let input = "
+        service fun_service {
+            def process: (int, string, bool) -> ((int, string), bool) =
+                fn (x: int, s: string, b: bool) => {{x, s}, b};
+            def test_call: ((int, string), bool) =
+                process(42, \"hello\", true);
+        }
+    ";
+    assert!(check_program(input).is_ok())
+}
+
+/// Verify multi argument function call argument count mismatch
+#[test]
+fn test_integration_multi_arg_function_call_mismatch() {
+    let input = "
+        service fun_service {
+            def process: (int, string, bool) -> ((int, string), bool) =
+                fn (x: int, s: string, b: bool) => {{x, s}, b};
+            def test_call: ((int, string), bool) =
+                process(42, \"hello\");
+        }
+    ";
+    assert!(check_program(input).is_err())
+}
+
+/// Verify higher order function type checking
+#[test]
+fn test_integration_higher_order_function() {
+    let input = "
+        service fun_service {
+            def apply_twice: ((int) -> int, int) -> int =
+                fn (f: (int) -> int, x: int) => f(f(x));
+        }
+    ";
+    assert!(check_program(input).is_ok())
+}
+
+/// Verify valid conditional expressions
+#[test]
+fn test_integration_if_expr_valid() {
+    let input = "
+        service cond_service {
+            def choose: (bool, int, int) -> int =
+                fn (cond: bool, a: int, b: int) =>
+                    (if (cond && (a > b)) then a + 10 else b - 10);
+        }
+    ";
+    assert!(check_program(input).is_ok())
+}
+
+/// Verify conditional expression with non boolean cond is rejected
+#[test]
+fn test_integration_if_expr_cond_mismatch() {
+    let input = "
+        service cond_service {
+            def choose: (int, int, int) -> int =
+                fn (cond: int, a: int, b: int) =>
+                    (if (cond) then a else b);
+        }
+    ";
+    assert!(check_program(input).is_err())
+}
+
+/// Verify conditional expression with mismatched branches is rejected
+#[test]
+fn test_integration_if_expr_branch_mismatch() {
+    let input = "
+        service cond_service {
+            def choose: (bool, int, string) -> int =
+                fn (cond: bool, a: int, b: string) =>
+                    (if (cond) then a else b);
+        }
+    ";
+    assert!(check_program(input).is_err())
+}
+
+/// Verify range expressions check as int list
+#[test]
+fn test_integration_range_expr_valid() {
+    let input = "
+        service range_service {
+            def build_range: (int, int) -> int list =
+                fn (start: int, end: int) => (start + 1)..(end - 1);
+        }
+    ";
+    assert!(check_program(input).is_ok())
+}
+
+/// Verify range expressions with non integer bounds are rejected
+#[test]
+fn test_integration_range_expr_mismatch() {
+    let input = "
+        service range_service {
+            def build_range: (int, string) -> int list =
+                fn (start: int, end: string) => start..end;
+        }
+    ";
+    assert!(check_program(input).is_err())
+}
+
+/// Verify annotated action let statements inside tests
+#[test]
+fn test_integration_action_let_annotated() {
+    let input = "
+        service test_s {}
+        @test(test_s) {
+            let x: ((int, string) list) = [
+                {1, \"first\"},
+                {2, \"second\"}
+            ];
+        }
+    ";
+    assert!(check_program(input).is_ok())
+}
+
+/// Verify unannotated action let statements inside tests
+#[test]
+fn test_integration_action_let_unannotated() {
+    let input = "
+        service test_s {}
+        @test(test_s) {
+            let x = [
+                {1, \"first\"},
+                {2, \"second\"}
+            ];
+        }
+    ";
+    assert!(check_program(input).is_ok())
+}
+
+/// Verify valid mutable assignment in tests
+#[test]
+fn test_integration_action_assign_valid() {
+    let input = "
+        service test_s {
+            var counter: int = 0;
+        }
+        @test(test_s) {
+            counter = (counter + 1) * 10 / 2;
+        }
+    ";
+    assert!(check_program(input).is_ok())
+}
+
+/// Verify mutable assignment type mismatch in tests
+#[test]
+fn test_integration_action_assign_mismatch() {
+    let input = "
+        service test_s {
+            var counter: int = 0;
+        }
+        @test(test_s) {
+            counter = \"invalid\";
+        }
+    ";
+    assert!(check_program(input).is_err())
+}
+
+/// Verify assert statements in test blocks
+#[test]
+fn test_integration_action_assert_valid() {
+    let input = "
+        service test_s {
+            def check: (int) -> bool = fn (x: int) => x > 0;
+        }
+        @test(test_s) {
+            assert(check(10) && !check(-5));
+        }
+    ";
+    assert!(check_program(input).is_ok())
+}
+
+/// Verify assert statements with non boolean expressions fail
+#[test]
+fn test_integration_action_assert_mismatch() {
+    let input = "
+        service test_s {
+            def check: (int) -> int = fn (x: int) => x;
+        }
+        @test(test_s) {
+            assert(check(10));
+        }
+    ";
+    assert!(check_program(input).is_err())
+}
+
+/// Verify valid for loops in test blocks
+#[test]
+fn test_integration_action_for_valid() {
+    let input = "
+        service test_s {}
+        @test(test_s) {
+            let limits: int list = 0..10;
+            for i in limits {
+                let x: int = i * i;
+            }
+        }
+    ";
+    assert!(check_program(input).is_ok())
+}
+
+/// Verify for loops over non iterables are rejected
+#[test]
+fn test_integration_action_for_mismatch() {
+    let input = "
+        service test_s {}
+        @test(test_s) {
+            for i in fn (x: int) => x {
+                let x = i;
+            }
+        }
+    ";
+    assert!(check_program(input).is_err())
+}
+
+/// Verify member access across services
+#[test]
+fn test_integration_cross_service_access() {
+    let input = "
+        service db_service {
+            def user: (int, string) = {42, \"Bob\"};
+        }
+        service api_service {
+            def fetch_user: () -> (int, string) =
+                fn () => db_service.user;
+        }
+    ";
+    assert!(check_program(input).is_ok())
+}
+
+/// Verify member access type mismatch is rejected
+#[test]
+fn test_integration_cross_service_access_mismatch() {
+    let input = "
+        service db_service {
+            def user: (int, string) = {42, \"Bob\"};
+        }
+        service api_service {
+            def fetch_user: () -> (bool, string) =
+                fn () => db_service.user;
+        }
+    ";
+    assert!(check_program(input).is_err())
+}
+
+/// Verify unbound member access across services is rejected
+#[test]
+fn test_integration_cross_service_access_unbound() {
+    let input = "
+        service db_service {}
+        service api_service {
+            def fetch_user: () -> (int, string) =
+                fn () => db_service.user;
+        }
+    ";
+    assert!(check_program(input).is_err())
+}
+
+/// Verify type checking of nested function signatures
+#[test]
+fn test_integration_nested_function_types() {
+    let input = "
+        service test_s {
+            def f: (int) -> (bool) -> (string) -> (unit) -> int =
+                fn (x: int) => fn (b: bool) =>
+                    fn (s: string) => fn (u: unit) => x;
+        }
+    ";
+    assert!(check_program(input).is_ok())
+}
+
+/// Verify unannotated self referencing variables are rejected
+#[test]
+fn test_integration_self_referencing_def_fail() {
+    let input = "
+        service test_s {
+            def x = fn () => x();
+        }
+    ";
+    assert!(check_program(input).is_err())
+}
+
+/// Verify HTML literals are typed as string
+#[test]
+fn test_integration_html_literal() {
+    let input = "
+        service test_s {
+            def html_val: string = (<div>The value is {10 + 20}</div>);
+        }
+    ";
+    assert!(check_program(input).is_ok())
+}
+
+/// Verify basic string operations type check
+#[test]
+fn test_integration_string_operations() {
+    let input = "
+        service test_s {
+            def a: string = \"hello\";
+            def b: string = a;
+        }
+    ";
+    assert!(check_program(input).is_ok())
+}
+
+/// Verify multiple services with independent scopes
+#[test]
+fn test_integration_multiple_services_independent() {
+    let input = "
+        service s1 {
+            def f: (int) -> int = fn (x: int) => x;
+        }
+        service s2 {
+            def f: (string) -> string = fn (s: string) => s;
+        }
+    ";
+    assert!(check_program(input).is_ok())
+}
+
+/// Verify empty service definition
+#[test]
+fn test_integration_empty_service() {
+    let input = "
+        service test_s {}
+    ";
+    assert!(check_program(input).is_ok())
+}
+
+/// Verify type inference on unannotated definitions
+#[test]
+fn test_integration_var_decl_type_inferred() {
+    let input = "
+        service test_s {
+            def x = {42, \"hello\"};
+            def y: (int, string) = x;
+        }
+    ";
+    assert!(check_program(input).is_ok())
+}
+
+/// Verify let scoping rules within test blocks
+#[test]
+fn test_integration_multiple_lets_scoping() {
+    let input = "
+        service test_s {}
+        @test(test_s) {
+            let a: (int) -> int = fn (x: int) => x + 1;
+            let b: (int) -> int = fn (y: int) => a(y) * 2;
+        }
+    ";
+    assert!(check_program(input).is_ok())
+}
+
+/// Verify shadowing of let variables in nested blocks
+#[test]
+fn test_integration_shadowing_let_valid() {
+    let input = "
+        service test_s {}
+        @test(test_s) {
+            let x: int = 10;
+            for i in 0..2 {
+                let x: (string, bool) = {\"shadowed\", true};
+                let y: (string, bool) = x;
+            }
+        }
+    ";
+    assert!(check_program(input).is_ok())
+}
+
+/// Verify unannotated def definitions infer types
+#[test]
+fn test_integration_unannotated_def() {
+    let input = "
+        service test_s {
+            def x = 42;
+        }
+    ";
+    assert!(check_program(input).is_ok())
+}
+
+/// Verify annotated def definitions check types
+#[test]
+fn test_integration_annotated_def() {
+    let input = "
+        service test_s {
+            def x: int = 42;
+        }
+    ";
+    assert!(check_program(input).is_ok())
+}
+
+/// Verify recursive lambda via mutable service variable
+#[test]
+fn test_integration_recursive_lambda_via_mutable_var() {
+    let input = "
+        service test_s {
+            var f: (int) -> int = fn (x: int) => x;
+        }
+        @test(test_s) {
+            f = fn (x: int) =>
+                (if (x == 0) then 1 else f(x - 1));
+        }
+    ";
+    assert!(check_program(input).is_ok())
+}
+
+/// Verify deeply nested lambda variable capturing and scoping
+#[test]
+fn test_integration_nested_lambdas_scoping() {
+    let input = "
+        service nested_lambda_service {
+            def run: (int) -> (int) -> (int) -> int =
+                fn (x: int) => fn (y: int) =>
+                    fn (z: int) => x + y + z;
+        }
+    ";
+    assert!(check_program(input).is_ok())
+}
+
+/// Verify annotated immediately invoked function expressions
+#[test]
+fn test_integration_iifa_annotated() {
+    let input = "
+        service iifa_service {
+            def val: int = (fn (x: int) => x + 10)(32);
+        }
+    ";
+    assert!(check_program(input).is_ok())
+}
+
+/// Verify unannotated immediately invoked function expressions fail
+#[test]
+fn test_integration_iifa_unannotated_fails() {
+    let input = "
+        service iifa_service {
+            def val: int = (fn x => x + 10)(32);
+        }
+    ";
+    assert!(check_program(input).is_err())
+}
+
+/// Verify action expressions without type annotations
+#[test]
+fn test_integration_action_expression_unannotated() {
+    let input = "
+        service action_service {
+            def run = fn () => action {
+                let x = 10;
+            };
+        }
+    ";
+    assert!(check_program(input).is_ok())
+}
+
+/// Verify unannotated action closures
+#[test]
+fn test_integration_action_closure_unannotated() {
+    let input = "
+        service action_service {
+            var state: int = 0;
+            def update_state: (int) -> unit =
+                fn x => action {
+                    state = x;
+                };
+        }
+    ";
+    assert!(check_program(input).is_ok())
+}
+
+/// Verify chains of indirect service member references
+#[test]
+fn test_integration_indirect_member_reference() {
+    let input = "
+        service s1 {
+            def val: int = 42;
+        }
+        service s2 {
+            def get: () -> int = fn () => s1.val;
+        }
+        service s3 {
+            def get: () -> int = fn () => s2.get();
+        }
+    ";
+    assert!(check_program(input).is_ok())
+}

--- a/meerkat-lib/tests/types_integration_test.rs
+++ b/meerkat-lib/tests/types_integration_test.rs
@@ -7,7 +7,7 @@ fn check_program(input: &str) -> Result<(), String> {
     let mut node = Node::new();
     let prog = parse_string(input, &mut node.interner)
         .map_err(|e| format!("Parse error: {}", e))
-        .unwrap();
+        .expect("Test program input must be syntactically valid.");
     node.check(&prog).map_err(|e| e.to_string())
 }
 
@@ -41,7 +41,7 @@ fn test_integration_primitive_mismatch() {
     ";
     let res = check_program(input);
     assert!(res.is_err());
-    let err = res.unwrap_err();
+    let err = res.expect_err("Type checking must fail.");
     assert!(err.contains("Type check error"))
 }
 

--- a/meerkat/tests/test_types.mkt
+++ b/meerkat/tests/test_types.mkt
@@ -1,0 +1,168 @@
+// Comprehensive grammar and type checking test demonstration
+
+// Import statement grammar rule
+import type_inference_demo
+
+// Watch statement grammar rule
+watch type_checking_demo.explicit_int;
+
+//////////////////////////////////////////////////////////////////////
+// Section 1: Synthesis Mode
+//
+// Shows how synthesis mode infers the types of expressions bottom-up
+// solely from their sub-components. The motivation is to automate type
+// inference for primitive literals, tuples, and constructs that possess
+// sufficient local type information, eliminating the boilerplate of
+// explicit annotations for self-contained expressions.
+//////////////////////////////////////////////////////////////////////
+
+service type_inference_demo {
+    // Primitive type inference
+    def inferred_int = 42;
+    def inferred_bool = true;
+    def inferred_string = "hello";
+
+    // Tuple type inference
+    def inferred_tuple = {100, false, "inferred"};
+
+    // List type inference
+    def inferred_list = [1, 2, 3, 4];
+
+    // Nested tuple and list type inference
+    def inferred_nested = {{10, true}, ["a", "b"]};
+
+    // Unannotated closure inference inside expected context
+    def mock_map: ((int) -> string, int list) -> string list =
+        fn (f: (int) -> string, xs: int list) => [];
+
+    // The closure argument type is inferred bidirectionally
+    def mapped_result =
+        mock_map(fn x => "inferred_str", [1, 2]);
+
+    // Table declaration with primitive fields
+    table users {
+        id: int,
+        name: string,
+        active: bool,
+    };
+
+    // Table selection returning list of units
+    def active_users =
+        select id, name from users where active;
+
+    // Table fold operation returning unit
+    def folded_val =
+        fold(users.id, fn (acc: int, item: int) => acc + item, 0);
+
+    // Key-value expression construct
+    def kv_expr = test_key : 42;
+
+    // Mutable variables for state tracking
+    var mutable_val = 10;
+    var recurse: (int) -> int = fn (val: int) => val;
+}
+
+
+//////////////////////////////////////////////////////////////////////
+// Section 2: Checking Mode
+//
+// Shows how checking mode propagates expected types down to type check
+// terms that cannot be inferred in isolation. By pushing expected
+// types down, it allows checking of unannotated closures, empty lists,
+// and other syntactical forms that lack sufficient local type context
+// to synthesize types on their own.
+//////////////////////////////////////////////////////////////////////
+
+service type_checking_demo {
+    // Annotated primitive check
+    def explicit_int: int = 100;
+    def explicit_bool: bool = false;
+
+    // Annotated tuple type check
+    def explicit_tuple: (int, bool, string) =
+        {10, true, "checked"};
+
+    // Annotated list type check
+    def explicit_list: int list = [1, 2, 3];
+
+    // Annotated nested tuple and list type check
+    def explicit_nested: ((int, bool), string list) =
+        {{20, false}, ["checked_str"]};
+
+    // Annotated closure parameter check
+    def explicit_closure: (int) -> string =
+        fn (val: int) => "checked_val";
+
+    // Annotated curried closure check
+    def explicit_curry: (int) -> (bool) -> string =
+        fn (x: int) => fn (y: bool) => "curried";
+
+    // Immediately Invoked Function Application (IIFA)
+    def explicit_iifa: int =
+        (fn (val: int) => val * 2)(50);
+
+    // HTML template literal check
+    def html_val: string =
+        (<div>The value is {explicit_int}</div>);
+}
+
+
+//////////////////////////////////////////////////////////////////////
+// Section 3: Cross-Service Referencing & Scoping
+//
+// Demonstrates references to members across service scopes.
+//////////////////////////////////////////////////////////////////////
+
+service cross_service_ref_demo {
+    // Reference inferred types from type_inference_demo
+    def ref_inferred_int: int =
+        type_inference_demo.inferred_int;
+
+    def ref_inferred_tuple: (int, bool, string) =
+        type_inference_demo.inferred_tuple;
+
+    // Reference explicitly checked types from type_checking_demo
+    def ref_checked_int: int =
+        type_checking_demo.explicit_int;
+
+    // Combine referenced values from multiple services
+    def sum_services: int =
+        type_inference_demo.inferred_int +
+        type_checking_demo.explicit_int;
+
+    // Internal state tracking variable
+    var state: int = 0;
+
+    // Action closure modifying current service variables
+    def update_state: (int) -> unit =
+        fn (new_val: int) => action {
+            state = new_val;
+        };
+}
+
+// Test block driving actions, loops, and bidirectional validation
+@test(type_inference_demo) {
+    // Scoped let bindings with explicit types
+    let checked_local: int = 50;
+
+    // Scoped let bindings using inference
+    let inferred_local = {10, "local"};
+
+    // Loops over integer range collections
+    for i in 0..5 {
+        let doubled: int = i * 2;
+    }
+
+    // Insert statements in action blocks
+    insert {1, "Bob", true} into users
+
+    // Do command execution of action closures
+    do cross_service_ref_demo.update_state(checked_local);
+
+    // Recursive function initialization inside test action block
+    recurse = fn (val: int) =>
+        (if (val == 0) then 1 else recurse(val - 1));
+
+    // Verification checks of properties using assertions
+    assert((checked_local > 0) && (inferred_local == {10, "local"}));
+}

--- a/meerkat/tests/test_types.mkt
+++ b/meerkat/tests/test_types.mkt
@@ -1,8 +1,5 @@
 // Comprehensive grammar and type checking test demonstration
 
-// Import statement grammar rule
-import type_inference_demo
-
 // Watch statement grammar rule
 watch type_checking_demo.explicit_int;
 
@@ -48,7 +45,7 @@ service type_inference_demo {
 
     // Table selection returning list of units
     def active_users =
-        select id, name from users where active;
+        select id, name from users where users.active;
 
     // Table fold operation returning unit
     def folded_val =


### PR DESCRIPTION
Introduce an augmented bidirectional type checking (BDTC) algorithm to maximize developer productivity. Closes Issue #34. By deliberately relaxing strict polarity and providing synthesis rules for constructors like tuples and annotated lambdas, this approach avoids the burden of explicit type annotations on right-hand side bindings while maintaining full static safety.

This implementation draws inspiration from Professor Frank Pfenning's [lecture notes on BDTC algorithms](https://www.cs.cmu.edu/~fp/courses/15312-f04/handouts/15-bidirectional.pdf). It polarizes the AST into introduction forms (which naturally check expected types) and elimination forms (which naturally synthesize types bottom-up) via the mutually recursive `infer` and `check_*` family of operations.

Implemented as the final match arm in the `check_expr` routine within the `tt::check` module, a central bridge rule (`chk/syn`) connects the two modes. When checking encounters an eliminator, this rule transitions seamlessly to inference, evaluating the expression and validating the synthesized result against the expected type context.

To handle function types, the algorithm enforces a clear boundary on unannotated closures. Because parameter types cannot be guessed from thin air without global constraint solving, unannotated closures must be checked against an expected type pushed down by the bridge rule. If a closure lacks both parameter annotations and an expected context, the checker safely rejects it with a clear, localized error.

During traversal, transient block-scoped variables (such as `let` bindings inside actions) are tracked using a lightweight, stacked `Env<'_, Type>`. This local environment is strictly bound by the system's `MAX_SCOPE_DEPTH` limit to prevent stack exhaustion on deeply nested blocks.

Similarly, structural equality checks between recursive types are heavily guarded by `MAX_TYPE_DEPTH`. This guarantees that comparing infinite or deeply malicious type structures during the bridge rule application will always terminate safely.

Rather than discarding type information after the pass, all constructed types are permanently stored in the `Node` state via its `service_classes` environment. This persists the validated signatures for subsequent runtime evaluation, API introspection, and eventual live code update comparisons.

Static name resolution does not currently implement checks for `update` statements, `import` declarations, and table types (including `select`, `fold`, and `insert`) due to Issue #34. When name resolution is updated to fully support these features, the type checking system will also need to be updated to match. This is tracked for follow up in Issue #156.

Key changes:

- Implement recursive `infer` and `check_*` family of routines
- Implement the bridge rule inside `check_expr` to connect modes
- Add augmented synthesis rules to reduce annotation burden
- Enforce strict rejection of context-free unannotated closures
- Guard type environment traversal with `MAX_SCOPE_DEPTH` limits
- Protect recursive type comparisons with `MAX_TYPE_DEPTH` bounds
- Propagate inferred types into `Node` service classes
- Introduce 67 integration tests covering all grammar rules
- Add inline unit tests with full coverage inside the submodule

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added an augmented bidirectional static type checker covering services, expressions, collections, function calls, and action/test blocks, including `watch` validation and cross-service member typing.

* **Bug Fixes**
  * Program validation now propagates name-resolution issues into type-checking results more reliably.
  * Improved member-access behavior: imported remote service members are handled correctly, while unknown service members now produce a hard unbound-variable type error.

* **Tests**
  * Expanded Rust integration coverage for member access and error formatting.
  * Added a comprehensive Meerkat type-checking demo program exercising inference, annotations, and action semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->