### PR TITLE
Issue #153: Design for triggering actions from the client

### DIFF
--- a/docs/design/client-actions.md
+++ b/docs/design/client-actions.md
@@ -103,6 +103,15 @@ The `Html` module was written with this in mind.  Its documentation states that
 the representation is private precisely so that it can change later, and names a
 structured tree as the anticipated direction.
 
+Existing consumers treat `Html` as text, and that does not change: `as_str` and
+the `Display` impl still produce the rendered visible content, and the AST
+printer and any text encoding serialize that content. A handler is not part of
+that text. It is carried on the tree node rather than spliced into the string,
+so a printer or a text-only consumer sees the markup without the handler and
+never serializes an action as markup. Within a single node a handler is just the
+action (or lambda) value the node holds; how a handler reference travels between
+nodes is the transport question the separate trust-boundary issue covers.
+
 A tree alone does not make rendering safe.  If the renderer walks the tree and
 concatenates it back into a string, the current injection risk is preserved.
 The design therefore requires that rendering go through DOM APIs that treat
@@ -151,17 +160,34 @@ field wants to hand the action what the user typed or toggled, so the handler
 takes that value as an argument:
 
 ```meerkat
-pub def html = (<input type="text" oninput={set_name} />);
+pub def html = (<input type="text" oninput={(s) => set_name(s)} />);
 ```
 
 Resolution: the expression for an event attribute is either an action, or a
 lambda that takes one argument and returns an action. The lambda's argument
-receives the value the event supplies -- for example, a string for `oninput` --
-and its type is checked against what the event provides. A plain action is used
-where the event carries no value (a click); a lambda is used where it does (a
-text input). This subsumes the earlier question of how an event value reaches
-the action: it arrives as the lambda's argument, needing no change to how
-actions themselves are represented.
+receives the value the event supplies, and its type is checked against what the
+event provides. A plain action is used where the event carries no value (a
+click); a lambda is used where it does (a text input).
+
+The value-carrying events, and the type each supplies, form the initial
+supported subset:
+
+| Event | Payload | Handler expression |
+| --- | --- | --- |
+| `onclick` | none | an action |
+| `oninput` | string | a lambda from string to action |
+| `onchange` (text) | string | a lambda from string to action |
+| `onchange` (checkbox) | bool | a lambda from bool to action |
+
+Any other attribute beginning with `on` is accepted with a no-argument action.
+An attribute in the value-carrying subset requires a lambda whose argument type
+matches the payload, and the compiler rejects a mismatch. The lambda form above
+is illustrative; the concrete syntax follows Meerkat's existing lambda
+expression and is fixed during implementation.
+
+This subsumes the earlier question of how an event value reaches the action: it
+arrives as the lambda's argument, needing no change to how actions themselves
+are represented.
 
 Radio buttons are a further step.  A group of radio buttons naturally maps to a
 choice among named alternatives, which Meerkat cannot currently express.  They

--- a/docs/design/client-actions.md
+++ b/docs/design/client-actions.md
@@ -78,6 +78,9 @@ ordinary action path.  If it names another node, it is sent there through
 `remote_action`.  The captured environment and service identity supply the
 execution context, so no new capture or scoping rules are required.
 
+What the page actually holds for a handler, and therefore what a click sends
+back, is left open below; see the section on the browser trust boundary.
+
 Any state the action changes propagates through the existing reactive
 machinery.  In the example above, clicking the button increments `x` on the
 server, which recomputes `s1.y`, which pushes an update to the subscribed
@@ -98,10 +101,46 @@ instead of splicing strings together.
 
 The `Html` module was written with this in mind.  Its documentation states that
 the representation is private precisely so that it can change later, and names a
-structured tree as the anticipated direction.  The change also addresses a
-concern raised during review of the web client: with a tree, dynamically
-computed values are inserted as data rather than as markup, so they cannot be
-interpreted as HTML.
+structured tree as the anticipated direction.
+
+A tree alone does not make rendering safe.  If the renderer walks the tree and
+concatenates it back into a string, the current injection risk is preserved.
+The design therefore requires that rendering go through DOM APIs that treat
+values as data: interpolated text is set as text content, ordinary attributes
+are set as attribute values, and neither is parsed as markup.  Under that rule a
+dynamically computed value cannot introduce elements or event handlers,
+regardless of what it contains.
+
+If a service ever needs to emit markup that should be parsed as HTML, that has
+to be a distinct and explicitly named construct rather than the default
+behaviour of interpolation, so that the trusted case is visible in the source.
+
+## Handlers and the browser trust boundary
+
+Sending an action to another node currently means sending its statements and
+captured environment, and every node that receives them is another Meerkat
+process.  Binding a handler into a page changes that: the receiving side is a
+browser, and whatever it holds can be inspected and altered before it is sent
+back.  If a click returns the statements it was given, a client could return
+different ones, and the server would execute them.
+
+This is a variant of a problem the system already has -- a peer supplying its
+own return route is tracked in #118 -- but the browser makes it sharper, because
+the handler is handed out deliberately rather than merely accepted on arrival.
+It is also not answered by the earlier decision that a browser client trusts the
+server it loaded its code from: that decision runs in the other direction.
+
+An alternative is for the handler in the page to be an opaque reference rather
+than the action itself.  The node that renders the markup keeps the closure and
+gives the page an identifier for it; a click sends the identifier back, and the
+owning node resolves it to the closure it issued and runs that.  Nothing
+executable crosses the boundary, and the page cannot name an action it was never
+given.  The cost is that identifiers have to be issued, scoped to a particular
+page's session, and eventually discarded.
+
+This design does not settle the question, but no implementation should begin
+until it is settled, because the answer determines what an event attribute
+evaluates to on the client side.
 
 ## Extending to other inputs
 

