### PR TITLE
Issue #151: add --identity flag for a stable Peer ID across restarts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,10 @@ target
 !/.vscode/extensions.json
 **/.DS_Store
 
-#!src/utils/debug/ 
+#!src/utils/debug/
+
+# Meerkat server keys for use with --identity
+**/*.key
 
 # Temporary folders
 tmp/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2308,6 +2308,7 @@ dependencies = [
  "tokio",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "web-sys",
  "web-time",
 ]
 

--- a/docs/identity.md
+++ b/docs/identity.md
@@ -1,0 +1,35 @@
+# Persistent node identity (`--identity`)
+
+By default, a Meerkat server generates a new random keypair each time it starts,
+so its Peer ID changes on every restart. The `--identity` option makes the Peer
+ID stable across restarts by persisting the keypair to disk. A stable Peer ID
+means a web page (or any client) can embed a fixed server address.
+
+## Usage
+
+    meerkat -f service.mkt --server --identity path/to/identity.key
+
+If the file at the given path exists, the keypair is loaded from it and the
+server reuses the same Peer ID. If the file does not exist, Meerkat generates a
+new ed25519 keypair, saves it to that path, and uses it. Later runs with the
+same path reuse that keypair.
+
+Omit `--identity` to keep the default behavior of a fresh random identity on
+each start.
+
+## Generating a keypair
+
+There is no separate generation step. Run the server once with `--identity`
+pointing at a path that does not yet exist, and Meerkat creates the keypair for
+you:
+
+    meerkat -f service.mkt --server --identity node.key
+
+The first run creates `node.key`; subsequent runs load it back, keeping the Peer
+ID the same.
+
+## The key file
+
+The file stores the keypair in libp2p's protobuf encoding. It contains a
+private key, so on Unix it is created atomically with owner-only (`0600`)
+permissions. Keep it secret and do not commit it to version control.

--- a/meerkat-lib/Cargo.toml
+++ b/meerkat-lib/Cargo.toml
@@ -33,6 +33,7 @@ libp2p = { version = "0.56", default-features = false, features = ["macros", "wa
 libp2p-stream = "0.4.0-alpha"
 wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"
+web-sys = { version = "0.3", features = ["console"] }
 getrandom = { version = "0.3", features = ["wasm_js"] }
 gloo-timers = { version = "0.4", features = ["futures"] }
 send_wrapper = { version = "0.6", features = ["futures"] }

--- a/meerkat-lib/src/net/actor.rs
+++ b/meerkat-lib/src/net/actor.rs
@@ -65,10 +65,18 @@ pub struct NetworkActor {
 }
 
 #[cfg(not(target_arch = "wasm32"))]
-async fn build_swarm() -> anyhow::Result<(libp2p::Swarm<MeerkatBehaviour>, PeerId)> {
+async fn build_swarm(
+    identity: Option<libp2p::identity::Keypair>,
+) -> anyhow::Result<(libp2p::Swarm<MeerkatBehaviour>, PeerId)> {
     use libp2p::identify;
 
-    let swarm = libp2p::SwarmBuilder::with_new_identity()
+    // #151: use a caller-provided keypair when present (stable Peer ID across
+    // restarts); otherwise fall back to a fresh random identity.
+    let builder = match identity {
+        Some(keypair) => libp2p::SwarmBuilder::with_existing_identity(keypair),
+        None => libp2p::SwarmBuilder::with_new_identity(),
+    };
+    let swarm = builder
         .with_tokio()
         .with_tcp(
             libp2p::tcp::Config::default(),
@@ -104,9 +112,13 @@ async fn build_swarm() -> anyhow::Result<(libp2p::Swarm<MeerkatBehaviour>, PeerI
 }
 
 #[cfg(target_arch = "wasm32")]
-async fn build_swarm() -> anyhow::Result<(libp2p::Swarm<MeerkatBehaviour>, PeerId)> {
+async fn build_swarm(
+    _identity: Option<libp2p::identity::Keypair>,
+) -> anyhow::Result<(libp2p::Swarm<MeerkatBehaviour>, PeerId)> {
     use libp2p::{core::upgrade, identity, Transport};
 
+    // #151: browser clients are ephemeral; a persistent identity is a server
+    // concern, so any provided keypair is ignored here.
     let id_keys = identity::Keypair::generate_ed25519();
     let local_peer_id = PeerId::from(id_keys.public());
 
@@ -158,7 +170,17 @@ fn spawn_event_loop(fut: impl std::future::Future<Output = ()> + 'static) {
 
 impl NetworkActor {
     pub async fn new(node_type: NodeType) -> anyhow::Result<Self> {
-        let (swarm, local_peer_id) = build_swarm().await?;
+        Self::new_with_identity(node_type, None).await
+    }
+
+    // #151: like `new`, but uses a caller-provided keypair when present so the
+    // node keeps a stable Peer ID across restarts. A `None` identity yields a
+    // fresh random one, matching `new`.
+    pub async fn new_with_identity(
+        node_type: NodeType,
+        identity: Option<libp2p::identity::Keypair>,
+    ) -> anyhow::Result<Self> {
+        let (swarm, local_peer_id) = build_swarm(identity).await?;
 
         let (command_tx, command_rx) = mpsc::unbounded_channel::<SwarmCommand>();
         let (event_tx, event_rx) = mpsc::unbounded_channel::<NetworkEvent>();

--- a/meerkat-lib/src/net/actor.rs
+++ b/meerkat-lib/src/net/actor.rs
@@ -113,12 +113,22 @@ async fn build_swarm(
 
 #[cfg(target_arch = "wasm32")]
 async fn build_swarm(
-    _identity: Option<libp2p::identity::Keypair>,
+    identity_keypair: Option<libp2p::identity::Keypair>,
 ) -> anyhow::Result<(libp2p::Swarm<MeerkatBehaviour>, PeerId)> {
     use libp2p::{core::upgrade, identity, Transport};
 
     // #151: browser clients are ephemeral; a persistent identity is a server
-    // concern, so any provided keypair is ignored here.
+    // concern. If one is provided here it is a likely misuse (e.g. the server
+    // path being wired into a wasm build), so warn to the JS console but keep
+    // going with a fresh ephemeral identity rather than failing.
+    if identity_keypair.is_some() {
+        web_sys::console::warn_1(&wasm_bindgen::JsValue::from_str(
+            "meerkat: a persistent identity was provided to a browser (wasm) \
+             client, which always uses an ephemeral identity; the keypair is \
+             ignored.",
+        ));
+    }
+
     let id_keys = identity::Keypair::generate_ed25519();
     let local_peer_id = PeerId::from(id_keys.public());
 

--- a/meerkat-lib/src/net/mod.rs
+++ b/meerkat-lib/src/net/mod.rs
@@ -8,6 +8,9 @@ pub mod protocol;
 pub mod types;
 
 pub use actor::NetworkActor;
+// #151: re-export libp2p's identity types so downstream crates can construct
+// a persistent keypair without depending on libp2p directly.
+pub use libp2p::identity;
 pub use messages::*;
 pub use mock::MockNetwork;
 pub use network_layer::NetworkLayer;

--- a/meerkat/src/main.rs
+++ b/meerkat/src/main.rs
@@ -152,10 +152,12 @@ pub async fn main() -> Result<(), Box<dyn Error>> {
                     prog,
                     file,
                     remote_url_map,
-                    args.port,
-                    args.ws_port,
-                    args.local,
-                    args.identity,
+                    ServerConfig {
+                        port: args.port,
+                        ws_port: args.ws_port,
+                        local: args.local,
+                        identity: args.identity,
+                    },
                     interner,
                 )
                 .await
@@ -303,14 +305,20 @@ fn listen_success_addr(reply: NetworkReply) -> Result<Address, Box<dyn Error>> {
     }
 }
 
-async fn run_server(
-    prog: Vec<Stmt>,
-    input_file: &str,
-    remote_url_map: std::collections::HashMap<String, String>,
+/// #151: server runtime configuration, grouped so related settings share a
+/// single home and `run_server` keeps a small, readable signature.
+struct ServerConfig {
     port: u16,
     ws_port: Option<u16>,
     local: bool,
     identity: Option<std::path::PathBuf>,
+}
+
+async fn run_server(
+    prog: Vec<Stmt>,
+    input_file: &str,
+    remote_url_map: std::collections::HashMap<String, String>,
+    config: ServerConfig,
     interner: Interner,
 ) -> Result<(), Box<dyn Error>> {
     // #39: the directory the server was started from is the root for serving
@@ -322,17 +330,17 @@ async fn run_server(
         .to_path_buf();
     // #151: when an identity file is configured, load (or create) a
     // persistent keypair so the Peer ID is stable across restarts.
-    let identity_keypair = match identity {
+    let identity_keypair = match config.identity {
         Some(path) => Some(load_or_create_identity(&path)?),
         None => None,
     };
     let mut net = NetworkActor::new_with_identity(NodeType::Server, identity_keypair).await?;
     let mut manager = Manager::new(interner);
-    manager.local = local;
+    manager.local = config.local;
 
     let node_ip = manager.get_node_ip();
-    let listen_ip = if local { "127.0.0.1" } else { "0.0.0.0" };
-    let listen_addr = Address::new(format!("/ip4/{}/tcp/{}", listen_ip, port));
+    let listen_ip = if config.local { "127.0.0.1" } else { "0.0.0.0" };
+    let listen_addr = Address::new(format!("/ip4/{}/tcp/{}", listen_ip, config.port));
     let reply = net
         .handle_command(NetworkCommand::Listen { addr: listen_addr })
         .await;
@@ -350,9 +358,10 @@ async fn run_server(
     // #39: browser (wasm) clients can only speak WebSocket, so listen on a
     // second address for them. The TCP address above stays canonical: native
     // peers dial it, and it is what service URLs and reply addresses use.
-    let ws_port = match ws_port {
+    let ws_port = match config.ws_port {
         Some(p) => p,
-        None => port
+        None => config
+            .port
             .checked_add(1)
             .ok_or("port 65535 has no room for a default WebSocket port; pass --ws-port")?,
     };

--- a/meerkat/src/main.rs
+++ b/meerkat/src/main.rs
@@ -15,6 +15,31 @@ use meerkat_lib::runtime::{parser, Manager, Node};
 use std::collections::HashSet;
 use std::error::Error;
 
+/// #151: load a persistent libp2p identity keypair from `path`, or create and
+/// save one if the file does not yet exist. Using the same file across runs
+/// keeps the node's Peer ID stable, so a web page can embed a fixed server
+/// address. The keypair is stored in libp2p's protobuf encoding; on Unix the
+/// file is created with owner-only permissions since it holds a private key.
+fn load_or_create_identity(
+    path: &std::path::Path,
+) -> Result<meerkat_lib::net::identity::Keypair, Box<dyn Error>> {
+    use meerkat_lib::net::identity::Keypair;
+    if path.exists() {
+        let bytes = std::fs::read(path)?;
+        Ok(Keypair::from_protobuf_encoding(&bytes)?)
+    } else {
+        let keypair = Keypair::generate_ed25519();
+        let bytes = keypair.to_protobuf_encoding()?;
+        std::fs::write(path, &bytes)?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))?;
+        }
+        Ok(keypair)
+    }
+}
+
 #[derive(Parser, Debug)]
 #[command(author, version, about)]
 struct Args {
@@ -42,6 +67,12 @@ struct Args {
     /// second, WebSocket address. Defaults to `port + 1`.
     #[arg(long = "ws-port")]
     ws_port: Option<u16>,
+
+    /// #151: path to a persistent identity keypair. If the file exists it is
+    /// loaded, giving a stable Peer ID across restarts; otherwise a new keypair
+    /// is generated and saved there. Omit for an ephemeral random identity.
+    #[arg(long = "identity")]
+    identity: Option<std::path::PathBuf>,
 
     /// Bind to loopback/localhost only (force 127.0.0.1 instead of public IP)
     #[arg(long = "local", default_value_t = false)]
@@ -124,6 +155,7 @@ pub async fn main() -> Result<(), Box<dyn Error>> {
                     args.port,
                     args.ws_port,
                     args.local,
+                    args.identity,
                     interner,
                 )
                 .await
@@ -278,6 +310,7 @@ async fn run_server(
     port: u16,
     ws_port: Option<u16>,
     local: bool,
+    identity: Option<std::path::PathBuf>,
     interner: Interner,
 ) -> Result<(), Box<dyn Error>> {
     // #39: the directory the server was started from is the root for serving
@@ -287,7 +320,13 @@ async fn run_server(
         .parent()
         .unwrap_or_else(|| std::path::Path::new("."))
         .to_path_buf();
-    let mut net = NetworkActor::new(NodeType::Server).await?;
+    // #151: when an identity file is configured, load (or create) a
+    // persistent keypair so the Peer ID is stable across restarts.
+    let identity_keypair = match identity {
+        Some(path) => Some(load_or_create_identity(&path)?),
+        None => None,
+    };
+    let mut net = NetworkActor::new_with_identity(NodeType::Server, identity_keypair).await?;
     let mut manager = Manager::new(interner);
     manager.local = local;
 

--- a/meerkat/src/main.rs
+++ b/meerkat/src/main.rs
@@ -43,9 +43,20 @@ fn load_or_create_identity(
                 options.mode(0o600);
             }
             use std::io::Write;
-            let mut file = options.open(path)?;
-            file.write_all(&bytes)?;
-            Ok(keypair)
+            // `create_new` fails with AlreadyExists if another process created
+            // the file in the window since our read above; in that case just
+            // load the key it wrote rather than failing startup.
+            match options.open(path) {
+                Ok(mut file) => {
+                    file.write_all(&bytes)?;
+                    Ok(keypair)
+                }
+                Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
+                    let bytes = std::fs::read(path)?;
+                    Ok(Keypair::from_protobuf_encoding(&bytes)?)
+                }
+                Err(e) => Err(Box::new(e)),
+            }
         }
         Err(e) => Err(Box::new(e)),
     }

--- a/meerkat/src/main.rs
+++ b/meerkat/src/main.rs
@@ -18,25 +18,36 @@ use std::error::Error;
 /// #151: load a persistent libp2p identity keypair from `path`, or create and
 /// save one if the file does not yet exist. Using the same file across runs
 /// keeps the node's Peer ID stable, so a web page can embed a fixed server
-/// address. The keypair is stored in libp2p's protobuf encoding; on Unix the
-/// file is created with owner-only permissions since it holds a private key.
+/// address. The keypair is stored in libp2p's protobuf encoding.
+///
+/// The file holds a private key, so on Unix it is created atomically with
+/// owner-only (0600) permissions using `create_new`; this leaves no window in
+/// which the key is world-readable and avoids a check-then-write race.
 fn load_or_create_identity(
     path: &std::path::Path,
 ) -> Result<meerkat_lib::net::identity::Keypair, Box<dyn Error>> {
     use meerkat_lib::net::identity::Keypair;
-    if path.exists() {
-        let bytes = std::fs::read(path)?;
-        Ok(Keypair::from_protobuf_encoding(&bytes)?)
-    } else {
-        let keypair = Keypair::generate_ed25519();
-        let bytes = keypair.to_protobuf_encoding()?;
-        std::fs::write(path, &bytes)?;
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))?;
+    // Try to load an existing key first; only generate one if it is absent.
+    // Reading first (rather than checking `exists()`) avoids a time-of-check
+    // to time-of-use gap between the check and the write.
+    match std::fs::read(path) {
+        Ok(bytes) => Ok(Keypair::from_protobuf_encoding(&bytes)?),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            let keypair = Keypair::generate_ed25519();
+            let bytes = keypair.to_protobuf_encoding()?;
+            let mut options = std::fs::OpenOptions::new();
+            options.write(true).create_new(true);
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::OpenOptionsExt;
+                options.mode(0o600);
+            }
+            use std::io::Write;
+            let mut file = options.open(path)?;
+            file.write_all(&bytes)?;
+            Ok(keypair)
         }
-        Ok(keypair)
+        Err(e) => Err(Box::new(e)),
     }
 }
 


### PR DESCRIPTION
#151

By default Meerkat generates a random keypair on startup, so a server's Peer ID
changes every restart. This adds an --identity <path> option that loads a
persistent keypair from disk (or generates and saves one on first run), giving
the server a stable Peer ID. This lets a web page embed a fixed server address.

## Changes
- --identity <path> CLI flag (server mode). If the file exists it is loaded via
  SwarmBuilder::with_existing_identity; if not, a new ed25519 keypair is
  generated, saved to that path, and used. On Unix the file is created with
  0600 permissions since it holds a private key.
- NetworkActor::new_with_identity(node_type, Option<Keypair>) added; the
  existing new() delegates to it with None, so all current callers are
  unchanged and clients/tests keep their ephemeral random identity.
- build_swarm threads the optional keypair to the native SwarmBuilder; the wasm
  path ignores it (browser clients are ephemeral by design).
- net re-exports libp2p::identity so the binary can construct a keypair without
  depending on libp2p directly.

## Verification
- With --identity: the Peer ID is identical across restarts (first run creates
  the key file, later runs load it).
- Without --identity: the Peer ID is random each start (unchanged default).
- Key file is created with owner-only (0600) permissions.
- Full test suite and wasm build pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional persistent network identities for server mode via `--identity <path>`.
  * Reusing the same identity file keeps a stable Peer ID across restarts.
  * If `--identity` is omitted, the server continues to use an ephemeral identity; browser clients still use temporary identities.
* **Documentation**
  * Added `identity.md` explaining how to use `--identity`, including key file format and Unix permission handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->