### PR TITLE
docs: document WASM target prerequisite

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ cargo build
 # Run all tests
 cargo test
 
+# Install the WASM target (one-time setup)
+rustup target add wasm32-unknown-unknown
+
 # Test WASM compatibility
 cargo check --locked -p meerkat-lib --target wasm32-unknown-unknown --all-features
 


### PR DESCRIPTION
Adds the missing rustup target add wasm32-unknown-unknown setup step before the documented WASM compatibility check. CI already installs this target explicitly, but contributors using a standard Rust installation otherwise receive `E0463: can't find crate for core`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added setup instructions for installing the `wasm32-unknown-unknown` Rust target before running WebAssembly compatibility checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->