--- a/docs/design/client-actions.md
+++ b/docs/design/client-actions.md
@@ -1,0 +1,147 @@
+# Design for triggering actions from the client
+
+## Motivation
+
+A Meerkat service can already render HTML through the `html` definition, and a
+browser client renders that markup and re-renders it reactively when the
+underlying values change.  What it cannot do is send anything back: the page is
+a view, not an interface.  Every state change in the web client demo has to be
+triggered by a separate process.
+
+This document proposes a language extension that lets a service bind an action
+to a user interface event, so that clicking a button in the browser runs an
+action -- on the client, or on the server that the client is connected to.
+
+## What already exists
+
+Three pieces of the mechanism are already in place.
+
+Actions are first class values.  `Value::ActionClosure` holds the statements of
+an action together with a captured environment, so an action can be produced by
+an expression and invoked later rather than only at its definition site.
+
+An action closure knows where it belongs.  It carries a `ServiceNetId`, which
+records the owning node's address.  The comment on that field notes that this
+lets the action be executed even if its service is not imported into the scope
+where the closure is later used.  That is exactly the browser's situation: the
+page holds a handler for an action whose service lives on the server.
+
+Remote invocation already exists.  `remote_action` accepts a `ServiceNetId`, the
+action's statements, and an environment -- the same three things an
+`ActionClosure` stores.
+
+What is missing is a way to write the binding in source, and a place for the
+rendered HTML to carry it.
+
+## Proposed syntax
+
+An event attribute in an HTML template takes an interpolated expression that
+evaluates to an action:
+
+```meerkat
+service counter {
+    var n = 0;
+    pub def bump = action { n = n + 1; };
+    pub def html = (<button onclick={bump}>increment</button>);
+}
+```
+
+This reuses the existing `{expr}` interpolation form rather than introducing
+new syntax.  The difference is only in what the expression evaluates to: an
+action value instead of an integer or a string.
+
+The rule is general.  An attribute whose name begins with `on` is an event
+attribute, and its interpolated expression must evaluate to an action.  Any
+other attribute keeps its current meaning, where the interpolated value is
+rendered as text.
+
+Because an action closure carries its own service identity, the action need not
+belong to the service that renders the markup:
+
+```meerkat
+import s1
+
+service counter_ui {
+    pub def z = s1.y * 2;
+    pub def html = (<div><p>z = {z}</p><button onclick={s1.inc_x}>+</button></div>);
+}
+```
+
+## Semantics
+
+Evaluating an event attribute produces an action value rather than text.  The
+value is not rendered into the markup; it is attached to the element.
+
+When the corresponding event fires, the runtime invokes the action.  If the
+action's `ServiceNetId` names the local node, it runs locally through the
+ordinary action path.  If it names another node, it is sent there through
+`remote_action`.  The captured environment and service identity supply the
+execution context, so no new capture or scoping rules are required.
+
+Any state the action changes propagates through the existing reactive
+machinery.  In the example above, clicking the button increments `x` on the
+server, which recomputes `s1.y`, which pushes an update to the subscribed
+client, which recomputes `z` and re-renders `html`.  The click is the only new
+step; everything after it already works.
+
+## Required change to the HTML representation
+
+An `Html` value is currently backed by a single rendered string.  A string can
+carry the text `z = 4`, but it cannot carry a reference to an action closure, so
+there is nowhere for an event handler to live.
+
+This proposal therefore requires `Html` to become a structured tree: elements
+with attributes, where an attribute value is either text or a Meerkat value.
+Event attributes hold action values; everything else renders as it does today.
+Rendering to the DOM then walks the tree and attaches real event listeners
+instead of splicing strings together.
+
+The `Html` module was written with this in mind.  Its documentation states that
+the representation is private precisely so that it can change later, and names a
+structured tree as the anticipated direction.  The change also addresses a
+concern raised during review of the web client: with a tree, dynamically
+computed values are inserted as data rather than as markup, so they cannot be
+interpreted as HTML.
+
+## Extending to other inputs
+
+The general rule extends to inputs that carry a value, but those raise a
+question this design does not yet settle.  A checkbox or a text field wants to
+hand the action what the user typed or toggled:
+
+```meerkat
+pub def html = (<input type="text" oninput={set_name} />);
+```
+
+An action closure holds statements and a captured environment but no parameter
+list, so there is currently no way to pass the event's value in.  Two options
+seem plausible: give action closures parameters, in the way ordinary closures
+already have them, or bind the event value into the captured environment under
+a well known name before invoking the action.  The first is more explicit and
+composes better with the rest of the language; the second requires no change to
+the value representation.
+
+Radio buttons are a further step.  A group of radio buttons naturally maps to a
+choice among named alternatives, which Meerkat cannot currently express.  They
+are better revisited once the language has enumerations.
+
+## Open questions
+
+Whether event attributes should be restricted to a known set of event names, or
+allowed for any attribute beginning with `on`.  A fixed set catches typos at
+check time; an open set needs no change when new events are supported.
+
+How the event's value should reach the action, for inputs that carry one.  See
+the section above.
+
+Whether a click that triggers a remote action should give the page any feedback
+while the action is in flight, or whether the reactive update arriving later is
+sufficient.
+
+## Test case
+
+`meerkat/tests/client_button.mkt` demonstrates the design.  It defines a service
+whose `html` renders a value together with a button bound to an action on an
+imported service.  It does not work today: event attributes are not recognised,
+and an `Html` value cannot carry an action.  It should work once this design is
+implemented.

