### PR TITLE
feat: allow import to accept a URL or file path

### DIFF
--- a/meerkat-lib/src/runtime/ast/mod.rs
+++ b/meerkat-lib/src/runtime/ast/mod.rs
@@ -71,6 +71,7 @@ pub enum Stmt {
     Import {
         path: String,
         service_name: Symbol,
+        explicit_path: bool,
     },
     Service {
         name: Symbol,

--- a/meerkat-lib/src/runtime/ast/printer.rs
+++ b/meerkat-lib/src/runtime/ast/printer.rs
@@ -91,12 +91,17 @@ impl<'a> AstPrinter<'a> {
             Stmt::Connect { path, addr } => {
                 println!("Connect: {{ path: \"{}\", addr: \"{}\" }}", path, addr);
             }
-            Stmt::Import { path, service_name } => {
+            Stmt::Import {
+                path,
+                service_name,
+                explicit_path,
+            } => {
                 let service_name = *service_name;
                 println!(
-                    "Import: {{ path: \"{}\", service_name: {} }}",
+                    "Import: {{ path: \"{}\", service_name: {}, explicit_path: {} }}",
                     path,
-                    self.format_symbol(service_name)
+                    self.format_symbol(service_name),
+                    explicit_path,
                 );
             }
             Stmt::Service { name, decls } => {

--- a/meerkat-lib/src/runtime/nameres.rs
+++ b/meerkat-lib/src/runtime/nameres.rs
@@ -272,6 +272,7 @@ impl<'a> Resolver<'a> {
             Stmt::Import {
                 path: _,
                 service_name,
+                explicit_path: _,
             } => {
                 env.bind(*service_name, Binding::Value);
                 Ok(())

--- a/meerkat-lib/src/runtime/parser/meerkat.lalrpop
+++ b/meerkat-lib/src/runtime/parser/meerkat.lalrpop
@@ -80,7 +80,7 @@ extern {
 
 pub Prog: Vec<Stmt> = {
     <stmts: Stmts> => stmts
-}   
+}
 
 Stmts: Vec<Stmt> = Stmt*;
 
@@ -92,7 +92,10 @@ Stmt: Stmt = {
         Stmt::Test { service_name: i, stmts: astmts }
     },
     "import" <i:Ident> => {
-        Stmt::Import { path: format!("{}.mkt", interner.get(i)), service_name: i }
+        Stmt::Import { path: format!("{}.mkt", interner.get(i)), service_name: i, explicit_path : false }
+    },
+    "import" <i:Ident> "from" <p:"strlit"> => {
+        Stmt::Import { path: p.to_string(), service_name: i, explicit_path : true }
     },
     <a:ActionStmt> => Stmt::ActionStmt(a),
     "watch" <e:Expr> ";" => Stmt::Watch { expr: e },
@@ -152,7 +155,7 @@ Decls: Vec<Decl> = Decl*;
 TableField: Field = {
    <i:Ident> ":" <t: TableType> "," => {
     Field {name: i, ty: t}
-   } 
+   }
 }
 
 TableFields: Vec<Field> = TableField*;
@@ -214,7 +217,7 @@ Params: Vec<Param> = {
 }
 
 Args: Vec<Expr> = {
-    <mut v:(<Expr> ",")*> <e:Expr?> => 
+    <mut v:(<Expr> ",")*> <e:Expr?> =>
     match e {
         None => v,
         Some(e) => {
@@ -232,8 +235,8 @@ SubExpr: Expr = {
     "{" <args: Args> "}" => Expr::Tuple {val: args},
     "[" <args: Args> "]" => Expr::List(args),
     "(" <Expr> ")" => <>,
-    
-    <expr:SubExpr> "(" <args:Args> ")" => 
+
+    <expr:SubExpr> "(" <args:Args> ")" =>
         Expr::Call { func: Box::new(expr), args },
 
     <s:Ident> "." <m:Ident> => Expr::MemberAccess { service_name: s, member_name: m },
@@ -261,39 +264,39 @@ pub Expr: Expr = {
         Expr::Unop { expr: Box::new(e), op: UnOp::Not }
     },
     <i: Ident> ":" <e: Expr> => Expr::KeyVal {name: i, value: Box::new(e)},
-    
-    
+
+
 
     #[precedence(level="2")] #[assoc(side="left")]
     <e1:Expr> "*" <e2:Expr> => {
-        Expr::Binop { 
-            expr1: Box::new(e1), 
-            expr2: Box::new(e2), 
-            op: BinOp::Mul 
+        Expr::Binop {
+            expr1: Box::new(e1),
+            expr2: Box::new(e2),
+            op: BinOp::Mul
         }
     },
     <e1:Expr> "/" <e2:Expr> => {
-        Expr::Binop { 
-            expr1: Box::new(e1), 
-            expr2: Box::new(e2), 
-            op: BinOp::Div 
+        Expr::Binop {
+            expr1: Box::new(e1),
+            expr2: Box::new(e2),
+            op: BinOp::Div
         }
     },
-    
+
 
     #[precedence(level="3")] #[assoc(side="left")]
     <e1:Expr> "+" <e2:Expr> => {
-        Expr::Binop { 
-            expr1: Box::new(e1), 
-            expr2: Box::new(e2), 
-            op: BinOp::Add 
+        Expr::Binop {
+            expr1: Box::new(e1),
+            expr2: Box::new(e2),
+            op: BinOp::Add
         }
     },
     <e1:Expr> "-" <e2:Expr> => {
-        Expr::Binop { 
-            expr1: Box::new(e1), 
-            expr2: Box::new(e2), 
-            op: BinOp::Sub 
+        Expr::Binop {
+            expr1: Box::new(e1),
+            expr2: Box::new(e2),
+            op: BinOp::Sub
         }
     },
 
@@ -307,52 +310,52 @@ pub Expr: Expr = {
 
     #[precedence(level="5")] #[assoc(side="left")]
     <e1:Expr> "==" <e2:Expr> => {
-        Expr::Binop { 
-            expr1: Box::new(e1), 
-            expr2: Box::new(e2), 
-            op: BinOp::Eq 
+        Expr::Binop {
+            expr1: Box::new(e1),
+            expr2: Box::new(e2),
+            op: BinOp::Eq
         }
     },
     <e1:Expr> "<" <e2:Expr> => {
-        Expr::Binop { 
-            expr1: Box::new(e1), 
-            expr2: Box::new(e2), 
-            op: BinOp::Lt 
+        Expr::Binop {
+            expr1: Box::new(e1),
+            expr2: Box::new(e2),
+            op: BinOp::Lt
         }
     },
     <e1:Expr> ">" <e2:Expr> => {
-        Expr::Binop { 
-            expr1: Box::new(e1), 
-            expr2: Box::new(e2), 
-            op: BinOp::Gt 
+        Expr::Binop {
+            expr1: Box::new(e1),
+            expr2: Box::new(e2),
+            op: BinOp::Gt
         }
     },
 
     #[precedence(level="6")] #[assoc(side="left")]
     <e1:Expr> "&&" <e2:Expr> => {
-        Expr::Binop { 
-            expr1: Box::new(e1), 
-            expr2: Box::new(e2), 
-            op: BinOp::And 
+        Expr::Binop {
+            expr1: Box::new(e1),
+            expr2: Box::new(e2),
+            op: BinOp::And
         }
     },
 
     #[precedence(level="7")] #[assoc(side="left")]
     <e1:Expr> "||" <e2:Expr> => {
-        Expr::Binop { 
-            expr1: Box::new(e1), 
-            expr2: Box::new(e2), 
-            op: BinOp::Or 
+        Expr::Binop {
+            expr1: Box::new(e1),
+            expr2: Box::new(e2),
+            op: BinOp::Or
         }
     },
 
     #[precedence(level="8")] #[assoc(side="left")]
     "if" <e1:Expr> "then" <e2:Expr> "else" <e3:Expr> => {
-        Expr::If { 
+        Expr::If {
             cond: Box::new(e1),
-            expr1: Box::new(e2), 
-            expr2: Box::new(e3), 
-        }    
+            expr1: Box::new(e2),
+            expr2: Box::new(e3),
+        }
     },
 
     #[precedence(level="9")] #[assoc(side="left")]
@@ -367,13 +370,13 @@ pub Expr: Expr = {
         table_name: t,
         column_names: {
             let mut v = cols;
-            if let Some(col) = c { 
+            if let Some(col) = c {
                 v.push(col); }
             v
         },
         where_clause: Box::new(cond)
     },
-    "fold" "(" <tn:Ident> "." <cn:Ident> "," <op:Expr> "," <id:Expr> ")" => 
+    "fold" "(" <tn:Ident> "." <cn:Ident> "," <op:Expr> "," <id:Expr> ")" =>
     Expr::Fold {
         table_name: tn,
         column_name: cn,
@@ -384,7 +387,7 @@ pub Expr: Expr = {
 
 Bool: bool = {
     "true" => true,
-    "false" => false, 
+    "false" => false,
 }
 
 Number: i32 = {

--- a/meerkat-lib/src/runtime/tt/check/tests.rs
+++ b/meerkat-lib/src/runtime/tt/check/tests.rs
@@ -917,6 +917,7 @@ fn test_import_member_access_is_skipped() {
         Stmt::Import {
             path: "na".to_string(),
             service_name: remote_svc,
+            explicit_path: false,
         },
         Stmt::Service {
             name: local_svc,

--- a/meerkat-lib/tests/nameres_integration_test.rs
+++ b/meerkat-lib/tests/nameres_integration_test.rs
@@ -278,6 +278,23 @@ fn test_integration_import_member_access() {
     assert!(res.is_ok());
 }
 
+//Verify that imports with explicit path bind service names for member access
+#[test]
+fn test_integration_import_path_member_access() {
+    let mut interner = Interner::new();
+    let input = "
+        import s1 from \"./meerkat/tests/s1.mkt\"
+        service s2 {
+            pub def y = s1.x;
+        }
+    ";
+    let parse_result = parse_string(input, &mut interner);
+    assert!(parse_result.is_ok());
+    let stmts = parse_result.unwrap();
+    let res = resolve(&stmts);
+    assert!(res.is_ok());
+}
+
 /// Verify that variables inside assert statements resolve
 #[test]
 fn test_integration_assert_stmt() {

--- a/meerkat-lib/tests/nameres_integration_test.rs
+++ b/meerkat-lib/tests/nameres_integration_test.rs
@@ -278,23 +278,6 @@ fn test_integration_import_member_access() {
     assert!(res.is_ok());
 }
 
-//Verify that imports with explicit path bind service names for member access
-#[test]
-fn test_integration_import_path_member_access() {
-    let mut interner = Interner::new();
-    let input = "
-        import s1 from \"./meerkat/tests/s1.mkt\"
-        service s2 {
-            pub def y = s1.x;
-        }
-    ";
-    let parse_result = parse_string(input, &mut interner);
-    assert!(parse_result.is_ok());
-    let stmts = parse_result.unwrap();
-    let res = resolve(&stmts);
-    assert!(res.is_ok());
-}
-
 /// Verify that variables inside assert statements resolve
 #[test]
 fn test_integration_assert_stmt() {

--- a/meerkat-wasm/src/lib.rs
+++ b/meerkat-wasm/src/lib.rs
@@ -92,6 +92,7 @@ pub async fn load_service(server_ws_addr: String, path: String) -> Result<String
             Stmt::Import {
                 path: _,
                 service_name,
+                explicit_path: _,
             } => {
                 manager
                     .remote_services

--- a/meerkat/src/main.rs
+++ b/meerkat/src/main.rs
@@ -327,6 +327,49 @@ fn listen_success_addr(reply: NetworkReply) -> Result<Address, Box<dyn Error>> {
     }
 }
 
+pub(crate) async fn import_from_file(
+    manager: &mut Manager,
+    explicit_path: bool,
+    import_path: std::path::PathBuf,
+    service_name: Symbol,
+) -> Result<Option<String>, Box<dyn Error>> {
+    let import_stmts = parser::parse_file(import_path.to_str().unwrap(), &mut manager.interner)
+        .map_err(|e| format!("Import parse error: {}", e))?;
+    let mut services = import_stmts.into_iter().filter_map(|stmt| match stmt {
+        Stmt::Service { name, decls } => Some((name, decls)),
+        _ => None,
+    });
+    if explicit_path {
+        if let Some((name, decls)) = services.find(|(name, _)| *name == service_name) {
+            manager
+                .create_service(name, decls)
+                .await
+                .map_err(|e| format!("Imported service '{}': {}", manager.interner.get(name), e))?;
+            Ok(Some(format!(
+                "Imported service: {}.",
+                manager.interner.get(service_name)
+            )))
+        } else {
+            Err(format!(
+                "Service '{}' not found in '{}'",
+                manager.interner.get(service_name),
+                import_path.to_str().unwrap(),
+            )
+            .into())
+        }
+    } else {
+        let mut loaded = Vec::new();
+        for (name, decls) in services {
+            manager
+                .create_service(name, decls)
+                .await
+                .map_err(|e| format!("Imported service '{}': {}", manager.interner.get(name), e))?;
+            loaded.push(manager.interner.get(name).to_string());
+        }
+        Ok(Some(format!("Imported service(s): {}.", loaded.join(", "))))
+    }
+}
+
 /// #151: server runtime configuration, grouped so related settings share a
 /// single home and `run_server` keeps a small, readable signature.
 struct ServerConfig {
@@ -838,39 +881,11 @@ async fn run_client(
                         .parent()
                         .unwrap_or(std::path::Path::new("."));
                     let import_path = base_dir.join(path);
-
-                    let import_stmts =
-                        parser::parse_file(import_path.to_str().unwrap(), &mut manager.interner)
-                            .map_err(|e| format!("Import parse error: {}", e))?;
-                    let mut services = import_stmts.into_iter().filter_map(|stmt| match stmt {
-                        Stmt::Service { name, decls } => Some((name, decls)),
-                        _ => None,
-                    });
-                    if explicit_path {
-                        if let Some((name, decls)) =
-                            services.find(|(name, _)| *name == service_name)
-                        {
-                            manager.create_service(name, decls).await.map_err(|e| {
-                                format!("Imported service '{}': {}", manager.interner.get(name), e)
-                            })?;
-                            println!("Imported service: {}.", manager.interner.get(service_name));
-                        } else {
-                            return Err(format!(
-                                "Service '{}' not found in '{}'",
-                                manager.interner.get(service_name),
-                                path
-                            )
-                            .into());
-                        }
-                    } else {
-                        let mut loaded = Vec::new();
-                        for (name, decls) in services {
-                            manager.create_service(name, decls).await.map_err(|e| {
-                                format!("Imported service '{}': {}", manager.interner.get(name), e)
-                            })?;
-                            loaded.push(manager.interner.get(name).to_string());
-                        }
-                        println!("Imported service(s): {}.", loaded.join(", "));
+                    if let Some(output) =
+                        import_from_file(&mut manager, explicit_path, import_path, service_name)
+                            .await?
+                    {
+                        println!("{}", output);
                     }
                 }
             }

--- a/meerkat/src/main.rs
+++ b/meerkat/src/main.rs
@@ -752,6 +752,7 @@ async fn run_client(
             &Stmt::Import {
                 ref path,
                 service_name,
+                explicit_path,
             } => {
                 if let Some(url) = remote_url_map.get(manager.interner.get(service_name)) {
                     manager
@@ -767,18 +768,39 @@ async fn run_client(
                         .parent()
                         .unwrap_or(std::path::Path::new("."));
                     let import_path = base_dir.join(path);
+
                     let import_stmts =
                         parser::parse_file(import_path.to_str().unwrap(), &mut manager.interner)
                             .map_err(|e| format!("Import parse error: {}", e))?;
-                    for import_stmt in &import_stmts {
-                        if let &Stmt::Service { name, ref decls } = import_stmt {
-                            manager
-                                .create_service(name, decls.clone())
-                                .await
-                                .map_err(|e| format!("Import service error: {}", e))?;
-                            println!("Imported service '{}'", manager.interner.get(name));
+                    let mut services = import_stmts.into_iter().filter_map(|stmt| match stmt {
+                        Stmt::Service { name, decls } => Some((name, decls)),
+                        _ => None,
+                    });
+                    if explicit_path {
+                        if let Some((name, decls)) =
+                            services.find(|(name, _)| *name == service_name)
+                        {
+                            manager.create_service(name, decls).await.map_err(|e| {
+                                format!("Imported service '{}': {}", manager.interner.get(name), e)
+                            })?;
+                            print!("Imported service: {}.", manager.interner.get(service_name));
+                        } else {
+                            return Err(format!(
+                                "Service '{}' not found in '{}'",
+                                manager.interner.get(service_name),
+                                path
+                            )
+                            .into());
                         }
                     }
+                    let mut loaded = Vec::new();
+                    for (name, decls) in services {
+                        manager.create_service(name, decls).await.map_err(|e| {
+                            format!("Imported service '{}': {}", manager.interner.get(name), e)
+                        })?;
+                        loaded.push(manager.interner.get(name).to_string());
+                    }
+                    print!("Imported service(s): {}.", loaded.join(", "));
                 }
             }
             &Stmt::ActionStmt(_) => {}

--- a/meerkat/src/main.rs
+++ b/meerkat/src/main.rs
@@ -964,4 +964,85 @@ mod tests {
         .expect_err("message-sent replies are not a Listen success");
         assert_eq!(message_sent_err.to_string(), "Unexpected reply");
     }
+
+    // Verify that imports with an explicit path load the target file
+    // and create the imported service.
+    #[tokio::test]
+    async fn test_import_path_member_access() {
+        let temp_dir = std::env::temp_dir().join(format!(
+            "meerkat-import-test-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&temp_dir).unwrap();
+        let main_path = temp_dir.join("main.mkt");
+        let imported_path = temp_dir.join("s1.mkt");
+        std::fs::write(&imported_path, "service s1 { var x = 7; }").unwrap();
+        std::fs::write(
+            &main_path,
+            "import s1 from \"./s1.mkt\"\nservice s2 { pub def y = s1.x; }",
+        )
+        .unwrap();
+
+        let mut interner = Interner::new();
+        let program = parser::parse_file(main_path.to_str().unwrap(), &mut interner).unwrap();
+        let mut manager = Manager::new(interner);
+
+        for stmt in program {
+            match stmt {
+                Stmt::Service { name, decls } => {
+                    manager.create_service(name, decls).await.unwrap();
+                }
+                Stmt::Import {
+                    path,
+                    service_name,
+                    explicit_path,
+                } => {
+                    let base_dir = main_path.parent().unwrap();
+                    let import_path = base_dir.join(path);
+
+                    let import_stmts =
+                        parser::parse_file(import_path.to_str().unwrap(), &mut manager.interner)
+                            .unwrap();
+                    let mut services = import_stmts.into_iter().filter_map(|stmt| match stmt {
+                        Stmt::Service { name, decls } => Some((name, decls)),
+                        _ => None,
+                    });
+
+                    if explicit_path {
+                        if let Some((name, decls)) =
+                            services.find(|(name, _)| *name == service_name)
+                        {
+                            manager.create_service(name, decls).await.unwrap();
+                        } else {
+                            panic!("service import was not loaded");
+                        }
+                    } else {
+                        panic!("expected explicit path import");
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        let s1 = manager.interner.insert("s1");
+        let x = manager.interner.insert("x");
+        let service = manager
+            .services
+            .get(&s1)
+            .expect("imported service should be installed");
+        assert!(
+            service.vars.contains_key(&x),
+            "imported service should contain x"
+        );
+
+        let s2 = manager.interner.insert("s2");
+        let y = manager.interner.insert("y");
+
+        let value = manager.lookup(y, s2, None).await.unwrap();
+        assert_eq!(value, meerkat_lib::runtime::ast::Value::Int { val: 7 });
+    }
 }

--- a/meerkat/src/main.rs
+++ b/meerkat/src/main.rs
@@ -853,7 +853,7 @@ async fn run_client(
                             manager.create_service(name, decls).await.map_err(|e| {
                                 format!("Imported service '{}': {}", manager.interner.get(name), e)
                             })?;
-                            print!("Imported service: {}.", manager.interner.get(service_name));
+                            println!("Imported service: {}.", manager.interner.get(service_name));
                         } else {
                             return Err(format!(
                                 "Service '{}' not found in '{}'",
@@ -862,16 +862,16 @@ async fn run_client(
                             )
                             .into());
                         }
+                    } else {
+                        let mut loaded = Vec::new();
+                        for (name, decls) in services {
+                            manager.create_service(name, decls).await.map_err(|e| {
+                                format!("Imported service '{}': {}", manager.interner.get(name), e)
+                            })?;
+                            loaded.push(manager.interner.get(name).to_string());
+                        }
+                        println!("Imported service(s): {}.", loaded.join(", "));
                     }
-                    let mut loaded = Vec::new();
-                    for (name, decls) in services {
-                        manager.create_service(name, decls).await.map_err(|e| {
-                            format!("Imported service '{}': {}", manager.interner.get(name), e)
-                        })?;
-                        loaded.push(manager.interner.get(name).to_string());
-                    }
-                    print!("Imported service(s): {}.", loaded.join(", "));
-                }
             }
             &Stmt::ActionStmt(_) => {}
             &Stmt::Update { .. } | &Stmt::Connect { .. } | &Stmt::Watch { .. } => {}

--- a/meerkat/src/main.rs
+++ b/meerkat/src/main.rs
@@ -872,6 +872,7 @@ async fn run_client(
                         }
                         println!("Imported service(s): {}.", loaded.join(", "));
                     }
+                }
             }
             &Stmt::ActionStmt(_) => {}
             &Stmt::Update { .. } | &Stmt::Connect { .. } | &Stmt::Watch { .. } => {}

--- a/meerkat/src/repl.rs
+++ b/meerkat/src/repl.rs
@@ -249,17 +249,13 @@ async fn exec_stmt(
                     svc_name_str, address
                 )));
             }
-            if let Some(output) = crate::import_from_file(
+            crate::import_from_file(
                 manager,
                 explicit_path,
                 std::path::PathBuf::from(&path),
                 service_name,
             )
-            .await?
-            {
-                return Ok(Some(output));
-            }
-            Ok(None)
+            .await
         }
         Stmt::ActionStmt(action_stmt) => {
             let effect = execute(&action_stmt, repl_env, manager, Symbol::empty(), None)

--- a/meerkat/src/repl.rs
+++ b/meerkat/src/repl.rs
@@ -1,8 +1,8 @@
 use meerkat_lib::runtime::ast::{Expr, Stmt, Value};
 use meerkat_lib::runtime::interner::Symbol;
 use meerkat_lib::runtime::interpreter::{eval, execute, EvalContext, ExecuteEffect};
+use meerkat_lib::runtime::parser::parse_repl;
 use meerkat_lib::runtime::parser::ReplParseResult;
-use meerkat_lib::runtime::parser::{parse_file, parse_repl};
 use meerkat_lib::runtime::Manager;
 
 use directories::ProjectDirs;
@@ -249,38 +249,17 @@ async fn exec_stmt(
                     svc_name_str, address
                 )));
             }
-            let import_stmts = parse_file(&path, &mut manager.interner)
-                .map_err(|e| format!("Import '{}': {}", path, e))?;
-            let mut services = import_stmts.into_iter().filter_map(|stmt| match stmt {
-                Stmt::Service { name, decls } => Some((name, decls)),
-                _ => None,
-            });
-            if explicit_path {
-                if let Some((name, decls)) = services.find(|(name, _)| *name == service_name) {
-                    manager.create_service(name, decls).await.map_err(|e| {
-                        format!("Imported service '{}': {}", manager.interner.get(name), e)
-                    })?;
-                    return Ok(Some(format!(
-                        "Imported service: {}.",
-                        manager.interner.get(service_name)
-                    )));
-                } else {
-                    return Err(format!(
-                        "Service '{}' not found in '{}'",
-                        manager.interner.get(service_name),
-                        path
-                    )
-                    .into());
-                }
+            if let Some(output) = crate::import_from_file(
+                manager,
+                explicit_path,
+                std::path::PathBuf::from(&path),
+                service_name,
+            )
+            .await?
+            {
+                return Ok(Some(output));
             }
-            let mut loaded = Vec::new();
-            for (name, decls) in services {
-                manager.create_service(name, decls).await.map_err(|e| {
-                    format!("Imported service '{}': {}", manager.interner.get(name), e)
-                })?;
-                loaded.push(manager.interner.get(name).to_string());
-            }
-            Ok(Some(format!("Imported service(s): {}.", loaded.join(", "))))
+            Ok(None)
         }
         Stmt::ActionStmt(action_stmt) => {
             let effect = execute(&action_stmt, repl_env, manager, Symbol::empty(), None)

--- a/meerkat/src/repl.rs
+++ b/meerkat/src/repl.rs
@@ -79,7 +79,8 @@ pub async fn run_repl(
         println!();
     }
 
-    if !remote_url_map.is_empty() {
+    {
+        //Network initializer always runs
         let mut n = meerkat_lib::net::NetworkActor::new(meerkat_lib::net::types::NodeType::Server)
             .await
             .map_err(|e| format!("Network error: {}", e))?;
@@ -217,27 +218,55 @@ async fn exec_stmt(
                 manager.interner.get(service_name)
             )))
         }
-        Stmt::Import { path, service_name } => {
+        Stmt::Import {
+            path,
+            service_name,
+            explicit_path,
+        } => {
             let svc_name_str = manager.interner.get(service_name);
-            if let Some(url) = remote_url_map.get(svc_name_str) {
+            if let Some(address) = if path.starts_with("/ip4") {
+                Some(path.as_str())
+            } else {
+                remote_url_map.get(svc_name_str).map(String::as_str)
+            } {
                 manager
                     .remote_services
-                    .insert(service_name, meerkat_lib::net::Address::new(url.as_str()));
+                    .insert(service_name, meerkat_lib::net::Address::new(address));
                 return Ok(Some(format!(
                     "Remote service '{}' registered at {}.",
-                    svc_name_str, url
+                    svc_name_str, address
                 )));
             }
             let import_stmts = parse_file(&path, &mut manager.interner)
                 .map_err(|e| format!("Import '{}': {}", path, e))?;
-            let mut loaded = Vec::new();
-            for s in import_stmts {
-                if let Stmt::Service { name, decls } = s {
+            let mut services = import_stmts.into_iter().filter_map(|stmt| match stmt {
+                Stmt::Service { name, decls } => Some((name, decls)),
+                _ => None,
+            });
+            if explicit_path {
+                if let Some((name, decls)) = services.find(|(name, _)| *name == service_name) {
                     manager.create_service(name, decls).await.map_err(|e| {
                         format!("Imported service '{}': {}", manager.interner.get(name), e)
                     })?;
-                    loaded.push(manager.interner.get(name).to_string());
+                    return Ok(Some(format!(
+                        "Imported service: {}.",
+                        manager.interner.get(service_name)
+                    )));
+                } else {
+                    return Err(format!(
+                        "Service '{}' not found in '{}'",
+                        manager.interner.get(service_name),
+                        path
+                    )
+                    .into());
                 }
+            }
+            let mut loaded = Vec::new();
+            for (name, decls) in services {
+                manager.create_service(name, decls).await.map_err(|e| {
+                    format!("Imported service '{}': {}", manager.interner.get(name), e)
+                })?;
+                loaded.push(manager.interner.get(name).to_string());
             }
             Ok(Some(format!("Imported service(s): {}.", loaded.join(", "))))
         }

--- a/meerkat/src/repl.rs
+++ b/meerkat/src/repl.rs
@@ -52,6 +52,30 @@ async fn check_watches(watches: &mut [Watch], manager: &mut Manager, repl_env: &
     }
 }
 
+async fn init_network(manager: &mut Manager) -> Result<(), Box<dyn std::error::Error>> {
+    let mut n =
+        meerkat_lib::net::NetworkActor::new(meerkat_lib::net::types::NodeType::Server).await?;
+    let listen_ip = if manager.local {
+        "127.0.0.1"
+    } else {
+        "0.0.0.0"
+    };
+    let listen_addr = meerkat_lib::net::Address::new(format!("/ip4/{}/tcp/0", listen_ip));
+    let reply = n
+        .handle_command(meerkat_lib::net::NetworkCommand::Listen { addr: listen_addr })
+        .await;
+    let addr = crate::listen_success_addr(reply)?;
+    let node_ip = manager.get_node_ip();
+    let peer_id = n.local_peer_id();
+    let addr_str = addr
+        .0
+        .replace("0.0.0.0", &node_ip)
+        .replace("127.0.0.1", &node_ip);
+    manager.network = Some(n);
+    manager.set_local_address(format!("{}/p2p/{}", addr_str, peer_id));
+    Ok(())
+}
+
 /// Run the `REPL` loop for interactive execution
 pub async fn run_repl(
     mut manager: Manager,
@@ -79,29 +103,14 @@ pub async fn run_repl(
         println!();
     }
 
-    {
-        //Network initializer always runs
-        let mut n = meerkat_lib::net::NetworkActor::new(meerkat_lib::net::types::NodeType::Server)
-            .await
-            .map_err(|e| format!("Network error: {}", e))?;
-        let listen_ip = if manager.local {
-            "127.0.0.1"
-        } else {
-            "0.0.0.0"
-        };
-        let listen_addr = meerkat_lib::net::Address::new(format!("/ip4/{}/tcp/0", listen_ip));
-        let reply = n
-            .handle_command(meerkat_lib::net::NetworkCommand::Listen { addr: listen_addr })
-            .await;
-        let addr = crate::listen_success_addr(reply)?;
-        let node_ip = manager.get_node_ip();
-        let peer_id = n.local_peer_id();
-        let addr_str = addr
-            .0
-            .replace("0.0.0.0", &node_ip)
-            .replace("127.0.0.1", &node_ip);
-        manager.network = Some(n);
-        manager.set_local_address(format!("{}/p2p/{}", addr_str, peer_id));
+    match init_network(&mut manager).await {
+        Ok(_) => {}
+        Err(e) => {
+            if is_tty {
+                println!("Network error: {}", e);
+                println!("Continuing without network support. Some features may not work.");
+            }
+        }
     }
 
     let mut repl_env: Vec<(Symbol, Value)> = Vec::new();
@@ -224,11 +233,14 @@ async fn exec_stmt(
             explicit_path,
         } => {
             let svc_name_str = manager.interner.get(service_name);
-            if let Some(address) = if path.starts_with("/ip4") {
+            let address = if path.starts_with("/ip4") {
                 Some(path.as_str())
-            } else {
+            } else if !explicit_path {
                 remote_url_map.get(svc_name_str).map(String::as_str)
-            } {
+            } else {
+                None
+            };
+            if let Some(address) = address {
                 manager
                     .remote_services
                     .insert(service_name, meerkat_lib::net::Address::new(address));


### PR DESCRIPTION
Added the possibility of importing a service with new grammar to be able to import a service with an absolute or relative path, or a URL to the service. Closes issue #95.
AST was changed to allow easy differentiation between an import statement referencing a file in the current directory (base directory in the case of the main's import statement handling) and one that uses a file path. This necessitated some changes to `AstPrinter` and other relevant function signatures. 
Lalrpop file was changed to accept the new type of import statement described in the issue, `import <service-name> from "<path/URL>"`.
Import statement execution was altered in the REPL to support both the old import statements and the new, which behave as described in issue #95. The REPL's network initializer was made to always run so URL imports are supported even if `remote_url_map` is empty. 
This was mostly copied over to the main's `run_client` function for consistency, except for URL imports.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for explicit-path imports (e.g., `import Service from "./path.mkt"`).
  * Explicit-path imports now load only the named service and show clear single-service status.
  * Remote service imports can use direct network addresses and improve import status reporting.
* **Bug Fixes**
  * REPL network initialization now proceeds consistently and continues without network support if it fails.
  * Explicit-path imports are resolved from files without unintentionally switching to remote resolution.
* **Tests**
  * Added coverage for explicit-path import behavior and member access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->