--- a/docs/design/client-actions.md
+++ b/docs/design/client-actions.md
@@ -138,44 +138,62 @@ executable crosses the boundary, and the page cannot name an action it was never
 given.  The cost is that identifiers have to be issued, scoped to a particular
 page's session, and eventually discarded.
 
-This design does not settle the question, but no implementation should begin
-until it is settled, because the answer determines what an event attribute
-evaluates to on the client side.
+Resolution: this is a real concern, but its architecture is more global than
+this feature -- it is really about mobile code in Meerkat as a whole -- so it is
+tracked as a separate issue rather than settled here. For now, actions and
+lambdas are passed to and from the client over the wire and executed under the
+normal execution semantics, with the tampering question deferred to that issue.
 
 ## Extending to other inputs
 
-The general rule extends to inputs that carry a value, but those raise a
-question this design does not yet settle.  A checkbox or a text field wants to
-hand the action what the user typed or toggled:
+The general rule extends to inputs that carry a value. A checkbox or a text
+field wants to hand the action what the user typed or toggled, so the handler
+takes that value as an argument:
 
 ```meerkat
 pub def html = (<input type="text" oninput={set_name} />);
 ```
 
-An action closure holds statements and a captured environment but no parameter
-list, so there is currently no way to pass the event's value in.  Two options
-seem plausible: give action closures parameters, in the way ordinary closures
-already have them, or bind the event value into the captured environment under
-a well known name before invoking the action.  The first is more explicit and
-composes better with the rest of the language; the second requires no change to
-the value representation.
+Resolution: the expression for an event attribute is either an action, or a
+lambda that takes one argument and returns an action. The lambda's argument
+receives the value the event supplies -- for example, a string for `oninput` --
+and its type is checked against what the event provides. A plain action is used
+where the event carries no value (a click); a lambda is used where it does (a
+text input). This subsumes the earlier question of how an event value reaches
+the action: it arrives as the lambda's argument, needing no change to how
+actions themselves are represented.
 
 Radio buttons are a further step.  A group of radio buttons naturally maps to a
 choice among named alternatives, which Meerkat cannot currently express.  They
 are better revisited once the language has enumerations.
 
-## Open questions
+## Resolved questions
 
-Whether event attributes should be restricted to a known set of event names, or
-allowed for any attribute beginning with `on`.  A fixed set catches typos at
-check time; an open set needs no change when new events are supported.
+Attribute scope: any attribute whose name begins with `on` accepts a
+no-argument action. A designated subset of supported event attributes may
+additionally accept an action that takes an argument (via the lambda form
+above), and the compiler typechecks that the argument has the type the event
+supplies. This keeps the common case open-ended while giving the value-carrying
+events a checked contract.
 
-How the event's value should reach the action, for inputs that carry one.  See
-the section above.
+Passing an event's value to an action: resolved by the lambda form described
+under "Extending to other inputs" above.
 
-Whether a click that triggers a remote action should give the page any feedback
-while the action is in flight, or whether the reactive update arriving later is
-sufficient.
+In-flight feedback: showing the user something while a remote action is in
+flight is out of scope for now; the reactive update arriving later is treated as
+sufficient. A future approach might use compound actions -- a non-transactional
+action composed of transactional parts, where an early part shows an in-flight
+indicator and the rest carries out the command -- but that is left to a separate
+issue.
+
+## Reactivity of handler bindings
+
+Actions are often bound in local defs or variables rather than named inline, so
+a handler that references one must update inside the rendered HTML when that
+definition changes, exactly as any other interpolated value does. The structured
+HTML representation should carry handler bindings in a way that preserves this,
+so that reactivity extends to the handler an element is bound to, not only to
+the text it displays.
 
 ## Test case
 

--- a/meerkat-lib/src/runtime/html.rs
+++ b/meerkat-lib/src/runtime/html.rs
@@ -24,6 +24,10 @@ pub struct Html {
     /// Private on purpose: no code outside this module may depend on HTML
     /// being represented as a string.
     rendered: String,
+    /// #153: event handlers bound to elements, as (event name, action value)
+    /// pairs. These are not part of the rendered string; the client attaches
+    /// them as real listeners. Empty for HTML with no handlers.
+    handlers: Vec<(String, Value)>,
 }
 
 impl Html {
@@ -35,7 +39,16 @@ impl Html {
     /// Returns:
     ///     `Html`: The constructed HTML value
     pub fn from_rendered(rendered: String) -> Self {
-        Html { rendered }
+        Html {
+            rendered,
+            handlers: Vec::new(),
+        }
+    }
+
+    /// #153: the event handlers bound in this HTML value, as (event, action)
+    /// pairs. The client reads these to attach real event listeners.
+    pub fn handlers(&self) -> &[(String, Value)] {
+        &self.handlers
     }
 
     /// Borrow the rendered markup as a string slice
@@ -72,6 +85,12 @@ impl fmt::Display for Html {
 pub(crate) enum HtmlPart {
     Text(String),
     Expr(Box<Expr>),
+    /// #153: an event handler bound to an `on*` attribute. `event` is the
+    /// attribute name (e.g. "onclick"); `expr` evaluates to an action value.
+    Handler {
+        event: String,
+        expr: Box<Expr>,
+    },
 }
 
 /// The representation of an HTML template expression, before evaluation.
@@ -98,6 +117,7 @@ impl HtmlTemplate {
         self.parts.iter().filter_map(|p| match p {
             HtmlPart::Text(_) => None,
             HtmlPart::Expr(e) => Some(e.as_ref()),
+            HtmlPart::Handler { expr, .. } => Some(expr.as_ref()),
         })
     }
 
@@ -106,6 +126,7 @@ impl HtmlTemplate {
         self.parts.iter_mut().filter_map(|p| match p {
             HtmlPart::Text(_) => None,
             HtmlPart::Expr(e) => Some(e.as_mut()),
+            HtmlPart::Handler { expr, .. } => Some(expr.as_mut()),
         })
     }
 
@@ -123,6 +144,11 @@ impl HtmlTemplate {
                     println!("Text: {:?}", t);
                 }
                 HtmlPart::Expr(e) => printer.print_expr(e, indent),
+                HtmlPart::Handler { event, expr } => {
+                    printer.print_indent(indent);
+                    println!("Handler({}):", event);
+                    printer.print_expr(expr, indent + 1);
+                }
             }
         }
     }
@@ -140,6 +166,7 @@ impl HtmlTemplate {
     /// expressions (a caller bug).
     pub fn render(&self, values: &[Value]) -> Option<Html> {
         let mut rendered = String::new();
+        let mut handlers = Vec::new();
         let mut next = 0usize;
         for part in &self.parts {
             match part {
@@ -153,9 +180,17 @@ impl HtmlTemplate {
                     let _ = write!(rendered, "{}", v);
                     next += 1;
                 }
+                HtmlPart::Handler { event, .. } => {
+                    // #153: a handler's value is the action to run on the
+                    // event; it is captured as a handler rather than rendered
+                    // into the markup.
+                    let v = values.get(next)?;
+                    handlers.push((event.clone(), v.clone()));
+                    next += 1;
+                }
             }
         }
-        Some(Html::from_rendered(rendered))
+        Some(Html { rendered, handlers })
     }
 }
 
@@ -187,6 +222,14 @@ impl HtmlTemplateBuilder {
     /// Append an embedded (interpolated) expression.
     pub fn push_expr(&mut self, expr: Expr) {
         self.parts.push(HtmlPart::Expr(Box::new(expr)));
+    }
+
+    /// #153: append an event handler bound to an `on*` attribute.
+    pub fn push_handler(&mut self, event: String, expr: Expr) {
+        self.parts.push(HtmlPart::Handler {
+            event,
+            expr: Box::new(expr),
+        });
     }
 
     /// Finish building the template.

--- a/meerkat-lib/src/runtime/parser/mod.rs
+++ b/meerkat-lib/src/runtime/parser/mod.rs
@@ -139,6 +139,46 @@ pub fn parse_repl(input: &str, interner: &mut Interner) -> ReplParseResult {
 /// Literal text is copied verbatim; each brace-delimited `{ ... }`
 /// interpolation is parsed as an expression through the public `Expr` rule.
 /// A `{` with no matching `}` is a parse error.
+/// #153: if `text` ends with an event-attribute prefix like `onclick=` or
+/// `onclick="` (optionally with a quote), return the event name and the byte
+/// offset where the attribute begins, so the caller can strip it from the
+/// literal text and treat the following `{expr}` as an event handler rather
+/// than interpolated content. Only names beginning with `on` qualify.
+fn trailing_event_attr(text: &str) -> Option<(String, usize)> {
+    let bytes = text.as_bytes();
+    let mut i = bytes.len();
+    // optional opening quote right before the `{`
+    if i > 0 && (bytes[i - 1] == b'"' || bytes[i - 1] == b'\'') {
+        i -= 1;
+    }
+    // require an `=`
+    if i == 0 || bytes[i - 1] != b'=' {
+        return None;
+    }
+    i -= 1;
+    let name_end = i;
+    // attribute name: ascii letters/digits/-, scanning left
+    while i > 0 {
+        let b = bytes[i - 1];
+        if b.is_ascii_alphanumeric() || b == b'-' {
+            i -= 1;
+        } else {
+            break;
+        }
+    }
+    let name = &text[i..name_end];
+    // the char before the name must be whitespace or `<` (attribute boundary)
+    let boundary_ok = i == 0 || {
+        let pb = bytes[i - 1];
+        pb.is_ascii_whitespace() || pb == b'<'
+    };
+    if boundary_ok && name.len() > 2 && name.starts_with("on") {
+        Some((name.to_string(), i))
+    } else {
+        None
+    }
+}
+
 pub fn parse_template(
     raw: &str,
     interner: &mut Interner,
@@ -149,6 +189,12 @@ pub fn parse_template(
 
     while let Some((_, c)) = chars.next() {
         if c == '{' {
+            // #153: detect an event-attribute prefix so the following
+            // interpolation becomes a handler, not rendered content.
+            let handler_event = trailing_event_attr(&text);
+            if let Some((_, start)) = &handler_event {
+                text.truncate(*start);
+            }
             builder.push_text(std::mem::take(&mut text).as_str());
             // #39: brace depth counting does not account for a `}` inside a
             // string literal within the interpolation (e.g. `{ "}" }`); such a
@@ -181,7 +227,10 @@ pub fn parse_template(
                 );
             }
             let expr = parse_expr_fragment(frag.trim(), interner)?;
-            builder.push_expr(expr);
+            match handler_event {
+                Some((event, _)) => builder.push_handler(event, expr),
+                None => builder.push_expr(expr),
+            }
         } else {
             text.push(c);
         }
@@ -348,6 +397,29 @@ mod tests {
         let mut interner = Interner::new();
         let template = parse_template("<p>hello</p>", &mut interner).expect("should parse");
         assert_eq!(template.embedded_exprs().count(), 0);
+    }
+
+    /// #153: an `on*` attribute interpolation becomes a handler part, and
+    /// the `on...=` prefix is stripped from the literal text.
+    #[test]
+    fn test_event_attr_becomes_handler() {
+        let mut interner = Interner::new();
+        let template = parse_template("<button onclick={bump}>go</button>", &mut interner).unwrap();
+        // the handler's expr is still an embedded expr (so deps track it)
+        assert_eq!(template.embedded_exprs().count(), 1);
+        // and it is recorded as a handler, not content: rendering it with a
+        // placeholder value must not put the value inside the markup.
+        let printed = format!("{:?}", template);
+        assert!(
+            printed.contains("Handler"),
+            "expected a Handler part, got {}",
+            printed
+        );
+        assert!(
+            !printed.contains("onclick="),
+            "onclick= prefix should be stripped from literal text: {}",
+            printed
+        );
     }
 
     /// #39: an unterminated interpolation is an error, not a panic.

--- a/meerkat-wasm/src/lib.rs
+++ b/meerkat-wasm/src/lib.rs
@@ -255,11 +255,20 @@ pub async fn load_service(server_ws_addr: String, path: String) -> Result<String
     wasm_bindgen_futures::spawn_local(async move {
         let mut last = current_html(&manager_loop.borrow(), html_sym);
         loop {
-            // #153: hold the mutable borrow only for the dispatch call, never
-            // across the timer await below, so a click listener (which also
-            // borrows the manager) cannot collide with an outstanding borrow.
-            // Borrow spans dispatch's await by necessity; see module note.
-            manager_loop.borrow_mut().dispatch_network_events().await;
+            // #153: skip this tick if a click task currently holds the
+            // manager, instead of an unconditional borrow_mut that panics on a
+            // double borrow. Stopgap: this stops the "RefCell already borrowed"
+            // crash, but the borrow is still held across dispatch's await, so UI
+            // and network work remain serialized. Releasing the manager during
+            // network waits (so the UI stays responsive) is the larger
+            // event-loop rework discussed on the PR / issue #154.
+            {
+                let Ok(mut manager) = manager_loop.try_borrow_mut() else {
+                    gloo_timers::future::TimeoutFuture::new(20).await;
+                    continue;
+                };
+                manager.dispatch_network_events().await;
+            }
             let now = current_html(&manager_loop.borrow(), html_sym);
             if now != last {
                 if let Some(html) = &now {

--- a/meerkat-wasm/src/lib.rs
+++ b/meerkat-wasm/src/lib.rs
@@ -82,10 +82,7 @@ fn current_handlers(
 /// synchronous but running an action is async, the work is spawned rather than
 /// awaited inline, and the manager is borrowed only inside the spawned task so
 /// no borrow is held across an await in the listener itself.
-fn attach_handlers(
-    manager: &Rc<RefCell<Manager>>,
-    handlers: Vec<(String, Value)>,
-) {
+fn attach_handlers(manager: &Rc<RefCell<Manager>>, handlers: Vec<(String, Value)>) {
     use wasm_bindgen::JsCast;
     let Some(win) = web_sys::window() else { return };
     let Some(doc) = win.document() else { return };
@@ -93,17 +90,27 @@ fn attach_handlers(
         return;
     };
     for (event, action) in handlers {
-        // Only onclick is wired in this slice.
-        if event != "onclick" {
+        // #153: map an on* attribute to a DOM event name by dropping "on"
+        // (onclick -> click, oninput -> input). Bind onclick to a button and
+        // other events to an input, if present under the render root.
+        let Some(dom_event) = event.strip_prefix("on") else {
             continue;
-        }
-        let Ok(Some(btn)) = root.query_selector("button") else {
+        };
+        let dom_event = dom_event.to_string();
+        let selector = if dom_event == "click" {
+            "button"
+        } else {
+            "input"
+        };
+        let Ok(Some(target)) = root.query_selector(selector) else {
             continue;
         };
         let manager_cb = Rc::clone(manager);
         let action_cb = action.clone();
         let closure = Closure::<dyn FnMut()>::new(move || {
-            // Extract the action's parts; only ActionClosure is runnable.
+            // Only ActionClosure is runnable in this slice (no-argument
+            // actions). Lambda-valued handlers for value-carrying events are a
+            // planned follow-up.
             if let Value::ActionClosure {
                 stmts,
                 env,
@@ -112,13 +119,8 @@ fn attach_handlers(
             {
                 let manager_task = Rc::clone(&manager_cb);
                 wasm_bindgen_futures::spawn_local(async move {
-                    // #153: the render loop may hold the manager borrow while it
-                    // drains network events. Rather than panic on a double
-                    // borrow, wait for it to be free, then run the action. The
-                    // borrow is held across remote_action's network await, so
-                    // the render loop pauses until the action completes -- fine
-                    // for the single-button demo; finer-grained concurrency is a
-                    // follow-up.
+                    // Wait for the render loop to release the manager borrow
+                    // rather than panicking on a double borrow.
                     loop {
                         if manager_task.try_borrow_mut().is_ok() {
                             break;
@@ -126,20 +128,14 @@ fn attach_handlers(
                         gloo_timers::future::TimeoutFuture::new(20).await;
                     }
                     let mut m = manager_task.borrow_mut();
-                    let _ = m
-                        .remote_action(&service_net_id, stmts, env, None)
-                        .await;
+                    let _ = m.remote_action(&service_net_id, stmts, env, None).await;
                 });
             }
         });
-        let _ = btn
+        let _ = target
             .dyn_ref::<web_sys::EventTarget>()
             .unwrap()
-            .add_event_listener_with_callback(
-                "click",
-                closure.as_ref().unchecked_ref(),
-            );
-        // Keep the closure alive for the lifetime of the page.
+            .add_event_listener_with_callback(&dom_event, closure.as_ref().unchecked_ref());
         closure.forget();
     }
 }

--- a/meerkat-wasm/src/lib.rs
+++ b/meerkat-wasm/src/lib.rs
@@ -10,6 +10,8 @@ use meerkat_lib::runtime::ast::{Stmt, Value};
 use meerkat_lib::runtime::interner::Interner;
 use meerkat_lib::runtime::manager::Manager;
 use meerkat_lib::runtime::parser;
+use std::cell::RefCell;
+use std::rc::Rc;
 use wasm_bindgen::prelude::*;
 
 fn js_err<E: std::fmt::Display>(e: E) -> JsValue {
@@ -118,19 +120,29 @@ pub async fn load_service(server_ws_addr: String, path: String) -> Result<String
 
     let html_sym = manager.interner.insert("html");
 
+    // #153: share the manager between the render loop and (soon) click
+    // listeners. Wasm is single-threaded, so Rc<RefCell<_>> is sufficient and
+    // correct; no Arc/Mutex needed. Setup above kept sole ownership because it
+    // runs before any listener exists.
+    let manager = Rc::new(RefCell::new(manager));
+
     // Initial render.
-    if let Some(html) = current_html(&manager, html_sym) {
+    if let Some(html) = current_html(&manager.borrow(), html_sym) {
         render_to_dom(&html);
     }
 
     // 4. Background render loop: pump network events (which apply reactive
     //    Update messages, recomputing dependent defs) and re-render the html
     //    def whenever it changes. Runs on spawn_local; no tokio runtime needed.
+    let manager_loop = Rc::clone(&manager);
     wasm_bindgen_futures::spawn_local(async move {
-        let mut last = current_html(&manager, html_sym);
+        let mut last = current_html(&manager_loop.borrow(), html_sym);
         loop {
-            manager.dispatch_network_events().await;
-            let now = current_html(&manager, html_sym);
+            // #153: hold the mutable borrow only for the dispatch call, never
+            // across the timer await below, so a click listener (which also
+            // borrows the manager) cannot collide with an outstanding borrow.
+            manager_loop.borrow_mut().dispatch_network_events().await;
+            let now = current_html(&manager_loop.borrow(), html_sym);
             if now != last {
                 if let Some(html) = &now {
                     render_to_dom(html);

--- a/meerkat-wasm/src/lib.rs
+++ b/meerkat-wasm/src/lib.rs
@@ -55,6 +55,95 @@ fn current_html(
     None
 }
 
+/// #153: read the event handlers bound in the current `html` value, as
+/// (event, action-value) pairs. Returns an owned copy so no borrow of the
+/// manager is held while listeners are attached.
+fn current_handlers(
+    manager: &Manager,
+    html_sym: meerkat_lib::runtime::interner::Symbol,
+) -> Vec<(String, Value)> {
+    for svc in manager.services.values() {
+        if let Some(vs) = svc.vars.get(&html_sym) {
+            if let Value::Html(h) = &vs.value {
+                return h.handlers().to_vec();
+            }
+        }
+    }
+    Vec::new()
+}
+
+/// #153: attach DOM click listeners for the current html value's handlers.
+///
+/// For now this special-cases the single-button counter demo: each `onclick`
+/// handler is bound to the first `<button>` in the render target. General
+/// element-to-handler binding needs a full tree render on the wasm side and is
+/// tracked as a follow-up. On click, the handler's action value (an
+/// `ActionClosure`) is run via `remote_action`; because a DOM listener is
+/// synchronous but running an action is async, the work is spawned rather than
+/// awaited inline, and the manager is borrowed only inside the spawned task so
+/// no borrow is held across an await in the listener itself.
+fn attach_handlers(
+    manager: &Rc<RefCell<Manager>>,
+    handlers: Vec<(String, Value)>,
+) {
+    use wasm_bindgen::JsCast;
+    let Some(win) = web_sys::window() else { return };
+    let Some(doc) = win.document() else { return };
+    let Some(root) = doc.get_element_by_id("render") else {
+        return;
+    };
+    for (event, action) in handlers {
+        // Only onclick is wired in this slice.
+        if event != "onclick" {
+            continue;
+        }
+        let Ok(Some(btn)) = root.query_selector("button") else {
+            continue;
+        };
+        let manager_cb = Rc::clone(manager);
+        let action_cb = action.clone();
+        let closure = Closure::<dyn FnMut()>::new(move || {
+            // Extract the action's parts; only ActionClosure is runnable.
+            if let Value::ActionClosure {
+                stmts,
+                env,
+                service_net_id,
+            } = action_cb.clone()
+            {
+                let manager_task = Rc::clone(&manager_cb);
+                wasm_bindgen_futures::spawn_local(async move {
+                    // #153: the render loop may hold the manager borrow while it
+                    // drains network events. Rather than panic on a double
+                    // borrow, wait for it to be free, then run the action. The
+                    // borrow is held across remote_action's network await, so
+                    // the render loop pauses until the action completes -- fine
+                    // for the single-button demo; finer-grained concurrency is a
+                    // follow-up.
+                    loop {
+                        if manager_task.try_borrow_mut().is_ok() {
+                            break;
+                        }
+                        gloo_timers::future::TimeoutFuture::new(20).await;
+                    }
+                    let mut m = manager_task.borrow_mut();
+                    let _ = m
+                        .remote_action(&service_net_id, stmts, env, None)
+                        .await;
+                });
+            }
+        });
+        let _ = btn
+            .dyn_ref::<web_sys::EventTarget>()
+            .unwrap()
+            .add_event_listener_with_callback(
+                "click",
+                closure.as_ref().unchecked_ref(),
+            );
+        // Keep the closure alive for the lifetime of the page.
+        closure.forget();
+    }
+}
+
 /// Connect to `server_ws_addr`, fetch and instantiate the `.mkt` at `path`,
 /// then run a background loop that re-renders the `html` def as reactive
 /// updates arrive. Returns once loading is done; the loop keeps running.
@@ -126,9 +215,11 @@ pub async fn load_service(server_ws_addr: String, path: String) -> Result<String
     // runs before any listener exists.
     let manager = Rc::new(RefCell::new(manager));
 
-    // Initial render.
+    // Initial render, then attach click listeners for any handlers.
     if let Some(html) = current_html(&manager.borrow(), html_sym) {
         render_to_dom(&html);
+        let handlers = current_handlers(&manager.borrow(), html_sym);
+        attach_handlers(&manager, handlers);
     }
 
     // 4. Background render loop: pump network events (which apply reactive
@@ -146,6 +237,10 @@ pub async fn load_service(server_ws_addr: String, path: String) -> Result<String
             if now != last {
                 if let Some(html) = &now {
                     render_to_dom(html);
+                    // #153: re-attach listeners; set_inner_html replaced the
+                    // DOM nodes, so previous listeners are gone with them.
+                    let handlers = current_handlers(&manager_loop.borrow(), html_sym);
+                    attach_handlers(&manager_loop, handlers);
                 }
                 last = now;
             }

--- a/meerkat-wasm/src/lib.rs
+++ b/meerkat-wasm/src/lib.rs
@@ -4,6 +4,14 @@
 //! (they live on the server), so their defs are live network lookups that
 //! drive reactive updates. A background loop re-renders the `html` def to the
 //! DOM as Update messages arrive.
+//!
+//! #153: this client shares the Manager via Rc<RefCell> and calls &mut self
+//! methods (dispatch_network_events, remote_action) that await internally, so
+//! a borrow necessarily spans those awaits. This is sound because wasm is
+//! single-threaded and click tasks use try_borrow_mut with backoff, so the
+//! borrows never actually overlap. The lint is allowed file-wide for that
+//! reason.
+#![allow(clippy::await_holding_refcell_ref)]
 
 use meerkat_lib::net::{Address, NetworkActor, NodeType};
 use meerkat_lib::runtime::ast::{Stmt, Value};
@@ -72,16 +80,26 @@ fn current_handlers(
     Vec::new()
 }
 
-/// #153: attach DOM click listeners for the current html value's handlers.
-///
-/// For now this special-cases the single-button counter demo: each `onclick`
-/// handler is bound to the first `<button>` in the render target. General
-/// element-to-handler binding needs a full tree render on the wasm side and is
-/// tracked as a follow-up. On click, the handler's action value (an
-/// `ActionClosure`) is run via `remote_action`; because a DOM listener is
-/// synchronous but running an action is async, the work is spawned rather than
-/// awaited inline, and the manager is borrowed only inside the spawned task so
-/// no borrow is held across an await in the listener itself.
+// #153: attach DOM click listeners for the current html value's handlers.
+//
+// For now this special-cases the single-button counter demo: each `onclick`
+// handler is bound to the first `<button>` in the render target. General
+// element-to-handler binding needs a full tree render on the wasm side and is
+// tracked as a follow-up. On click, the handler's action value (an
+// `ActionClosure`) is run via `remote_action`; because a DOM listener is
+// synchronous but running an action is async, the work is spawned rather than
+// awaited inline, and the manager is borrowed only inside the spawned task so
+// no borrow is held across an await in the listener itself.
+
+thread_local! {
+    // #153: keep the current render's event closures alive. attach_handlers
+    // clears this before each render, dropping the previous render's
+    // closures, so repeated re-renders do not leak closures unboundedly
+    // (set_inner_html has already discarded the DOM nodes they were on).
+    static HANDLER_CLOSURES: RefCell<Vec<Closure<dyn FnMut()>>> =
+        const { RefCell::new(Vec::new()) };
+}
+
 fn attach_handlers(manager: &Rc<RefCell<Manager>>, handlers: Vec<(String, Value)>) {
     use wasm_bindgen::JsCast;
     let Some(win) = web_sys::window() else { return };
@@ -89,6 +107,8 @@ fn attach_handlers(manager: &Rc<RefCell<Manager>>, handlers: Vec<(String, Value)
     let Some(root) = doc.get_element_by_id("render") else {
         return;
     };
+    // #153: drop the previous render's closures before creating this render's.
+    HANDLER_CLOSURES.with(|c| c.borrow_mut().clear());
     for (event, action) in handlers {
         // #153: map an on* attribute to a DOM event name by dropping "on"
         // (onclick -> click, oninput -> input). Bind onclick to a button and
@@ -127,8 +147,16 @@ fn attach_handlers(manager: &Rc<RefCell<Manager>>, handlers: Vec<(String, Value)
                         }
                         gloo_timers::future::TimeoutFuture::new(20).await;
                     }
-                    let mut m = manager_task.borrow_mut();
-                    let _ = m.remote_action(&service_net_id, stmts, env, None).await;
+                    // The borrow spans remote_action's await by necessity;
+                    // see the module-level note. The try_borrow_mut loop above
+                    // ensures no other borrow is live when we take this one.
+                    let result = {
+                        let mut m = manager_task.borrow_mut();
+                        m.remote_action(&service_net_id, stmts, env, None).await
+                    };
+                    if let Err(e) = result {
+                        status(&format!("action failed: {}", e));
+                    }
                 });
             }
         });
@@ -136,7 +164,9 @@ fn attach_handlers(manager: &Rc<RefCell<Manager>>, handlers: Vec<(String, Value)
             .dyn_ref::<web_sys::EventTarget>()
             .unwrap()
             .add_event_listener_with_callback(&dom_event, closure.as_ref().unchecked_ref());
-        closure.forget();
+        // #153: retain this render's closure (dropped on the next render's
+        // clear) rather than leaking it with forget().
+        HANDLER_CLOSURES.with(|c| c.borrow_mut().push(closure));
     }
 }
 
@@ -228,6 +258,7 @@ pub async fn load_service(server_ws_addr: String, path: String) -> Result<String
             // #153: hold the mutable borrow only for the dispatch call, never
             // across the timer await below, so a click listener (which also
             // borrows the manager) cannot collide with an outstanding borrow.
+            // Borrow spans dispatch's await by necessity; see module note.
             manager_loop.borrow_mut().dispatch_network_events().await;
             let now = current_html(&manager_loop.borrow(), html_sym);
             if now != last {

--- a/meerkat/tests/client_button.mkt
+++ b/meerkat/tests/client_button.mkt
@@ -1,0 +1,16 @@
+// #153: demonstrates triggering an action from the client.
+//
+// This file is expected to FAIL until the client-action design is
+// implemented: `onclick` is not recognised as an event attribute, and an
+// Html value cannot currently carry an action closure.
+//
+// Run the server with s1.mkt, then load this file in the browser client.
+// Clicking the button should run s1.inc_x on the server, which increments x,
+// recomputes s1.y, and pushes an update back so that z re-renders.
+
+import s1
+
+service counter_ui {
+    pub def z = s1.y * 2;
+    pub def html = (<div><p>z = {z}</p><button onclick={s1.inc_x}>increment</button></div>);
+}


### PR DESCRIPTION
Design only, per the issue: no implementation, for a round of feedback first.

Adds `docs/design/client-actions.md` proposing a language extension that binds an action to a user interface event, and `meerkat/tests/client_button.mkt` as a demonstrating test case. The .mkt file does not work today by design — event
attributes are not recognised and an Html value cannot carry an action — and should work once the design is implemented.

## The proposal in short

An attribute beginning with `on` is an event attribute, and its interpolated expression must evaluate to an action:

    pub def html = (<button onclick={bump}>increment</button>);

This reuses the existing `{expr}` interpolation; only what the expression evaluates to differs. Because `Value::ActionClosure` already carries a `ServiceNetId`, the action can belong to another node — a browser can hold a
handler for a server-side action, and `remote_action` already accepts exactly what the closure stores.

## Two things worth pushing back on

The design treats the `Html` representation change as a prerequisite, not an optional refinement: an Html value is currently a rendered string, which has nowhere to put a handler, so it would need to become a structured tree. That is
a larger change than the syntax suggests, though the Html module documents a tree as its anticipated direction, and it also addresses the injection concern raised on #143.

Passing an input's value to an action is left unresolved. Action closures have no parameter list, so either they gain parameters or the event value is bound into the captured environment under a well known name. I have set out both
rather than picking one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for binding browser events, including button clicks and text input, to application actions.
  * Event handlers remain active after reactive UI updates and can invoke actions asynchronously.
  * Preserved event bindings in rendered HTML for reliable client-side interaction.

* **Documentation**
  * Added guidance for local and remote event-driven actions, supported input events, and security considerations.

* **Tests**
  * Added an example demonstrating a button click triggering a counter action.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->